### PR TITLE
write-pr 스킬 PR 생성 시 develop을 base로 지정

### DIFF
--- a/.claude/skills/write-pr/SKILL.md
+++ b/.claude/skills/write-pr/SKILL.md
@@ -97,6 +97,7 @@ gh api user --jq .login
 ```bash
 gh pr create \
   --title "<title>" \
+  --base develop \
   --assignee "<github-username>" \
   --reviewer "team-incube/flooding-server" \
   --label "<Type 라벨>" \


### PR DESCRIPTION
## #️⃣연관된 이슈

> #47

## 📝작업 내용

`write-pr` 스킬의 `gh pr create` 명령에 `--base develop`이 누락되어 PR이 레포 기본 브랜치(`master`)로 생성되는 문제가 있었습니다.

Step 6의 `gh pr create` 명령에 `--base develop` 옵션을 추가하여 이후 생성되는 PR이 항상 `develop` 브랜치를 대상으로 하도록 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음