### PR TITLE
동아리 개설 신청 API 구현

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubController.kt
@@ -4,16 +4,22 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import team.incube.flooding.domain.club.entity.ClubType
+import team.incube.flooding.domain.club.presentation.data.request.CreateClubRequest
 import team.incube.flooding.domain.club.presentation.data.response.CreateAutonomousClubApplicationResponse
 import team.incube.flooding.domain.club.presentation.data.response.GetClubListResponse
 import team.incube.flooding.domain.club.service.CreateAutonomousClubApplicationService
+import team.incube.flooding.domain.club.service.CreateClubService
 import team.incube.flooding.domain.club.service.GetClubListService
 import team.themoment.sdk.response.CommonApiResponse
 
@@ -23,7 +29,21 @@ import team.themoment.sdk.response.CommonApiResponse
 class ClubController(
     private val createAutonomousClubApplicationService: CreateAutonomousClubApplicationService,
     private val getClubListService: GetClubListService,
+    private val createClubService: CreateClubService,
 ) {
+    @Operation(summary = "동아리 개설 신청", description = "새로운 동아리 개설을 신청합니다. 신청 후 status는 NEW로 설정되며 관리자 승인이 필요합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "개설 신청 성공"),
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    fun createClub(
+        @Valid @RequestBody request: CreateClubRequest,
+    ): CommonApiResponse<Nothing> {
+        createClubService.execute(request)
+        return CommonApiResponse.success("OK")
+    }
+
     @Operation(summary = "자율 동아리 선착순 신청", description = "자율 동아리에 선착순으로 신청합니다.")
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "신청 성공"),

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/request/CreateClubRequest.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/request/CreateClubRequest.kt
@@ -1,0 +1,12 @@
+package team.incube.flooding.domain.club.presentation.data.request
+
+import team.incube.flooding.domain.club.entity.ClubType
+
+data class CreateClubRequest(
+    val name: String,
+    val type: ClubType,
+    val description: String,
+    val imageUrl: String?,
+    val leaderId: Long,
+    val maxMember: Int?,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/request/CreateClubRequest.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/request/CreateClubRequest.kt
@@ -1,10 +1,12 @@
 package team.incube.flooding.domain.club.presentation.data.request
 
+import team.incube.flooding.domain.club.entity.ClubStatus
 import team.incube.flooding.domain.club.entity.ClubType
 
 data class CreateClubRequest(
     val name: String,
     val type: ClubType,
+    val status: ClubStatus,
     val description: String,
     val imageUrl: String?,
     val maxMember: Int?,

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/request/CreateClubRequest.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/request/CreateClubRequest.kt
@@ -7,6 +7,5 @@ data class CreateClubRequest(
     val type: ClubType,
     val description: String,
     val imageUrl: String?,
-    val leaderId: Long,
     val maxMember: Int?,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/CreateClubService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/CreateClubService.kt
@@ -1,0 +1,7 @@
+package team.incube.flooding.domain.club.service
+
+import team.incube.flooding.domain.club.presentation.data.request.CreateClubRequest
+
+interface CreateClubService {
+    fun execute(request: CreateClubRequest)
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateClubServiceImpl.kt
@@ -1,0 +1,38 @@
+package team.incube.flooding.domain.club.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.club.entity.ClubJpaEntity
+import team.incube.flooding.domain.club.entity.ClubStatus
+import team.incube.flooding.domain.club.presentation.data.request.CreateClubRequest
+import team.incube.flooding.domain.club.repository.ClubRepository
+import team.incube.flooding.domain.club.service.CreateClubService
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class CreateClubServiceImpl(
+    private val clubRepository: ClubRepository,
+    private val userRepository: UserRepository,
+) : CreateClubService {
+    @Transactional
+    override fun execute(request: CreateClubRequest) {
+        val leader =
+            userRepository.findById(request.leaderId).orElseThrow {
+                ExpectedException("존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND)
+            }
+
+        clubRepository.save(
+            ClubJpaEntity(
+                name = request.name,
+                type = request.type,
+                leader = leader,
+                imageUrl = request.imageUrl,
+                status = ClubStatus.NEW,
+                description = request.description,
+                maxMember = request.maxMember,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateClubServiceImpl.kt
@@ -3,7 +3,6 @@ package team.incube.flooding.domain.club.service.impl
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.club.entity.ClubJpaEntity
-import team.incube.flooding.domain.club.entity.ClubStatus
 import team.incube.flooding.domain.club.presentation.data.request.CreateClubRequest
 import team.incube.flooding.domain.club.repository.ClubRepository
 import team.incube.flooding.domain.club.service.CreateClubService
@@ -24,7 +23,7 @@ class CreateClubServiceImpl(
                 type = request.type,
                 leader = leader,
                 imageUrl = request.imageUrl,
-                status = ClubStatus.NEW,
+                status = request.status,
                 description = request.description,
                 maxMember = request.maxMember,
             ),

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateClubServiceImpl.kt
@@ -1,6 +1,5 @@
 package team.incube.flooding.domain.club.service.impl
 
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.club.entity.ClubJpaEntity
@@ -8,20 +7,16 @@ import team.incube.flooding.domain.club.entity.ClubStatus
 import team.incube.flooding.domain.club.presentation.data.request.CreateClubRequest
 import team.incube.flooding.domain.club.repository.ClubRepository
 import team.incube.flooding.domain.club.service.CreateClubService
-import team.incube.flooding.domain.user.repository.UserRepository
-import team.themoment.sdk.exception.ExpectedException
+import team.incube.flooding.global.security.util.CurrentUserProvider
 
 @Service
 class CreateClubServiceImpl(
     private val clubRepository: ClubRepository,
-    private val userRepository: UserRepository,
+    private val currentUserProvider: CurrentUserProvider,
 ) : CreateClubService {
     @Transactional
     override fun execute(request: CreateClubRequest) {
-        val leader =
-            userRepository.findById(request.leaderId).orElseThrow {
-                ExpectedException("존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND)
-            }
+        val leader = currentUserProvider.getCurrentUser()
 
         clubRepository.save(
             ClubJpaEntity(

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/CreateClubServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/CreateClubServiceTest.kt
@@ -1,13 +1,11 @@
 package team.incube.flooding.domain.club.service
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import org.springframework.http.HttpStatus
 import team.incube.flooding.domain.club.entity.ClubJpaEntity
 import team.incube.flooding.domain.club.entity.ClubStatus
 import team.incube.flooding.domain.club.entity.ClubType
@@ -17,16 +15,14 @@ import team.incube.flooding.domain.club.service.impl.CreateClubServiceImpl
 import team.incube.flooding.domain.user.entity.Role
 import team.incube.flooding.domain.user.entity.Sex
 import team.incube.flooding.domain.user.entity.UserJpaEntity
-import team.incube.flooding.domain.user.repository.UserRepository
-import team.themoment.sdk.exception.ExpectedException
-import java.util.Optional
+import team.incube.flooding.global.security.util.CurrentUserProvider
 
 class CreateClubServiceTest :
     BehaviorSpec({
         val clubRepository = mockk<ClubRepository>()
-        val userRepository = mockk<UserRepository>()
+        val currentUserProvider = mockk<CurrentUserProvider>()
 
-        val service = CreateClubServiceImpl(clubRepository, userRepository)
+        val service = CreateClubServiceImpl(clubRepository, currentUserProvider)
 
         val leader =
             UserJpaEntity(
@@ -45,26 +41,14 @@ class CreateClubServiceTest :
                 type = ClubType.MAJOR_CLUB,
                 description = "테스트 설명",
                 imageUrl = null,
-                leaderId = 1L,
                 maxMember = 20,
             )
-
-        given("존재하지 않는 leaderId로 요청할 때") {
-            `when`("개설 신청하면") {
-                then("NOT_FOUND 예외가 발생한다") {
-                    every { userRepository.findById(1L) } returns Optional.empty()
-
-                    val exception = shouldThrow<ExpectedException> { service.execute(request) }
-                    exception.statusCode shouldBe HttpStatus.NOT_FOUND
-                }
-            }
-        }
 
         given("유효한 요청이 올 때") {
             `when`("개설 신청하면") {
                 then("status가 NEW인 동아리가 저장된다") {
                     val slot = slot<ClubJpaEntity>()
-                    every { userRepository.findById(1L) } returns Optional.of(leader)
+                    every { currentUserProvider.getCurrentUser() } returns leader
                     every { clubRepository.save(capture(slot)) } answers { slot.captured }
 
                     service.execute(request)

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/CreateClubServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/CreateClubServiceTest.kt
@@ -33,7 +33,7 @@ class CreateClubServiceTest :
                 name = "리더",
                 sex = Sex.MAN,
                 email = "leader@test.com",
-                studentNumber = 10101,
+                studentNumber = 1101,
                 role = Role.GENERAL_STUDENT,
                 dormitoryRoom = 101,
             )

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/CreateClubServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/CreateClubServiceTest.kt
@@ -1,0 +1,82 @@
+package team.incube.flooding.domain.club.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.springframework.http.HttpStatus
+import team.incube.flooding.domain.club.entity.ClubJpaEntity
+import team.incube.flooding.domain.club.entity.ClubStatus
+import team.incube.flooding.domain.club.entity.ClubType
+import team.incube.flooding.domain.club.presentation.data.request.CreateClubRequest
+import team.incube.flooding.domain.club.repository.ClubRepository
+import team.incube.flooding.domain.club.service.impl.CreateClubServiceImpl
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.themoment.sdk.exception.ExpectedException
+import java.util.Optional
+
+class CreateClubServiceTest :
+    BehaviorSpec({
+        val clubRepository = mockk<ClubRepository>()
+        val userRepository = mockk<UserRepository>()
+
+        val service = CreateClubServiceImpl(clubRepository, userRepository)
+
+        val leader =
+            UserJpaEntity(
+                id = 1L,
+                name = "리더",
+                sex = Sex.MAN,
+                email = "leader@test.com",
+                studentNumber = 10101,
+                role = Role.GENERAL_STUDENT,
+                dormitoryRoom = 101,
+            )
+
+        val request =
+            CreateClubRequest(
+                name = "테스트 동아리",
+                type = ClubType.MAJOR_CLUB,
+                description = "테스트 설명",
+                imageUrl = null,
+                leaderId = 1L,
+                maxMember = 20,
+            )
+
+        given("존재하지 않는 leaderId로 요청할 때") {
+            `when`("개설 신청하면") {
+                then("NOT_FOUND 예외가 발생한다") {
+                    every { userRepository.findById(1L) } returns Optional.empty()
+
+                    val exception = shouldThrow<ExpectedException> { service.execute(request) }
+                    exception.statusCode shouldBe HttpStatus.NOT_FOUND
+                }
+            }
+        }
+
+        given("유효한 요청이 올 때") {
+            `when`("개설 신청하면") {
+                then("status가 NEW인 동아리가 저장된다") {
+                    val slot = slot<ClubJpaEntity>()
+                    every { userRepository.findById(1L) } returns Optional.of(leader)
+                    every { clubRepository.save(capture(slot)) } answers { slot.captured }
+
+                    service.execute(request)
+
+                    val saved = slot.captured
+                    saved.name shouldBe "테스트 동아리"
+                    saved.type shouldBe ClubType.MAJOR_CLUB
+                    saved.status shouldBe ClubStatus.NEW
+                    saved.leader shouldBe leader
+                    saved.maxMember shouldBe 20
+                    verify(exactly = 1) { clubRepository.save(any()) }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/CreateClubServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/CreateClubServiceTest.kt
@@ -2,6 +2,7 @@ package team.incube.flooding.domain.club.service
 
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -24,6 +25,8 @@ class CreateClubServiceTest :
 
         val service = CreateClubServiceImpl(clubRepository, currentUserProvider)
 
+        beforeEach { clearAllMocks() }
+
         val leader =
             UserJpaEntity(
                 id = 1L,
@@ -35,18 +38,18 @@ class CreateClubServiceTest :
                 dormitoryRoom = 101,
             )
 
-        val request =
-            CreateClubRequest(
-                name = "테스트 동아리",
-                type = ClubType.MAJOR_CLUB,
-                description = "테스트 설명",
-                imageUrl = null,
-                maxMember = 20,
-            )
-
-        given("유효한 요청이 올 때") {
+        given("status=NEW로 요청이 올 때") {
             `when`("개설 신청하면") {
                 then("status가 NEW인 동아리가 저장된다") {
+                    val request =
+                        CreateClubRequest(
+                            name = "테스트 동아리",
+                            type = ClubType.MAJOR_CLUB,
+                            status = ClubStatus.NEW,
+                            description = "테스트 설명",
+                            imageUrl = null,
+                            maxMember = 20,
+                        )
                     val slot = slot<ClubJpaEntity>()
                     every { currentUserProvider.getCurrentUser() } returns leader
                     every { clubRepository.save(capture(slot)) } answers { slot.captured }
@@ -59,6 +62,31 @@ class CreateClubServiceTest :
                     saved.status shouldBe ClubStatus.NEW
                     saved.leader shouldBe leader
                     saved.maxMember shouldBe 20
+                    verify(exactly = 1) { clubRepository.save(any()) }
+                }
+            }
+        }
+
+        given("status=MAINTAIN으로 요청이 올 때") {
+            `when`("개설 신청하면") {
+                then("status가 MAINTAIN인 동아리가 저장된다") {
+                    val request =
+                        CreateClubRequest(
+                            name = "테스트 동아리",
+                            type = ClubType.MAJOR_CLUB,
+                            status = ClubStatus.MAINTAIN,
+                            description = "테스트 설명",
+                            imageUrl = null,
+                            maxMember = 20,
+                        )
+                    val slot = slot<ClubJpaEntity>()
+                    every { currentUserProvider.getCurrentUser() } returns leader
+                    every { clubRepository.save(capture(slot)) } answers { slot.captured }
+
+                    service.execute(request)
+
+                    val saved = slot.captured
+                    saved.status shouldBe ClubStatus.MAINTAIN
                     verify(exactly = 1) { clubRepository.save(any()) }
                 }
             }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

POST /clubs 엔드포인트를 구현합니다.

- 인증된 사용자라면 누구나 호출 가능
- `leaderId`로 리더 사용자를 조회하며, 존재하지 않으면 404 반환
- 동아리 생성 시 `status`는 `NEW`로 설정되어 관리자 승인 대기 상태가 됨

추가/변경 파일:

- `CreateClubRequest`: 신규 생성, 동아리 개설 요청 DTO
- `CreateClubService`: 신규 서비스 인터페이스
- `CreateClubServiceImpl`: 신규 서비스 구현체, leaderId 검증 및 ClubJpaEntity 저장
- `ClubController`: POST /clubs 엔드포인트 추가
- `CreateClubServiceTest`: 신규 단위 테스트 (Kotest BehaviorSpec + MockK)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음