### PR TITLE
fix(security): k8s probe HTTP 403 해결을 위해 actuator 경로 permitAll 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -24,6 +24,7 @@ class SecurityConfig(
             .formLogin { it.disable() }
             .httpBasic { it.disable() }
             .authorizeHttpRequests {
+                it.requestMatchers("/actuator/health").permitAll()
                 it.requestMatchers("/v2/auth/**").permitAll()
                 it.requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #8 


## 📝작업 내용
fix(security): k8s probe HTTP 403 해결을 위해 actuator 경로에 permitAll 추가
