### PR TITLE
 기상음악 엔티티 와일드카드 import를 개별 import로 변경

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
@@ -1,6 +1,14 @@
 package team.incube.flooding.domain.dormitory.music.entity
 
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
 import team.incube.flooding.domain.user.entity.UserJpaEntity
 import java.time.LocalDateTime
 

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicLikeJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicLikeJpaEntity.kt
@@ -1,6 +1,14 @@
 package team.incube.flooding.domain.dormitory.music.entity
 
-import jakarta.persistence.*
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import team.incube.flooding.domain.user.entity.UserJpaEntity
 
 @Entity


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #34 


## 📝작업 내용

>  기상음악 엔티티 와일드카드 import를 개별 import로 변경


### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
