### PR TITLE
Refresh Token Redis 저장 및 Token Rotation 구현

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/auth/adapter/RefreshTokenRedisAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/auth/adapter/RefreshTokenRedisAdapter.kt
@@ -1,0 +1,33 @@
+package team.incube.flooding.domain.auth.adapter
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class RefreshTokenRedisAdapter(
+    private val redisTemplate: RedisTemplate<String, String>,
+    @Value("\${jwt.refresh-token-expiration}") private val refreshTokenExpirationMs: Long,
+) {
+    companion object {
+        private const val KEY_PREFIX = "refresh:token:"
+    }
+
+    fun save(
+        userId: Long,
+        refreshToken: String,
+    ) {
+        redisTemplate.opsForValue().set(
+            "$KEY_PREFIX$userId",
+            refreshToken,
+            Duration.ofMillis(refreshTokenExpirationMs),
+        )
+    }
+
+    fun find(userId: Long): String? = redisTemplate.opsForValue().get("$KEY_PREFIX$userId")
+
+    fun delete(userId: Long) {
+        redisTemplate.delete("$KEY_PREFIX$userId")
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/auth/controller/AuthController.kt
@@ -4,12 +4,16 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import team.incube.flooding.domain.auth.dto.request.ReissueTokenRequest
 import team.incube.flooding.domain.auth.dto.request.SignInRequest
+import team.incube.flooding.domain.auth.dto.response.ReissueTokenResponse
 import team.incube.flooding.domain.auth.dto.response.SignInResponse
+import team.incube.flooding.domain.auth.service.ReissueTokenService
 import team.incube.flooding.domain.auth.service.SignInService
 
 @Tag(name = "인증", description = "인증 관련 API")
@@ -17,6 +21,7 @@ import team.incube.flooding.domain.auth.service.SignInService
 @RequestMapping("/auth")
 class AuthController(
     private val signInService: SignInService,
+    private val reissueTokenService: ReissueTokenService,
 ) {
     @Operation(
         summary = "로그인",
@@ -30,4 +35,17 @@ class AuthController(
     fun signIn(
         @RequestBody request: SignInRequest,
     ): SignInResponse = signInService.execute(request.authCode)
+
+    @Operation(
+        summary = "토큰 재발급",
+        description = "Refresh Token으로 새로운 Access Token과 Refresh Token을 발급합니다. 기존 Refresh Token은 즉시 무효화됩니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+        ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰"),
+    )
+    @PostMapping("/reissue")
+    fun reissueToken(
+        @Valid @RequestBody request: ReissueTokenRequest,
+    ): ReissueTokenResponse = reissueTokenService.execute(request.refreshToken)
 }

--- a/src/main/kotlin/team/incube/flooding/domain/auth/dto/request/ReissueTokenRequest.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/auth/dto/request/ReissueTokenRequest.kt
@@ -1,0 +1,8 @@
+package team.incube.flooding.domain.auth.dto.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class ReissueTokenRequest(
+    @field:NotBlank
+    val refreshToken: String,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/auth/dto/response/ReissueTokenResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/auth/dto/response/ReissueTokenResponse.kt
@@ -1,0 +1,6 @@
+package team.incube.flooding.domain.auth.dto.response
+
+data class ReissueTokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/auth/service/ReissueTokenService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/auth/service/ReissueTokenService.kt
@@ -20,6 +20,7 @@ class ReissueTokenService(
         val storedToken = refreshTokenRedisAdapter.find(userId)
 
         if (storedToken != refreshToken) {
+            refreshTokenRedisAdapter.delete(userId)
             throw ExpectedException("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED)
         }
 

--- a/src/main/kotlin/team/incube/flooding/domain/auth/service/ReissueTokenService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/auth/service/ReissueTokenService.kt
@@ -1,0 +1,36 @@
+package team.incube.flooding.domain.auth.service
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import team.incube.flooding.domain.auth.adapter.RefreshTokenRedisAdapter
+import team.incube.flooding.domain.auth.dto.response.ReissueTokenResponse
+import team.incube.flooding.global.auth.provider.JwtProvider
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class ReissueTokenService(
+    private val jwtProvider: JwtProvider,
+    private val refreshTokenRedisAdapter: RefreshTokenRedisAdapter,
+) {
+    fun execute(refreshToken: String): ReissueTokenResponse {
+        val userId =
+            jwtProvider.getUserIdOrNull(refreshToken)
+                ?: throw ExpectedException("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED)
+
+        val storedToken = refreshTokenRedisAdapter.find(userId)
+
+        if (storedToken != refreshToken) {
+            throw ExpectedException("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED)
+        }
+
+        val newAccessToken = jwtProvider.generateAccessToken(userId)
+        val newRefreshToken = jwtProvider.generateRefreshToken(userId)
+
+        refreshTokenRedisAdapter.save(userId, newRefreshToken)
+
+        return ReissueTokenResponse(
+            accessToken = newAccessToken,
+            refreshToken = newRefreshToken,
+        )
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/auth/service/SignInService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/auth/service/SignInService.kt
@@ -3,6 +3,7 @@ package team.incube.flooding.domain.auth.service
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.auth.adapter.RefreshTokenRedisAdapter
 import team.incube.flooding.domain.auth.dto.response.SignInResponse
 import team.incube.flooding.domain.user.repository.UserRepository
 import team.incube.flooding.domain.user.service.CreateUserService
@@ -17,6 +18,7 @@ class SignInService(
     private val userRepository: UserRepository,
     private val createUserService: CreateUserService,
     private val jwtProvider: JwtProvider,
+    private val refreshTokenRedisAdapter: RefreshTokenRedisAdapter,
 ) {
     fun execute(authCode: String): SignInResponse {
         val tokenResponse = dataGsmClient.exchangeToken(authCode)
@@ -24,12 +26,18 @@ class SignInService(
 
         if (!oauthUser.isStudent()) throw ExpectedException("학생이 아닙니다.", HttpStatus.FORBIDDEN)
 
-        val student = oauthUser.student!!
+        val student =
+            oauthUser.student ?: throw ExpectedException("학생 정보를 가져올 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
         val user = userRepository.findById(student.id).orElse(createUserService.execute(oauthUser))
 
+        val accessToken = jwtProvider.generateAccessToken(user.id)
+        val refreshToken = jwtProvider.generateRefreshToken(user.id)
+
+        refreshTokenRedisAdapter.save(user.id, refreshToken)
+
         return SignInResponse(
-            accessToken = jwtProvider.generateAccessToken(user.id),
-            refreshToken = jwtProvider.generateRefreshToken(user.id),
+            accessToken = accessToken,
+            refreshToken = refreshToken,
         )
     }
 }

--- a/src/main/kotlin/team/incube/flooding/global/auth/provider/JwtProvider.kt
+++ b/src/main/kotlin/team/incube/flooding/global/auth/provider/JwtProvider.kt
@@ -30,6 +30,13 @@ class JwtProvider(
             .subject
             .toLong()
 
+    fun getUserIdOrNull(token: String): Long? =
+        try {
+            getUserId(token)
+        } catch (e: JwtException) {
+            null
+        }
+
     fun isValid(token: String): Boolean =
         try {
             Jwts

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -43,7 +43,7 @@ class SecurityConfig(
             .httpBasic { it.disable() }
             .authorizeHttpRequests {
                 it.requestMatchers("/actuator/**").permitAll()
-                it.requestMatchers("/v2/auth/**").permitAll()
+                it.requestMatchers("/auth/signin", "/auth/reissue").permitAll()
                 it.requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
                 // ai
                 it.requestMatchers(HttpMethod.POST, "/ai/chat").hasRole(Role.GENERAL_STUDENT.name)


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

로그인 시 발급된 Refresh Token을 Redis에 서버 측 저장하고,
Token Rotation 방식으로 재발급하는 시스템을 구현합니다.

- `RefreshTokenRedisAdapter` 추가 — `refresh:token:{userId}` 키로 저장, TTL 7일
- `POST /auth/reissue` 엔드포인트 추가 — JWT 서명 검증 + Redis 저장값 대조 후 새 토큰 쌍 발급, 이전 토큰 즉시 무효화
- `JwtProvider.getUserIdOrNull()` 추가 — 기존 isValid + getUserId 이중 파싱 제거
- `SecurityConfig`에서 `/v2/auth/**` 잔존 규칙 제거, `/auth/signin` · `/auth/reissue` permitAll 추가
- `SignInService`에서 `student!!` 강제 non-null 제거

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음