### PR TITLE
CI에서 Slack 알림 단계 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 # ─────────────────────────────────────────────────────────────────
 # CI Workflow — Flooding-Server-V2
 # Triggers  : push (all branches), PR to master/develop
-# Secrets   : HARBOR_HOST, HARBOR_USERNAME, HARBOR_PASSWORD,
-#             SLACK_WEBHOOK_URL
+# Secrets   : HARBOR_HOST, HARBOR_USERNAME, HARBOR_PASSWORD
 # ─────────────────────────────────────────────────────────────────
 name: CI
 
@@ -132,30 +131,3 @@ jobs:
     with:
       image_tag: ${{ needs.build.outputs.image_tag }}
     secrets: inherit
-
-  # ── 4. Slack notification ────────────────────────────────────
-  notify:
-    name: Slack Notify
-    runs-on: ubuntu-latest
-    needs: [test, build]
-    if: always()
-    steps:
-      - name: Send Slack notification
-        uses: slackapi/slack-github-action@v1
-        with:
-          payload: |
-            {
-              "text": "*[CI/CD] Flooding-Server-V2*",
-              "attachments": [{
-                "color": "${{ (needs.build.result == 'success') && 'good' || 'danger' }}",
-                "fields": [
-                  { "title": "Status",  "value": "${{ (needs.build.result == 'success') && '✅ SUCCESS' || '❌ FAILED' }}", "short": true },
-                  { "title": "Branch",  "value": "${{ github.ref_name }}", "short": true },
-                  { "title": "Commit",  "value": "${{ github.sha }}", "short": true },
-                  { "title": "Message", "value": "${{ github.event.head_commit.message }}", "short": false }
-                ]
-              }]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

CI 워크플로우에서 Slack 알림(`notify`) 잡을 완전히 삭제했습니다.

- `notify` 잡 전체 제거 (slackapi/slack-github-action 사용 단계 포함)
- 헤더 주석에서 `SLACK_WEBHOOK_URL` 시크릿 항목 제거

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음