### PR TITLE
홈베이스 신청 사유 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/homebase/dto/request/CreateHomebaseRequest.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/dto/request/CreateHomebaseRequest.kt
@@ -1,11 +1,16 @@
 package team.incube.flooding.domain.homebase.dto.request
 
+import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Size
 import team.incube.flooding.domain.homebase.dto.MemberDto
 
 data class CreateHomebaseRequest(
     val startPeriod: Int,
     val endPeriod: Int,
+    @field:NotBlank(message = "예약 사유를 입력해주세요.")
+    @field:Size(max = 300, message = "예약 사유는 300자 이내로 입력해주세요.")
+    val reason: String,
     @field:NotEmpty(message = "예약 인원은 최소 1명 이상이어야 합니다.")
     val members: List<MemberDto>,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/dto/response/GetHomebaseResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/dto/response/GetHomebaseResponse.kt
@@ -6,6 +6,7 @@ data class GetHomebaseResponse(
     val id: Long,
     val startPeriod: Int,
     val endPeriod: Int,
+    val reason: String,
     val homebaseId: Long,
     val members: List<MemberDto>,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
@@ -23,6 +23,8 @@ class HomebaseReservationJpaEntity(
     val startPeriod: Int,
     @field:Column(nullable = false)
     val endPeriod: Int,
+    @field:Column(nullable = false, length = 300)
+    val reason: String,
     @field:ManyToOne(fetch = FetchType.LAZY)
     @field:JoinColumn(name = "homebase_id", nullable = false)
     val homebase: HomebaseJpaEntity,
@@ -34,6 +36,7 @@ class HomebaseReservationJpaEntity(
             id = id,
             startPeriod = startPeriod,
             endPeriod = endPeriod,
+            reason = reason,
             homebaseId = homebase.id,
             members = members.map { MemberDto(it.studentNumber, it.name) },
         )

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
@@ -24,7 +24,7 @@ class HomebaseReservationJpaEntity(
     @field:Column(nullable = false)
     val endPeriod: Int,
     @field:Column(nullable = false, length = 300)
-    var reason: String = "",
+    val reason: String = "",
     @field:ManyToOne(fetch = FetchType.LAZY)
     @field:JoinColumn(name = "homebase_id", nullable = false)
     val homebase: HomebaseJpaEntity,

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
@@ -24,7 +24,7 @@ class HomebaseReservationJpaEntity(
     @field:Column(nullable = false)
     val endPeriod: Int,
     @field:Column(nullable = false, length = 300)
-    val reason: String,
+    var reason: String = "",
     @field:ManyToOne(fetch = FetchType.LAZY)
     @field:JoinColumn(name = "homebase_id", nullable = false)
     val homebase: HomebaseJpaEntity,

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/CreateHomebaseReservationService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/CreateHomebaseReservationService.kt
@@ -34,6 +34,7 @@ class CreateHomebaseReservationService(
                 HomebaseReservationJpaEntity(
                     startPeriod = request.startPeriod,
                     endPeriod = request.endPeriod,
+                    reason = request.reason,
                     homebase = homebase,
                 ),
             )


### PR DESCRIPTION
## #️⃣연관된 이슈

> #13 


## 📝작업 내용

- ``CreateHomebaseRequest``에 사유(reason) 필드 추가
- ``HomebaseReservationJpaEntity`` 및 DB 테이블에 사유 컬럼 추가
- 예약 조회 시 사유를 포함하도록 ``GetHomebaseResponse`` 수정

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 없음
