### PR TITLE
AI 음악 추천 요청 방식을 히스토리 기반으로 전환

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/ai/presentation/controller/AiController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/presentation/controller/AiController.kt
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import team.incube.flooding.domain.ai.presentation.data.request.RecommendAiSongRequest
 import team.incube.flooding.domain.ai.presentation.data.request.SendAiChatRequest
 import team.incube.flooding.domain.ai.presentation.data.response.RecommendAiSongResponse
 import team.incube.flooding.domain.ai.presentation.data.response.SendAiChatResponse
@@ -39,15 +38,13 @@ class AiController(
 
     @Operation(
         summary = "AI 음악 추천",
-        description = "최근 들은 노래 5곡을 기반으로 AI가 추천하는 유튜브 링크 3개를 반환합니다.",
+        description = "로그인한 사용자의 최근 기상송 신청 내역(최대 5곡)을 기반으로 AI가 추천하는 유튜브 링크 3개를 반환합니다.",
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "AI 음악 추천 성공"),
         ApiResponse(responseCode = "502", description = "AI 음악 추천 서버 오류"),
     )
     @PostMapping("/song")
-    fun recommendAiSong(
-        @Valid @RequestBody request: RecommendAiSongRequest,
-    ): CommonApiResponse<RecommendAiSongResponse> =
-        CommonApiResponse.success("OK", recommendAiSongService.execute(request))
+    fun recommendAiSong(): CommonApiResponse<RecommendAiSongResponse> =
+        CommonApiResponse.success("OK", recommendAiSongService.execute())
 }

--- a/src/main/kotlin/team/incube/flooding/domain/ai/service/RecommendAiSongService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/service/RecommendAiSongService.kt
@@ -1,8 +1,7 @@
 package team.incube.flooding.domain.ai.service
 
-import team.incube.flooding.domain.ai.presentation.data.request.RecommendAiSongRequest
 import team.incube.flooding.domain.ai.presentation.data.response.RecommendAiSongResponse
 
 interface RecommendAiSongService {
-    fun execute(request: RecommendAiSongRequest): RecommendAiSongResponse
+    fun execute(): RecommendAiSongResponse
 }

--- a/src/main/kotlin/team/incube/flooding/domain/ai/service/impl/RecommendAiSongServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/service/impl/RecommendAiSongServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.ai.service.impl
 
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.ai.adapter.AiSongAdapter
@@ -9,6 +10,7 @@ import team.incube.flooding.domain.ai.presentation.data.response.RecommendAiSong
 import team.incube.flooding.domain.ai.service.RecommendAiSongService
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.global.security.util.CurrentUserProvider
+import team.themoment.sdk.exception.ExpectedException
 
 @Service
 class RecommendAiSongServiceImpl(
@@ -19,10 +21,11 @@ class RecommendAiSongServiceImpl(
     @Transactional(readOnly = true)
     override fun execute(): RecommendAiSongResponse {
         val user = currentUserProvider.getCurrentUser()
-        val recentSongs =
-            wakeUpMusicRepository
-                .findTop5ByUserIdOrderByAppliedAtDesc(user.id)
-                .map { SongRequest(title = it.title, artist = it.artist) }
+        val history = wakeUpMusicRepository.findTop5ByUserIdOrderByAppliedAtDesc(user.id)
+        if (history.isEmpty()) {
+            throw ExpectedException("추천을 위한 기상송 신청 내역이 존재하지 않습니다.", HttpStatus.NOT_FOUND)
+        }
+        val recentSongs = history.map { SongRequest(title = it.title, artist = it.artist) }
         return aiSongAdapter.recommend(RecommendAiSongRequest(recentSongs = recentSongs))
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/ai/service/impl/RecommendAiSongServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/service/impl/RecommendAiSongServiceImpl.kt
@@ -1,14 +1,28 @@
 package team.incube.flooding.domain.ai.service.impl
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.ai.adapter.AiSongAdapter
 import team.incube.flooding.domain.ai.presentation.data.request.RecommendAiSongRequest
+import team.incube.flooding.domain.ai.presentation.data.request.SongRequest
 import team.incube.flooding.domain.ai.presentation.data.response.RecommendAiSongResponse
 import team.incube.flooding.domain.ai.service.RecommendAiSongService
+import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
+import team.incube.flooding.global.security.util.CurrentUserProvider
 
 @Service
 class RecommendAiSongServiceImpl(
     private val aiSongAdapter: AiSongAdapter,
+    private val currentUserProvider: CurrentUserProvider,
+    private val wakeUpMusicRepository: WakeUpMusicRepository,
 ) : RecommendAiSongService {
-    override fun execute(request: RecommendAiSongRequest): RecommendAiSongResponse = aiSongAdapter.recommend(request)
+    @Transactional(readOnly = true)
+    override fun execute(): RecommendAiSongResponse {
+        val user = currentUserProvider.getCurrentUser()
+        val recentSongs =
+            wakeUpMusicRepository
+                .findTop5ByUserIdOrderByAppliedAtDesc(user.id)
+                .map { SongRequest(title = it.title, artist = it.artist) }
+        return aiSongAdapter.recommend(RecommendAiSongRequest(recentSongs = recentSongs))
+    }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.OneToOne
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import team.incube.flooding.domain.user.entity.UserJpaEntity
 import java.time.LocalDateTime
@@ -18,11 +18,15 @@ class WakeUpMusicJpaEntity(
     @field:Id
     @field:GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
-    @field:OneToOne(fetch = FetchType.LAZY)
-    @field:JoinColumn(name = "user_id", nullable = false, unique = true)
+    @field:ManyToOne(fetch = FetchType.LAZY)
+    @field:JoinColumn(name = "user_id", nullable = false)
     val user: UserJpaEntity,
     @field:Column(name = "music_url", nullable = false)
     val musicUrl: String,
+    @field:Column(name = "title", nullable = false)
+    val title: String,
+    @field:Column(name = "artist", nullable = false)
+    val artist: String,
     @field:Column(name = "applied_at", nullable = false)
     val appliedAt: LocalDateTime = LocalDateTime.now(),
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/request/ApplyWakeUpMusicRequest.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/request/ApplyWakeUpMusicRequest.kt
@@ -1,5 +1,12 @@
 package team.incube.flooding.domain.dormitory.music.presentation.data.request
 
+import jakarta.validation.constraints.NotBlank
+
 data class ApplyWakeUpMusicRequest(
+    @field:NotBlank
     val musicUrl: String,
+    @field:NotBlank
+    val title: String,
+    @field:NotBlank
+    val artist: String,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
@@ -7,7 +7,7 @@ import team.incube.flooding.domain.dormitory.music.presentation.data.response.Wa
 import java.time.LocalDateTime
 
 interface WakeUpMusicRepository : JpaRepository<WakeUpMusicJpaEntity, Long> {
-    fun existsByUserId(userId: Long): Boolean
+    fun findTop5ByUserIdOrderByAppliedAtDesc(userId: Long): List<WakeUpMusicJpaEntity>
 
     @Query(
         """

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -1,6 +1,5 @@
 package team.incube.flooding.domain.dormitory.music.service.impl
 
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.music.entity.WakeUpMusicJpaEntity
@@ -8,7 +7,6 @@ import team.incube.flooding.domain.dormitory.music.presentation.data.request.App
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.domain.dormitory.music.service.ApplyWakeUpMusicService
 import team.incube.flooding.global.security.util.CurrentUserProvider
-import team.themoment.sdk.exception.ExpectedException
 
 @Service
 class ApplyWakeUpMusicServiceImpl(
@@ -19,14 +17,12 @@ class ApplyWakeUpMusicServiceImpl(
     override fun execute(request: ApplyWakeUpMusicRequest) {
         val user = currentUserProvider.getCurrentUser()
 
-        if (wakeUpMusicRepository.existsByUserId(user.id)) {
-            throw ExpectedException("이미 기상음악을 신청했습니다.", HttpStatus.CONFLICT)
-        }
-
         wakeUpMusicRepository.save(
             WakeUpMusicJpaEntity(
                 user = user,
                 musicUrl = request.musicUrl,
+                title = request.title,
+                artist = request.artist,
             ),
         )
     }

--- a/src/test/kotlin/team/incube/flooding/domain/ai/service/RecommendAiSongServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/ai/service/RecommendAiSongServiceImplTest.kt
@@ -1,23 +1,60 @@
 package team.incube.flooding.domain.ai.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.http.HttpStatus
 import team.incube.flooding.domain.ai.adapter.AiSongAdapter
 import team.incube.flooding.domain.ai.presentation.data.request.RecommendAiSongRequest
 import team.incube.flooding.domain.ai.presentation.data.request.SongRequest
 import team.incube.flooding.domain.ai.presentation.data.response.RecommendAiSongResponse
 import team.incube.flooding.domain.ai.service.impl.RecommendAiSongServiceImpl
+import team.incube.flooding.domain.dormitory.music.entity.WakeUpMusicJpaEntity
+import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.global.security.util.CurrentUserProvider
+import team.themoment.sdk.exception.ExpectedException
 
 class RecommendAiSongServiceImplTest :
     BehaviorSpec({
 
         val aiSongAdapter = mockk<AiSongAdapter>()
-        val service = RecommendAiSongServiceImpl(aiSongAdapter)
+        val currentUserProvider = mockk<CurrentUserProvider>()
+        val wakeUpMusicRepository = mockk<WakeUpMusicRepository>()
+        val service = RecommendAiSongServiceImpl(aiSongAdapter, currentUserProvider, wakeUpMusicRepository)
 
-        val sampleRequest =
+        val mockUser = mockk<UserJpaEntity>()
+        every { mockUser.id } returns 1L
+        every { currentUserProvider.getCurrentUser() } returns mockUser
+
+        val mockHistories =
+            listOf(
+                mockk<WakeUpMusicJpaEntity>().also {
+                    every { it.title } returns "Life"
+                    every { it.artist } returns "Ignito"
+                },
+                mockk<WakeUpMusicJpaEntity>().also {
+                    every { it.title } returns "Newspaper"
+                    every { it.artist } returns "이현준"
+                },
+                mockk<WakeUpMusicJpaEntity>().also {
+                    every { it.title } returns "아침에"
+                    every { it.artist } returns "양홍원"
+                },
+                mockk<WakeUpMusicJpaEntity>().also {
+                    every { it.title } returns "Hip Hop"
+                    every { it.artist } returns "dwen"
+                },
+                mockk<WakeUpMusicJpaEntity>().also {
+                    every { it.title } returns "우리가 바로"
+                    every { it.artist } returns "TEAM NY"
+                },
+            )
+
+        val expectedRequest =
             RecommendAiSongRequest(
                 recentSongs =
                     listOf(
@@ -39,30 +76,30 @@ class RecommendAiSongServiceImplTest :
                             "https://www.youtube.com/watch?v=ghi",
                         ),
                 )
-            every { aiSongAdapter.recommend(sampleRequest) } returns expectedResponse
+
+            every { wakeUpMusicRepository.findTop5ByUserIdOrderByAppliedAtDesc(1L) } returns mockHistories
+            every { aiSongAdapter.recommend(expectedRequest) } returns expectedResponse
 
             When("음악 추천을 요청하면") {
-                val response = service.execute(sampleRequest)
+                val response = service.execute()
 
                 Then("유튜브 링크 3개를 반환한다") {
                     response.youtubeLinks.size shouldBe 3
                     response.youtubeLinks[0] shouldBe "https://www.youtube.com/watch?v=abc"
                     response.youtubeLinks[1] shouldBe "https://www.youtube.com/watch?v=def"
                     response.youtubeLinks[2] shouldBe "https://www.youtube.com/watch?v=ghi"
-                    verify(exactly = 1) { aiSongAdapter.recommend(sampleRequest) }
+                    verify(exactly = 1) { aiSongAdapter.recommend(expectedRequest) }
                 }
             }
         }
 
-        Given("AI 음악 추천 서버가 빈 링크를 반환할 때") {
-            val emptyResponse = RecommendAiSongResponse(youtubeLinks = emptyList())
-            every { aiSongAdapter.recommend(sampleRequest) } returns emptyResponse
+        Given("기상송 신청 내역이 없을 때") {
+            every { wakeUpMusicRepository.findTop5ByUserIdOrderByAppliedAtDesc(1L) } returns emptyList()
 
             When("음악 추천을 요청하면") {
-                val response = service.execute(sampleRequest)
-
-                Then("빈 리스트를 반환한다") {
-                    response.youtubeLinks.size shouldBe 0
+                Then("404 예외를 던진다") {
+                    val exception = shouldThrow<ExpectedException> { service.execute() }
+                    exception.statusCode shouldBe HttpStatus.NOT_FOUND
                 }
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #74

## 📝작업 내용

기존에 프론트엔드가 recent_songs를 직접 요청 바디에 담아 보내던 방식을, 백엔드가 로그인한 사용자의 기상송 신청 히스토리에서 자동으로 최대 5곡을 조회해 AI 서버에 넘기는 방식으로 변경하였습니다.

- WakeUpMusicJpaEntity: OneToOne → ManyToOne 변경, title/artist 필드 추가
- ApplyWakeUpMusicRequest: title, artist 필드 추가
- WakeUpMusicRepository: 최근 5곡 조회 메서드 추가, existsByUserId 제거
- ApplyWakeUpMusicServiceImpl: 중복 신청 체크 제거, title/artist 함께 저장
- RecommendAiSongServiceImpl: DB에서 최근 5곡 조회 후 AI에 전달하도록 변경
- POST /ai/song: RequestBody 제거

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음