### PR TITLE
AiSongAdapter RestClient 직접 생성 방식으로 변경

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
@@ -13,10 +13,10 @@ import team.themoment.sdk.exception.ExpectedException
 @Component
 class AiSongAdapter(
     @Value("\${ai.song.base-url}") baseUrl: String,
-    restClientBuilder: RestClient.Builder,
 ) {
     private val restClient =
-        restClientBuilder
+        RestClient
+            .builder()
             .baseUrl(baseUrl)
             .requestFactory(
                 SimpleClientHttpRequestFactory().apply {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #62

## 📝작업 내용

- AiSongAdapter 생성자에서 RestClient.Builder를 주입받는 방식을 RestClient.builder()를 직접 호출하는 방식으로 변경
- RestClient.Builder 빈이 스프링 컨텍스트에 등록되지 않아 dev 서버 배포 시 앱이 실행되지 않는 문제 수정
- AiChatbotAdapter와 동일한 방식으로 통일

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음