### PR TITLE
동아리 단건 조회 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,9 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
+    // Coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+
     // External SDK
     implementation("com.github.themoment-team:datagsm-oauth-sdk-java:1.0.0")
     implementation("com.github.themoment-team:the-sdk:1.4")

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubController.kt
@@ -94,7 +94,7 @@ class ClubController(
         ApiResponse(responseCode = "404", description = "존재하지 않는 동아리"),
     )
     @GetMapping("/{clubId}")
-    fun getClub(
+    suspend fun getClub(
         @PathVariable clubId: Long,
     ): CommonApiResponse<GetClubResponse> = CommonApiResponse.success("OK", getClubService.execute(clubId))
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubController.kt
@@ -20,10 +20,12 @@ import team.incube.flooding.domain.club.presentation.data.request.CreateClubRequ
 import team.incube.flooding.domain.club.presentation.data.request.PatchClubApprovalRequest
 import team.incube.flooding.domain.club.presentation.data.response.CreateAutonomousClubApplicationResponse
 import team.incube.flooding.domain.club.presentation.data.response.GetClubListResponse
+import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
 import team.incube.flooding.domain.club.presentation.data.response.PatchClubApprovalResponse
 import team.incube.flooding.domain.club.service.CreateAutonomousClubApplicationService
 import team.incube.flooding.domain.club.service.CreateClubService
 import team.incube.flooding.domain.club.service.GetClubListService
+import team.incube.flooding.domain.club.service.GetClubService
 import team.incube.flooding.domain.club.service.PatchClubApprovalService
 import team.themoment.sdk.response.CommonApiResponse
 
@@ -34,6 +36,7 @@ class ClubController(
     private val createAutonomousClubApplicationService: CreateAutonomousClubApplicationService,
     private val patchClubApprovalService: PatchClubApprovalService,
     private val getClubListService: GetClubListService,
+    private val getClubService: GetClubService,
     private val createClubService: CreateClubService,
 ) {
     @Operation(summary = "동아리 개설 신청", description = "새로운 동아리 개설을 신청합니다. 신청 후 status는 NEW로 설정되며 관리자 승인이 필요합니다.")
@@ -84,4 +87,14 @@ class ClubController(
         @RequestParam type: ClubType,
         @RequestParam(required = false) name: String?,
     ): CommonApiResponse<GetClubListResponse> = CommonApiResponse.success("OK", getClubListService.execute(type, name))
+
+    @Operation(summary = "동아리 단건 조회", description = "동아리 ID로 상세 정보 + 멤버 + 프로젝트를 조회합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "404", description = "존재하지 않는 동아리"),
+    )
+    @GetMapping("/{clubId}")
+    fun getClub(
+        @PathVariable clubId: Long,
+    ): CommonApiResponse<GetClubResponse> = CommonApiResponse.success("OK", getClubService.execute(clubId))
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubResponse.kt
@@ -1,0 +1,40 @@
+package team.incube.flooding.domain.club.presentation.data.response
+
+data class GetClubResponse(
+    val club: ClubDetail,
+    val member: List<MemberSummary>,
+    val project: List<ProjectSummary>,
+) {
+    data class ClubDetail(
+        val id: Long,
+        val name: String,
+        val type: String,
+        val leader: String?,
+        val description: String?,
+        val imageUrl: String?,
+        val maxMember: Int?,
+    )
+
+    data class MemberSummary(
+        val id: Long,
+        val name: String,
+        val studentNumber: Int,
+        val sex: String,
+        val specialty: String?,
+    )
+
+    data class ProjectSummary(
+        val id: Long,
+        val name: String,
+        val description: String,
+        val participants: List<ParticipantSummary>,
+    )
+
+    data class ParticipantSummary(
+        val id: Long,
+        val name: String,
+        val studentNumber: Int?,
+        val sex: String,
+        val specialty: String?,
+    )
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubResponse.kt
@@ -2,8 +2,8 @@ package team.incube.flooding.domain.club.presentation.data.response
 
 data class GetClubResponse(
     val club: ClubDetail,
-    val member: List<MemberSummary>,
-    val project: List<ProjectSummary>,
+    val members: List<MemberSummary>,
+    val projects: List<ProjectSummary>,
 ) {
     data class ClubDetail(
         val id: Long,

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantRepository.kt
@@ -15,4 +15,7 @@ interface ClubParticipantRepository : JpaRepository<ClubParticipantJpaEntity, Cl
         "SELECT p.club.id as clubId, COUNT(p) as count FROM ClubParticipantJpaEntity p WHERE p.club.id IN :clubIds GROUP BY p.club.id",
     )
     fun countGroupByClubIdIn(clubIds: List<Long>): List<ClubMemberCountProjection>
+
+    @Query("SELECT p FROM ClubParticipantJpaEntity p JOIN FETCH p.user WHERE p.club.id = :clubId")
+    fun findAllByClubId(clubId: Long): List<ClubParticipantJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
@@ -6,6 +6,9 @@ import team.incube.flooding.domain.club.entity.ClubJpaEntity
 import team.incube.flooding.domain.club.entity.ClubType
 
 interface ClubRepository : JpaRepository<ClubJpaEntity, Long> {
+    @Query("SELECT c FROM ClubJpaEntity c LEFT JOIN FETCH c.leader WHERE c.id = :id")
+    fun findByIdWithLeader(id: Long): ClubJpaEntity?
+
     fun findAllByType(type: ClubType): List<ClubJpaEntity>
 
     @Query(

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/GetClubService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/GetClubService.kt
@@ -3,5 +3,5 @@ package team.incube.flooding.domain.club.service
 import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
 
 interface GetClubService {
-    fun execute(clubId: Long): GetClubResponse
+    suspend fun execute(clubId: Long): GetClubResponse
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/GetClubService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/GetClubService.kt
@@ -1,0 +1,7 @@
+package team.incube.flooding.domain.club.service
+
+import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
+
+interface GetClubService {
+    fun execute(clubId: Long): GetClubResponse
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
@@ -2,7 +2,7 @@ package team.incube.flooding.domain.club.service.impl
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.coroutineScope
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
@@ -18,12 +18,12 @@ class GetClubServiceImpl(
     private val clubParticipantRepository: ClubParticipantRepository,
     private val dataGsmProjectClient: DataGsmProjectClient,
 ) : GetClubService {
-    override fun execute(clubId: Long): GetClubResponse {
-        val club =
-            clubRepository.findByIdWithLeader(clubId)
-                ?: throw ExpectedException("존재하지 않는 동아리입니다.", HttpStatus.NOT_FOUND)
+    override suspend fun execute(clubId: Long): GetClubResponse =
+        coroutineScope {
+            val club =
+                clubRepository.findByIdWithLeader(clubId)
+                    ?: throw ExpectedException("존재하지 않는 동아리입니다.", HttpStatus.NOT_FOUND)
 
-        return runBlocking {
             val membersDeferred =
                 async(Dispatchers.IO) {
                     clubParticipantRepository.findAllByClubId(clubId).map { p ->
@@ -52,9 +52,8 @@ class GetClubServiceImpl(
                         imageUrl = club.imageUrl,
                         maxMember = club.maxMember,
                     ),
-                member = membersDeferred.await(),
-                project = projectsDeferred.await(),
+                members = membersDeferred.await(),
+                projects = projectsDeferred.await(),
             )
         }
-    }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
@@ -20,10 +20,7 @@ class GetClubServiceImpl(
 ) : GetClubService {
     override suspend fun execute(clubId: Long): GetClubResponse =
         coroutineScope {
-            val club =
-                clubRepository.findByIdWithLeader(clubId)
-                    ?: throw ExpectedException("존재하지 않는 동아리입니다.", HttpStatus.NOT_FOUND)
-
+            val clubDeferred = async(Dispatchers.IO) { clubRepository.findByIdWithLeader(clubId) }
             val membersDeferred =
                 async(Dispatchers.IO) {
                     clubParticipantRepository.findAllByClubId(clubId).map { p ->
@@ -40,6 +37,10 @@ class GetClubServiceImpl(
                 async(Dispatchers.IO) {
                     dataGsmProjectClient.getProjectsByClubId(clubId)
                 }
+
+            val club =
+                clubDeferred.await()
+                    ?: throw ExpectedException("존재하지 않는 동아리입니다.", HttpStatus.NOT_FOUND)
 
             GetClubResponse(
                 club =

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
@@ -1,0 +1,60 @@
+package team.incube.flooding.domain.club.service.impl
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
+import team.incube.flooding.domain.club.repository.ClubParticipantRepository
+import team.incube.flooding.domain.club.repository.ClubRepository
+import team.incube.flooding.domain.club.service.GetClubService
+import team.incube.flooding.global.client.DataGsmProjectClient
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class GetClubServiceImpl(
+    private val clubRepository: ClubRepository,
+    private val clubParticipantRepository: ClubParticipantRepository,
+    private val dataGsmProjectClient: DataGsmProjectClient,
+) : GetClubService {
+    override fun execute(clubId: Long): GetClubResponse {
+        val club =
+            clubRepository.findByIdWithLeader(clubId)
+                ?: throw ExpectedException("존재하지 않는 동아리입니다.", HttpStatus.NOT_FOUND)
+
+        return runBlocking {
+            val membersDeferred =
+                async(Dispatchers.IO) {
+                    clubParticipantRepository.findAllByClubId(clubId).map { p ->
+                        GetClubResponse.MemberSummary(
+                            id = p.user.id,
+                            name = p.user.name,
+                            studentNumber = p.user.studentNumber,
+                            sex = p.user.sex.name,
+                            specialty = p.user.specialty,
+                        )
+                    }
+                }
+            val projectsDeferred =
+                async(Dispatchers.IO) {
+                    dataGsmProjectClient.getProjectsByClubId(clubId)
+                }
+
+            GetClubResponse(
+                club =
+                    GetClubResponse.ClubDetail(
+                        id = club.id,
+                        name = club.name,
+                        type = club.type.name,
+                        leader = club.leader?.name,
+                        description = club.description,
+                        imageUrl = club.imageUrl,
+                        maxMember = club.maxMember,
+                    ),
+                member = membersDeferred.await(),
+                project = projectsDeferred.await(),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/user/entity/UserJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/entity/UserJpaEntity.kt
@@ -32,7 +32,7 @@ class UserJpaEntity(
     var role: Role,
     @field:Column(name = "dormitory_room", nullable = false)
     var dormitoryRoom: Int,
-    @field:Column(name = "specialty", length = 30)
+    @field:Column(name = "specialty", length = 100)
     var specialty: String? = null,
     @field:Column(name = "penalty_score", nullable = false)
     var penaltyScore: Int = 0,

--- a/src/main/kotlin/team/incube/flooding/domain/user/entity/UserJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/entity/UserJpaEntity.kt
@@ -32,6 +32,8 @@ class UserJpaEntity(
     var role: Role,
     @field:Column(name = "dormitory_room", nullable = false)
     var dormitoryRoom: Int,
+    @field:Column(name = "specialty", length = 30)
+    var specialty: String? = null,
     @field:Column(name = "penalty_score", nullable = false)
     var penaltyScore: Int = 0,
     @field:ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/CreateUserService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/CreateUserService.kt
@@ -37,6 +37,7 @@ class CreateUserService(
                         StudentRole.DORMITORY_MANAGER -> Role.DORMITORY_MANAGER
                     },
                 dormitoryRoom = student.dormitoryRoom,
+                specialty = student.major?.name,
             )
 
         userRepository.save(user)

--- a/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
@@ -39,15 +39,16 @@ class DataGsmProjectClient(
     }
 
     private fun fetchFromApi(clubId: Long): List<GetClubResponse.ProjectSummary> =
-        restClient
-            .get()
-            .uri("/v1/projects?clubId=$clubId")
-            .retrieve()
-            .body(DataGsmResponse::class.java)
-            ?.data
-            ?.projects
-            ?.map { it.toSummary() }
-            ?: emptyList()
+        runCatching {
+            restClient
+                .get()
+                .uri("/v1/projects?clubId=$clubId")
+                .retrieve()
+                .body(DataGsmResponse::class.java)
+                ?.data
+                ?.projects
+                ?.map { it.toSummary() }
+        }.getOrNull() ?: emptyList()
 
     data class DataGsmResponse(
         val data: ProjectData,

--- a/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
@@ -13,6 +13,7 @@ import java.time.Duration
 class DataGsmProjectClient(
     private val redisTemplate: RedisTemplate<String, String>,
     private val objectMapper: ObjectMapper,
+    private val restClientBuilder: RestClient.Builder,
     @Value("\${datagsm.open-api-key}") private val apiKey: String,
 ) {
     companion object {
@@ -21,8 +22,7 @@ class DataGsmProjectClient(
     }
 
     private val restClient: RestClient by lazy {
-        RestClient
-            .builder()
+        restClientBuilder
             .baseUrl("https://api.datagsm.com")
             .defaultHeader("X-API-KEY", apiKey)
             .build()

--- a/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
@@ -1,0 +1,91 @@
+package team.incube.flooding.global.client
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
+import tools.jackson.core.type.TypeReference
+import tools.jackson.databind.ObjectMapper
+import java.time.Duration
+
+@Component
+class DataGsmProjectClient(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+    @Value("\${datagsm.open-api-key}") private val apiKey: String,
+) {
+    companion object {
+        private const val CACHE_PREFIX = "club:projects:"
+        private val CACHE_TTL = Duration.ofMinutes(30)
+    }
+
+    private val restClient: RestClient by lazy {
+        RestClient
+            .builder()
+            .baseUrl("https://api.datagsm.com")
+            .defaultHeader("X-API-KEY", apiKey)
+            .build()
+    }
+
+    fun getProjectsByClubId(clubId: Long): List<GetClubResponse.ProjectSummary> {
+        val cacheKey = "$CACHE_PREFIX$clubId"
+        redisTemplate.opsForValue().get(cacheKey)?.let {
+            return objectMapper.readValue(it, object : TypeReference<List<GetClubResponse.ProjectSummary>>() {})
+        }
+        val projects = fetchFromApi(clubId)
+        redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(projects), CACHE_TTL)
+        return projects
+    }
+
+    private fun fetchFromApi(clubId: Long): List<GetClubResponse.ProjectSummary> =
+        restClient
+            .get()
+            .uri("/v1/projects?clubId=$clubId")
+            .retrieve()
+            .body(DataGsmResponse::class.java)
+            ?.data
+            ?.projects
+            ?.map { it.toSummary() }
+            ?: emptyList()
+
+    data class DataGsmResponse(
+        val data: ProjectData,
+    ) {
+        data class ProjectData(
+            val projects: List<Project>,
+        )
+
+        data class Project(
+            val id: Long,
+            val name: String,
+            val description: String,
+            val participants: List<Participant>,
+        ) {
+            fun toSummary() =
+                GetClubResponse.ProjectSummary(
+                    id = id,
+                    name = name,
+                    description = description,
+                    participants =
+                        participants.map {
+                            GetClubResponse.ParticipantSummary(
+                                id = it.id,
+                                name = it.name,
+                                studentNumber = it.studentNumber,
+                                sex = it.sex,
+                                specialty = it.major,
+                            )
+                        },
+                )
+        }
+
+        data class Participant(
+            val id: Long,
+            val name: String,
+            val studentNumber: Int?,
+            val major: String?,
+            val sex: String,
+        )
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/global/config/RestClientConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/RestClientConfig.kt
@@ -1,0 +1,11 @@
+package team.incube.flooding.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+
+@Configuration
+class RestClientConfig {
+    @Bean
+    fun restClientBuilder(): RestClient.Builder = RestClient.builder()
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,6 +69,9 @@ oauth:
   client-id: ${OAUTH_CLIENT_ID}
   client-secret: ${OAUTH_CLIENT_SECRET}
 
+datagsm:
+  open-api-key: ${DATAGSM_OPEN_API_KEY}
+
 ai:
   chatbot:
     base-url: ${AI_CHATBOT_URL:http://localhost:8081}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #59

## 📝작업 내용

- `GET /clubs/{clubId}` 엔드포인트 추가
- 응답: 동아리 기본 정보 + 멤버 목록 + DataGSM 프로젝트 목록
- 멤버 DB 조회와 DataGSM 외부 API 호출을 코루틴(runBlocking + async)으로 병렬 실행하여 첫 조회 레이턴시 최소화
- DataGSM 프로젝트 결과는 Redis에 30분 캐싱
- LazyInitializationException 방지를 위해 club.leader를 JOIN FETCH로 미리 로딩
- UserJpaEntity에 specialty(전공) 필드 추가 및 로그인 시 DataGSM SDK의 major 값으로 저장

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음