### PR TITLE
동아리 전체 조회 API 구현

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubController.kt
@@ -4,12 +4,17 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import team.incube.flooding.domain.club.entity.ClubType
 import team.incube.flooding.domain.club.presentation.data.response.CreateAutonomousClubApplicationResponse
+import team.incube.flooding.domain.club.presentation.data.response.GetClubListResponse
 import team.incube.flooding.domain.club.service.CreateAutonomousClubApplicationService
+import team.incube.flooding.domain.club.service.GetClubListService
 import team.themoment.sdk.response.CommonApiResponse
 
 @Tag(name = "동아리", description = "동아리 관련 API")
@@ -17,6 +22,7 @@ import team.themoment.sdk.response.CommonApiResponse
 @RequestMapping("/clubs")
 class ClubController(
     private val createAutonomousClubApplicationService: CreateAutonomousClubApplicationService,
+    private val getClubListService: GetClubListService,
 ) {
     @Operation(summary = "자율 동아리 선착순 신청", description = "자율 동아리에 선착순으로 신청합니다.")
     @ApiResponses(
@@ -30,4 +36,14 @@ class ClubController(
         @PathVariable clubId: Long,
     ): CommonApiResponse<CreateAutonomousClubApplicationResponse> =
         CommonApiResponse.success("OK", createAutonomousClubApplicationService.execute(clubId))
+
+    @Operation(summary = "동아리 목록 조회", description = "타입으로 필터링하고 동아리명 또는 리더 이름으로 검색합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+    )
+    @GetMapping
+    fun getClubList(
+        @RequestParam type: ClubType,
+        @RequestParam(required = false) name: String?,
+    ): CommonApiResponse<GetClubListResponse> = CommonApiResponse.success("OK", getClubListService.execute(type, name))
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubListResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubListResponse.kt
@@ -1,7 +1,7 @@
 package team.incube.flooding.domain.club.presentation.data.response
 
 data class GetClubListResponse(
-    val club: List<ClubSummary>,
+    val clubs: List<ClubSummary>,
 ) {
     data class ClubSummary(
         val id: Long,

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubListResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubListResponse.kt
@@ -1,0 +1,14 @@
+package team.incube.flooding.domain.club.presentation.data.response
+
+data class GetClubListResponse(
+    val club: List<ClubSummary>,
+) {
+    data class ClubSummary(
+        val id: Long,
+        val name: String,
+        val type: String,
+        val description: String?,
+        val imageUrl: String?,
+        val totalMember: Long,
+    )
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantRepository.kt
@@ -1,0 +1,18 @@
+package team.incube.flooding.domain.club.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import team.incube.flooding.domain.club.entity.ClubParticipantId
+import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
+
+interface ClubMemberCountProjection {
+    val clubId: Long
+    val count: Long
+}
+
+interface ClubParticipantRepository : JpaRepository<ClubParticipantJpaEntity, ClubParticipantId> {
+    @Query(
+        "SELECT p.club.id as clubId, COUNT(p) as count FROM ClubParticipantJpaEntity p WHERE p.club.id IN :clubIds GROUP BY p.club.id",
+    )
+    fun countGroupByClubIdIn(clubIds: List<Long>): List<ClubMemberCountProjection>
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
@@ -13,8 +13,8 @@ interface ClubRepository : JpaRepository<ClubJpaEntity, Long> {
         SELECT c FROM ClubJpaEntity c
         LEFT JOIN c.leader l
         WHERE c.type = :type
-        AND (c.name ILIKE CONCAT('%', :keyword, '%')
-             OR l.name ILIKE CONCAT('%', :keyword, '%'))
+        AND (LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+             OR LOWER(l.name) LIKE LOWER(CONCAT('%', :keyword, '%')))
         """,
     )
     fun findAllByTypeAndKeyword(

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
@@ -1,6 +1,24 @@
 package team.incube.flooding.domain.club.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import team.incube.flooding.domain.club.entity.ClubJpaEntity
+import team.incube.flooding.domain.club.entity.ClubType
 
-interface ClubRepository : JpaRepository<ClubJpaEntity, Long>
+interface ClubRepository : JpaRepository<ClubJpaEntity, Long> {
+    fun findAllByType(type: ClubType): List<ClubJpaEntity>
+
+    @Query(
+        """
+        SELECT c FROM ClubJpaEntity c
+        LEFT JOIN c.leader l
+        WHERE c.type = :type
+        AND (LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+             OR LOWER(l.name) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        """,
+    )
+    fun findAllByTypeAndKeyword(
+        type: ClubType,
+        keyword: String,
+    ): List<ClubJpaEntity>
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
@@ -13,8 +13,8 @@ interface ClubRepository : JpaRepository<ClubJpaEntity, Long> {
         SELECT c FROM ClubJpaEntity c
         LEFT JOIN c.leader l
         WHERE c.type = :type
-        AND (LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
-             OR LOWER(l.name) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        AND (c.name ILIKE CONCAT('%', :keyword, '%')
+             OR l.name ILIKE CONCAT('%', :keyword, '%'))
         """,
     )
     fun findAllByTypeAndKeyword(

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/GetClubListService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/GetClubListService.kt
@@ -1,0 +1,11 @@
+package team.incube.flooding.domain.club.service
+
+import team.incube.flooding.domain.club.entity.ClubType
+import team.incube.flooding.domain.club.presentation.data.response.GetClubListResponse
+
+interface GetClubListService {
+    fun execute(
+        type: ClubType,
+        name: String?,
+    ): GetClubListResponse
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
@@ -22,7 +22,7 @@ class GetClubListServiceImpl(
             if (name.isNullOrBlank()) {
                 clubRepository.findAllByType(type)
             } else {
-                clubRepository.findAllByTypeAndKeyword(type, name)
+                clubRepository.findAllByTypeAndKeyword(type, name.trim())
             }
         if (clubs.isEmpty()) {
             return GetClubListResponse(clubs = emptyList())

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
@@ -29,7 +29,7 @@ class GetClubListServiceImpl(
                 .countGroupByClubIdIn(clubs.map { it.id })
                 .associate { it.clubId to it.count }
         return GetClubListResponse(
-            club =
+            clubs =
                 clubs.map { club ->
                     GetClubListResponse.ClubSummary(
                         id = club.id,

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
@@ -24,6 +24,9 @@ class GetClubListServiceImpl(
             } else {
                 clubRepository.findAllByTypeAndKeyword(type, name)
             }
+        if (clubs.isEmpty()) {
+            return GetClubListResponse(clubs = emptyList())
+        }
         val countMap =
             clubParticipantRepository
                 .countGroupByClubIdIn(clubs.map { it.id })

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
@@ -1,0 +1,45 @@
+package team.incube.flooding.domain.club.service.impl
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.club.entity.ClubType
+import team.incube.flooding.domain.club.presentation.data.response.GetClubListResponse
+import team.incube.flooding.domain.club.repository.ClubParticipantRepository
+import team.incube.flooding.domain.club.repository.ClubRepository
+import team.incube.flooding.domain.club.service.GetClubListService
+
+@Service
+@Transactional(readOnly = true)
+class GetClubListServiceImpl(
+    private val clubRepository: ClubRepository,
+    private val clubParticipantRepository: ClubParticipantRepository,
+) : GetClubListService {
+    override fun execute(
+        type: ClubType,
+        name: String?,
+    ): GetClubListResponse {
+        val clubs =
+            if (name.isNullOrBlank()) {
+                clubRepository.findAllByType(type)
+            } else {
+                clubRepository.findAllByTypeAndKeyword(type, name)
+            }
+        val countMap =
+            clubParticipantRepository
+                .countGroupByClubIdIn(clubs.map { it.id })
+                .associate { it.clubId to it.count }
+        return GetClubListResponse(
+            club =
+                clubs.map { club ->
+                    GetClubListResponse.ClubSummary(
+                        id = club.id,
+                        name = club.name,
+                        type = club.type.name,
+                        description = club.description,
+                        imageUrl = club.imageUrl,
+                        totalMember = countMap[club.id] ?: 0L,
+                    )
+                },
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #44

## 📝작업 내용

GET /clubs 엔드포인트를 구현합니다.

- type(MAJOR_CLUB | AUTONOMOUS_CLUB) 필수 쿼리 파라미터로 동아리 타입 필터링
- name 선택 쿼리 파라미터로 동아리명 또는 리더 이름 기준 검색(대소문자 무시)
- totalMember는 ClubParticipantRepository의 IN절 배치 쿼리로 N+1 없이 집계

추가/변경 파일:
- ClubRepository: findAllByType, findAllByTypeAndKeyword(JPQL) 메서드 추가
- ClubParticipantRepository: 신규 생성, GROUP BY 배치 count 쿼리
- GetClubListResponse: 신규 응답 DTO
- GetClubListService / GetClubListServiceImpl: 신규 서비스 인터페이스 및 구현체
- ClubController: GET /clubs 엔드포인트 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음