### PR TITLE
자습 및 안마의자 신청 현황 조회 API 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/adapter/MassageRedisAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/adapter/MassageRedisAdapter.kt
@@ -45,4 +45,10 @@ class MassageRedisAdapter(
     }
 
     fun getCount(): Long = redisTemplate.opsForList().size(QUEUE_KEY) ?: 0L
+
+    fun getQueue(): List<Long> =
+        redisTemplate
+            .opsForList()
+            .range(QUEUE_KEY, 0, -1)
+            ?.map { it.toLong() } ?: emptyList()
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/controller/MassageController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/controller/MassageController.kt
@@ -24,14 +24,14 @@ class MassageController(
     private val getMassageService: GetMassageService,
 ) {
     @Operation(
-        summary = "안마의자 신청 현황 조회",
-        description = "현재 사용자의 안마의자 신청 여부, 대기 순번, 전체 신청 인원을 조회합니다.",
+        summary = "안마의자 신청자 목록 조회",
+        description = "오늘 안마의자를 신청한 학생 목록을 대기 순번과 함께 조회합니다.",
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "조회 성공"),
     )
     @GetMapping
-    fun getMassage(): CommonApiResponse<GetMassageResponse> =
+    fun getMassage(): CommonApiResponse<List<GetMassageResponse>> =
         CommonApiResponse.success("OK", getMassageService.execute())
 
     @Operation(

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/controller/MassageController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/controller/MassageController.kt
@@ -31,7 +31,8 @@ class MassageController(
         ApiResponse(responseCode = "200", description = "조회 성공"),
     )
     @GetMapping
-    fun getMassage(): CommonApiResponse<GetMassageResponse> = CommonApiResponse.success(getMassageService.execute())
+    fun getMassage(): CommonApiResponse<GetMassageResponse> =
+        CommonApiResponse.success("OK", getMassageService.execute())
 
     @Operation(
         summary = "마사지 신청",

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/controller/MassageController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/controller/MassageController.kt
@@ -5,11 +5,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import team.incube.flooding.domain.dormitory.massage.presentation.data.response.GetMassageResponse
 import team.incube.flooding.domain.dormitory.massage.service.ApplyMassageService
 import team.incube.flooding.domain.dormitory.massage.service.CancelMassageService
+import team.incube.flooding.domain.dormitory.massage.service.GetMassageService
 import team.themoment.sdk.response.CommonApiResponse
 
 @Tag(name = "마사지", description = "마사지 신청 관련 API")
@@ -18,7 +21,18 @@ import team.themoment.sdk.response.CommonApiResponse
 class MassageController(
     private val applyMassageService: ApplyMassageService,
     private val cancelMassageService: CancelMassageService,
+    private val getMassageService: GetMassageService,
 ) {
+    @Operation(
+        summary = "안마의자 신청 현황 조회",
+        description = "현재 사용자의 안마의자 신청 여부, 대기 순번, 전체 신청 인원을 조회합니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+    )
+    @GetMapping
+    fun getMassage(): CommonApiResponse<GetMassageResponse> = CommonApiResponse.success(getMassageService.execute())
+
     @Operation(
         summary = "마사지 신청",
         description = "마사지 신청 시간 내에 마사지를 신청합니다. 이미 신청한 경우 신청할 수 없습니다.",

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/data/response/GetMassageResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/data/response/GetMassageResponse.kt
@@ -1,0 +1,7 @@
+package team.incube.flooding.domain.dormitory.massage.presentation.data.response
+
+data class GetMassageResponse(
+    val isApplied: Boolean,
+    val order: Long?,
+    val currentCount: Long,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/data/response/GetMassageResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/data/response/GetMassageResponse.kt
@@ -1,7 +1,7 @@
 package team.incube.flooding.domain.dormitory.massage.presentation.data.response
 
 data class GetMassageResponse(
-    val isApplied: Boolean,
-    val order: Long?,
-    val currentCount: Long,
+    val order: Long,
+    val name: String,
+    val studentNumber: Int,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/GetMassageService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/GetMassageService.kt
@@ -1,0 +1,7 @@
+package team.incube.flooding.domain.dormitory.massage.service
+
+import team.incube.flooding.domain.dormitory.massage.presentation.data.response.GetMassageResponse
+
+interface GetMassageService {
+    fun execute(): GetMassageResponse
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/GetMassageService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/GetMassageService.kt
@@ -3,5 +3,5 @@ package team.incube.flooding.domain.dormitory.massage.service
 import team.incube.flooding.domain.dormitory.massage.presentation.data.response.GetMassageResponse
 
 interface GetMassageService {
-    fun execute(): GetMassageResponse
+    fun execute(): List<GetMassageResponse>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
@@ -1,0 +1,24 @@
+package team.incube.flooding.domain.dormitory.massage.service.impl
+
+import org.springframework.stereotype.Service
+import team.incube.flooding.domain.dormitory.massage.adapter.MassageRedisAdapter
+import team.incube.flooding.domain.dormitory.massage.presentation.data.response.GetMassageResponse
+import team.incube.flooding.domain.dormitory.massage.service.GetMassageService
+import team.incube.flooding.global.security.util.CurrentUserProvider
+
+@Service
+class GetMassageServiceImpl(
+    private val massageRedisAdapter: MassageRedisAdapter,
+    private val currentUserProvider: CurrentUserProvider,
+) : GetMassageService {
+    override fun execute(): GetMassageResponse {
+        val user = currentUserProvider.getCurrentUser()
+        val isApplied = massageRedisAdapter.isApply(user.id)
+        val order = if (isApplied) massageRedisAdapter.getOrder(user.id) else null
+        return GetMassageResponse(
+            isApplied = isApplied,
+            order = order,
+            currentCount = massageRedisAdapter.getCount(),
+        )
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
@@ -1,24 +1,26 @@
 package team.incube.flooding.domain.dormitory.massage.service.impl
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.massage.adapter.MassageRedisAdapter
 import team.incube.flooding.domain.dormitory.massage.presentation.data.response.GetMassageResponse
 import team.incube.flooding.domain.dormitory.massage.service.GetMassageService
-import team.incube.flooding.global.security.util.CurrentUserProvider
+import team.incube.flooding.domain.user.repository.UserRepository
 
 @Service
+@Transactional(readOnly = true)
 class GetMassageServiceImpl(
     private val massageRedisAdapter: MassageRedisAdapter,
-    private val currentUserProvider: CurrentUserProvider,
+    private val userRepository: UserRepository,
 ) : GetMassageService {
-    override fun execute(): GetMassageResponse {
-        val user = currentUserProvider.getCurrentUser()
-        val isApplied = massageRedisAdapter.isApply(user.id)
-        val order = if (isApplied) massageRedisAdapter.getOrder(user.id) else null
-        return GetMassageResponse(
-            isApplied = isApplied,
-            order = order,
-            currentCount = massageRedisAdapter.getCount(),
-        )
+    override fun execute(): List<GetMassageResponse> {
+        val queue = massageRedisAdapter.getQueue()
+        if (queue.isEmpty()) return emptyList()
+        val userMap = userRepository.findAllById(queue).associateBy { it.id }
+        return queue
+            .mapIndexed { index, userId ->
+                val user = userMap[userId] ?: return@mapIndexed null
+                GetMassageResponse(order = index + 1L, name = user.name, studentNumber = user.studentNumber)
+            }.filterNotNull()
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
@@ -15,6 +15,7 @@ class StudyRedisAdapter(
     companion object {
         private const val APPLICATION_KEY = "study:application"
         private const val COUNT_KEY = "study:count"
+        private const val APPLICANTS_KEY = "study:applicants"
     }
 
     private fun ttlUntilMidnight(): Duration {
@@ -49,4 +50,23 @@ class StudyRedisAdapter(
     }
 
     fun getCount(): Long = redisTemplate.opsForValue().get(COUNT_KEY)?.toLong() ?: 0
+
+    fun addApplicant(userId: Long) {
+        redisTemplate.opsForSet().add(APPLICANTS_KEY, userId.toString())
+        val size = redisTemplate.opsForSet().size(APPLICANTS_KEY) ?: 0L
+        if (size == 1L) {
+            redisTemplate.expire(APPLICANTS_KEY, ttlUntilMidnight())
+        }
+    }
+
+    fun removeApplicant(userId: Long) {
+        redisTemplate.opsForSet().remove(APPLICANTS_KEY, userId.toString())
+    }
+
+    fun getApplicantIds(): Set<Long> =
+        redisTemplate
+            .opsForSet()
+            .members(APPLICANTS_KEY)
+            ?.map { it.toLong() }
+            ?.toSet() ?: emptySet()
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
@@ -35,7 +35,7 @@ class StudyController(
         ApiResponse(responseCode = "200", description = "조회 성공"),
     )
     @GetMapping
-    fun getStudy(): CommonApiResponse<GetStudyResponse> = CommonApiResponse.success(getStudyService.execute())
+    fun getStudy(): CommonApiResponse<GetStudyResponse> = CommonApiResponse.success("OK", getStudyService.execute())
 
     @Operation(
         summary = "자습 신청",

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
@@ -6,12 +6,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import team.incube.flooding.domain.dormitory.study.presentation.data.response.GetStudyResponse
 import team.incube.flooding.domain.dormitory.study.service.BanStudyService
 import team.incube.flooding.domain.dormitory.study.service.CancelStudyService
+import team.incube.flooding.domain.dormitory.study.service.GetStudyService
 import team.incube.flooding.domain.dormitory.study.service.StudyApplicationService
 import team.themoment.sdk.response.CommonApiResponse
 
@@ -22,7 +25,18 @@ class StudyController(
     private val studyApplicationService: StudyApplicationService,
     private val cancelStudyService: CancelStudyService,
     private val banStudyService: BanStudyService,
+    private val getStudyService: GetStudyService,
 ) {
+    @Operation(
+        summary = "자습 신청 현황 조회",
+        description = "현재 사용자의 자습 신청 상태, 금지 여부, 전체 신청 인원을 조회합니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+    )
+    @GetMapping
+    fun getStudy(): CommonApiResponse<GetStudyResponse> = CommonApiResponse.success(getStudyService.execute())
+
     @Operation(
         summary = "자습 신청",
         description = "자습 신청 시간 내에 자습을 신청합니다. 금지 상태이거나 이미 신청한 경우 신청할 수 없습니다.",

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
@@ -28,14 +28,15 @@ class StudyController(
     private val getStudyService: GetStudyService,
 ) {
     @Operation(
-        summary = "자습 신청 현황 조회",
-        description = "현재 사용자의 자습 신청 상태, 금지 여부, 전체 신청 인원을 조회합니다.",
+        summary = "자습 신청자 목록 조회",
+        description = "오늘 자습을 신청한 학생 목록을 조회합니다.",
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "조회 성공"),
     )
     @GetMapping
-    fun getStudy(): CommonApiResponse<GetStudyResponse> = CommonApiResponse.success("OK", getStudyService.execute())
+    fun getStudy(): CommonApiResponse<List<GetStudyResponse>> =
+        CommonApiResponse.success("OK", getStudyService.execute())
 
     @Operation(
         summary = "자습 신청",

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
@@ -1,9 +1,6 @@
 package team.incube.flooding.domain.dormitory.study.presentation.data.response
 
-import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
-
 data class GetStudyResponse(
-    val status: StudyApplicationStatus?,
-    val currentCount: Long,
-    val isBanned: Boolean,
+    val name: String,
+    val studentNumber: Int,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
@@ -1,0 +1,9 @@
+package team.incube.flooding.domain.dormitory.study.presentation.data.response
+
+import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
+
+data class GetStudyResponse(
+    val status: StudyApplicationStatus?,
+    val currentCount: Long,
+    val isBanned: Boolean,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyService.kt
@@ -3,5 +3,5 @@ package team.incube.flooding.domain.dormitory.study.service
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.GetStudyResponse
 
 interface GetStudyService {
-    fun execute(): GetStudyResponse
+    fun execute(): List<GetStudyResponse>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyService.kt
@@ -1,0 +1,7 @@
+package team.incube.flooding.domain.dormitory.study.service
+
+import team.incube.flooding.domain.dormitory.study.presentation.data.response.GetStudyResponse
+
+interface GetStudyService {
+    fun execute(): GetStudyResponse
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/CancelStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/CancelStudyServiceImpl.kt
@@ -25,5 +25,6 @@ class CancelStudyServiceImpl(
 
         studyRedisAdapter.saveApplication(user.id, StudyApplicationStatus.CANCELLED)
         studyRedisAdapter.decrementCount()
+        studyRedisAdapter.removeApplicant(user.id)
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
@@ -3,30 +3,22 @@ package team.incube.flooding.domain.dormitory.study.service.impl
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
-import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.GetStudyResponse
-import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
 import team.incube.flooding.domain.dormitory.study.service.GetStudyService
-import team.incube.flooding.global.security.util.CurrentUserProvider
-import java.time.LocalDateTime
+import team.incube.flooding.domain.user.repository.UserRepository
 
 @Service
 @Transactional(readOnly = true)
 class GetStudyServiceImpl(
     private val studyRedisAdapter: StudyRedisAdapter,
-    private val studyBanJpaRepository: StudyBanJpaRepository,
-    private val currentUserProvider: CurrentUserProvider,
+    private val userRepository: UserRepository,
 ) : GetStudyService {
-    override fun execute(): GetStudyResponse {
-        val user = currentUserProvider.getCurrentUser()
-        val status = studyRedisAdapter.getApplicationStatus(user.id)
-        val isBanned =
-            status == StudyApplicationStatus.BANNED ||
-                studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now())
-        return GetStudyResponse(
-            status = status,
-            currentCount = studyRedisAdapter.getCount(),
-            isBanned = isBanned,
-        )
+    override fun execute(): List<GetStudyResponse> {
+        val applicantIds = studyRedisAdapter.getApplicantIds()
+        if (applicantIds.isEmpty()) return emptyList()
+        return userRepository
+            .findAllById(applicantIds)
+            .sortedBy { it.studentNumber }
+            .map { GetStudyResponse(name = it.name, studentNumber = it.studentNumber) }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
@@ -1,0 +1,32 @@
+package team.incube.flooding.domain.dormitory.study.service.impl
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
+import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
+import team.incube.flooding.domain.dormitory.study.presentation.data.response.GetStudyResponse
+import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
+import team.incube.flooding.domain.dormitory.study.service.GetStudyService
+import team.incube.flooding.global.security.util.CurrentUserProvider
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class GetStudyServiceImpl(
+    private val studyRedisAdapter: StudyRedisAdapter,
+    private val studyBanJpaRepository: StudyBanJpaRepository,
+    private val currentUserProvider: CurrentUserProvider,
+) : GetStudyService {
+    override fun execute(): GetStudyResponse {
+        val user = currentUserProvider.getCurrentUser()
+        val status = studyRedisAdapter.getApplicationStatus(user.id)
+        val isBanned =
+            status == StudyApplicationStatus.BANNED ||
+                studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now())
+        return GetStudyResponse(
+            status = status,
+            currentCount = studyRedisAdapter.getCount(),
+            isBanned = isBanned,
+        )
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
@@ -62,6 +62,7 @@ class StudyApplicationServiceImpl(
             }
 
             studyRedisAdapter.saveApplication(user.id, StudyApplicationStatus.APPROVED)
+            studyRedisAdapter.addApplicant(user.id)
         } finally {
             lock.unlock()
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #73 

## 📝작업 내용

자습 및 안마의자 신청 현황을 조회하는 GET API를 추가합니다.

**자습 (`GET /dormitory/studies`)**
- 현재 사용자의 신청 상태(`status`): APPROVED / CANCELLED / BANNED / null(미신청)
- 금지 여부(`isBanned`): Redis 상태 및 DB 금지 기록 모두 확인
- 전체 신청 인원(`currentCount`)

**안마의자 (`GET /dormitory/massages`)**
- 현재 사용자의 신청 여부(`isApplied`)
- 대기 순번(`order`): 미신청 시 null
- 전체 신청 인원(`currentCount`)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음