### PR TITLE
동아리 신청 목록 조회 API 구현

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubApplicationController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubApplicationController.kt
@@ -43,7 +43,7 @@ class ClubApplicationController(
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "조회 성공"),
         ApiResponse(responseCode = "403", description = "권한 없음"),
-        ApiResponse(responseCode = "404", description = "존재하지 않는 동아리"),
+        ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 또는 생성된 폼 없음"),
     )
     @GetMapping("/{clubId}/applications")
     fun getClubApplicationList(

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubApplicationController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubApplicationController.kt
@@ -42,6 +42,7 @@ class ClubApplicationController(
     @Operation(summary = "동아리 신청 목록 조회", description = "정규 동아리의 폼 신청 목록을 조회합니다. 리더 또는 ADMIN/STUDENT_COUNCIL만 호출 가능합니다.")
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "400", description = "정규 동아리가 아님"),
         ApiResponse(responseCode = "403", description = "권한 없음"),
         ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 또는 생성된 폼 없음"),
     )

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubApplicationController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubApplicationController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -12,7 +13,9 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.incube.flooding.domain.club.presentation.data.request.CreateClubApplicationRequest
 import team.incube.flooding.domain.club.presentation.data.response.CreateClubApplicationResponse
+import team.incube.flooding.domain.club.presentation.data.response.GetClubApplicationListResponse
 import team.incube.flooding.domain.club.service.CreateClubApplicationService
+import team.incube.flooding.domain.club.service.GetClubApplicationListService
 import team.themoment.sdk.response.CommonApiResponse
 
 @Tag(name = "동아리 신청", description = "동아리 신청 관련 API")
@@ -20,6 +23,7 @@ import team.themoment.sdk.response.CommonApiResponse
 @RequestMapping("/clubs")
 class ClubApplicationController(
     private val createClubApplicationService: CreateClubApplicationService,
+    private val getClubApplicationListService: GetClubApplicationListService,
 ) {
     @Operation(summary = "동아리 신청", description = "해당 동아리의 활성 폼에 신청합니다.")
     @ApiResponses(
@@ -34,4 +38,16 @@ class ClubApplicationController(
         @Valid @RequestBody request: CreateClubApplicationRequest,
     ): CommonApiResponse<CreateClubApplicationResponse> =
         CommonApiResponse.success("OK", createClubApplicationService.execute(clubId, request))
+
+    @Operation(summary = "동아리 신청 목록 조회", description = "정규 동아리의 폼 신청 목록을 조회합니다. 리더 또는 ADMIN/STUDENT_COUNCIL만 호출 가능합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "403", description = "권한 없음"),
+        ApiResponse(responseCode = "404", description = "존재하지 않는 동아리"),
+    )
+    @GetMapping("/{clubId}/applications")
+    fun getClubApplicationList(
+        @PathVariable clubId: Long,
+    ): CommonApiResponse<GetClubApplicationListResponse> =
+        CommonApiResponse.success("OK", getClubApplicationListService.execute(clubId))
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubApplicationListResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubApplicationListResponse.kt
@@ -1,0 +1,26 @@
+package team.incube.flooding.domain.club.presentation.data.response
+
+import java.time.LocalDateTime
+
+data class GetClubApplicationListResponse(
+    val applications: List<ApplicationSummary>,
+) {
+    data class ApplicationSummary(
+        val submissionId: Long,
+        val applicant: ApplicantInfo,
+        val submittedAt: LocalDateTime,
+        val answers: List<AnswerInfo>,
+    )
+
+    data class ApplicantInfo(
+        val id: Long,
+        val name: String,
+        val studentNumber: Int,
+    )
+
+    data class AnswerInfo(
+        val fieldId: Long,
+        val label: String,
+        val value: String?,
+    )
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormAnswerRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormAnswerRepository.kt
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.Query
 import team.incube.flooding.domain.club.entity.ClubFormAnswerJpaEntity
 
 interface ClubFormAnswerRepository : JpaRepository<ClubFormAnswerJpaEntity, Long> {
-    @Query("SELECT a FROM ClubFormAnswerJpaEntity a JOIN FETCH a.field WHERE a.submission.id IN :submissionIds")
+    @Query(
+        "SELECT a FROM ClubFormAnswerJpaEntity a JOIN FETCH a.field WHERE a.submission.id IN :submissionIds ORDER BY a.field.fieldOrder ASC",
+    )
     fun findAllBySubmissionIdIn(submissionIds: List<Long>): List<ClubFormAnswerJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormAnswerRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormAnswerRepository.kt
@@ -1,6 +1,10 @@
 package team.incube.flooding.domain.club.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import team.incube.flooding.domain.club.entity.ClubFormAnswerJpaEntity
 
-interface ClubFormAnswerRepository : JpaRepository<ClubFormAnswerJpaEntity, Long>
+interface ClubFormAnswerRepository : JpaRepository<ClubFormAnswerJpaEntity, Long> {
+    @Query("SELECT a FROM ClubFormAnswerJpaEntity a JOIN FETCH a.field WHERE a.submission.id IN :submissionIds")
+    fun findAllBySubmissionIdIn(submissionIds: List<Long>): List<ClubFormAnswerJpaEntity>
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormSubmissionRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormSubmissionRepository.kt
@@ -10,6 +10,8 @@ interface ClubFormSubmissionRepository : JpaRepository<ClubFormSubmissionJpaEnti
         userId: Long,
     ): Boolean
 
-    @Query("SELECT s FROM ClubFormSubmissionJpaEntity s JOIN FETCH s.user WHERE s.form.id = :formId")
+    @Query(
+        "SELECT s FROM ClubFormSubmissionJpaEntity s JOIN FETCH s.user WHERE s.form.id = :formId ORDER BY s.submittedAt DESC",
+    )
     fun findAllByFormIdWithUser(formId: Long): List<ClubFormSubmissionJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormSubmissionRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormSubmissionRepository.kt
@@ -1,6 +1,7 @@
 package team.incube.flooding.domain.club.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import team.incube.flooding.domain.club.entity.ClubFormSubmissionJpaEntity
 
 interface ClubFormSubmissionRepository : JpaRepository<ClubFormSubmissionJpaEntity, Long> {
@@ -8,4 +9,7 @@ interface ClubFormSubmissionRepository : JpaRepository<ClubFormSubmissionJpaEnti
         formId: Long,
         userId: Long,
     ): Boolean
+
+    @Query("SELECT s FROM ClubFormSubmissionJpaEntity s JOIN FETCH s.user WHERE s.form.id = :formId")
+    fun findAllByFormIdWithUser(formId: Long): List<ClubFormSubmissionJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/GetClubApplicationListService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/GetClubApplicationListService.kt
@@ -1,0 +1,7 @@
+package team.incube.flooding.domain.club.service
+
+import team.incube.flooding.domain.club.presentation.data.response.GetClubApplicationListResponse
+
+interface GetClubApplicationListService {
+    fun execute(clubId: Long): GetClubApplicationListResponse
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubApplicationListServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubApplicationListServiceImpl.kt
@@ -36,7 +36,7 @@ class GetClubApplicationListServiceImpl(
 
         val form =
             clubFormRepository.findByClubIdAndIsActiveTrue(clubId)
-                ?: return GetClubApplicationListResponse(emptyList())
+                ?: throw ExpectedException("생성된 폼이 없습니다.", HttpStatus.NOT_FOUND)
 
         val submissions = submissionRepository.findAllByFormIdWithUser(form.id)
         if (submissions.isEmpty()) return GetClubApplicationListResponse(emptyList())

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubApplicationListServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubApplicationListServiceImpl.kt
@@ -1,0 +1,74 @@
+package team.incube.flooding.domain.club.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.club.presentation.data.response.GetClubApplicationListResponse
+import team.incube.flooding.domain.club.repository.ClubFormAnswerRepository
+import team.incube.flooding.domain.club.repository.ClubFormRepository
+import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
+import team.incube.flooding.domain.club.repository.ClubRepository
+import team.incube.flooding.domain.club.service.GetClubApplicationListService
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.global.security.util.CurrentUserProvider
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class GetClubApplicationListServiceImpl(
+    private val clubRepository: ClubRepository,
+    private val clubFormRepository: ClubFormRepository,
+    private val submissionRepository: ClubFormSubmissionRepository,
+    private val answerRepository: ClubFormAnswerRepository,
+    private val currentUserProvider: CurrentUserProvider,
+) : GetClubApplicationListService {
+    @Transactional(readOnly = true)
+    override fun execute(clubId: Long): GetClubApplicationListResponse {
+        val currentUser = currentUserProvider.getCurrentUser()
+        val club =
+            clubRepository.findByIdWithLeader(clubId)
+                ?: throw ExpectedException("존재하지 않는 동아리입니다.", HttpStatus.NOT_FOUND)
+
+        val isLeader = club.leader?.id == currentUser.id
+        val isPrivileged = currentUser.role in listOf(Role.ADMIN, Role.STUDENT_COUNCIL)
+        if (!isLeader && !isPrivileged) {
+            throw ExpectedException("접근 권한이 없습니다.", HttpStatus.FORBIDDEN)
+        }
+
+        val form =
+            clubFormRepository.findByClubIdAndIsActiveTrue(clubId)
+                ?: return GetClubApplicationListResponse(emptyList())
+
+        val submissions = submissionRepository.findAllByFormIdWithUser(form.id)
+        if (submissions.isEmpty()) return GetClubApplicationListResponse(emptyList())
+
+        val submissionIds = submissions.map { it.id }
+        val answersBySubmission =
+            answerRepository
+                .findAllBySubmissionIdIn(submissionIds)
+                .groupBy { it.submission.id }
+
+        val applications =
+            submissions.map { submission ->
+                val answers =
+                    answersBySubmission[submission.id].orEmpty().map { answer ->
+                        GetClubApplicationListResponse.AnswerInfo(
+                            fieldId = answer.field.id,
+                            label = answer.field.label,
+                            value = answer.value,
+                        )
+                    }
+                GetClubApplicationListResponse.ApplicationSummary(
+                    submissionId = submission.id,
+                    applicant =
+                        GetClubApplicationListResponse.ApplicantInfo(
+                            id = submission.user.id,
+                            name = submission.user.name,
+                            studentNumber = submission.user.studentNumber,
+                        ),
+                    submittedAt = submission.submittedAt,
+                    answers = answers,
+                )
+            }
+        return GetClubApplicationListResponse(applications)
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubApplicationListServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubApplicationListServiceImpl.kt
@@ -3,6 +3,7 @@ package team.incube.flooding.domain.club.service.impl
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.club.entity.ClubType
 import team.incube.flooding.domain.club.presentation.data.response.GetClubApplicationListResponse
 import team.incube.flooding.domain.club.repository.ClubFormAnswerRepository
 import team.incube.flooding.domain.club.repository.ClubFormRepository
@@ -32,6 +33,10 @@ class GetClubApplicationListServiceImpl(
         val isPrivileged = currentUser.role in listOf(Role.ADMIN, Role.STUDENT_COUNCIL)
         if (!isLeader && !isPrivileged) {
             throw ExpectedException("접근 권한이 없습니다.", HttpStatus.FORBIDDEN)
+        }
+
+        if (club.type != ClubType.MAJOR_CLUB) {
+            throw ExpectedException("정규 동아리가 아닙니다.", HttpStatus.BAD_REQUEST)
         }
 
         val form =


### PR DESCRIPTION
## #️⃣연관된 이슈

> #65

## 📝작업 내용

- `GET /clubs/{clubId}/applications` 엔드포인트 추가
- 정규 동아리(MAJOR_CLUB)의 폼 신청 목록 조회
- 접근 권한: 동아리 리더 또는 ADMIN/STUDENT_COUNCIL
- 응답: 신청자 정보(이름, 학번) + 모든 질문-답변 포함
- N+1 없이 submission 1회 + answer 1회 쿼리로 구현 (JOIN FETCH)
- 활성 폼 없는 경우 404 예외 반환

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음