### PR TITLE
유저 본인 정보 조회 엔드포인트 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
@@ -2,7 +2,6 @@ package team.incube.flooding.domain.user.presentation.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -13,7 +12,7 @@ import team.themoment.sdk.response.CommonApiResponse
 
 @Tag(name = "유저", description = "유저 관련 API")
 @RestController
-@RequestMapping("/me")
+@RequestMapping("/users")
 class UserController(
     private val getMeService: GetMeService,
 ) {
@@ -21,10 +20,8 @@ class UserController(
         summary = "내 정보 조회",
         description = "현재 로그인한 유저의 정보를 반환합니다.",
     )
-    @ApiResponses(
-        ApiResponse(responseCode = "200", description = "조회 성공"),
-        ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-    )
-    @GetMapping
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    @GetMapping("/me")
     fun getMe(): CommonApiResponse<GetMeResponse> = CommonApiResponse.success("OK", getMeService.execute())
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
@@ -1,0 +1,30 @@
+package team.incube.flooding.domain.user.presentation.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import team.incube.flooding.domain.user.presentation.data.response.GetMeResponse
+import team.incube.flooding.domain.user.service.GetMeService
+import team.themoment.sdk.response.CommonApiResponse
+
+@Tag(name = "유저", description = "유저 관련 API")
+@RestController
+@RequestMapping("/me")
+class UserController(
+    private val getMeService: GetMeService,
+) {
+    @Operation(
+        summary = "내 정보 조회",
+        description = "현재 로그인한 유저의 정보를 반환합니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+    )
+    @GetMapping
+    fun getMe(): CommonApiResponse<GetMeResponse> = CommonApiResponse.success("OK", getMeService.execute())
+}

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/GetMeResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/GetMeResponse.kt
@@ -1,0 +1,40 @@
+package team.incube.flooding.domain.user.presentation.data.response
+
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+
+data class GetMeResponse(
+    val id: Long,
+    val name: String,
+    val sex: Sex,
+    val email: String,
+    val studentNumber: Int,
+    val grade: Int,
+    val classNumber: Int,
+    val number: Int,
+    val role: Role,
+    val dormitoryRoom: Int,
+    val dormitoryFloor: Int,
+    val specialty: String?,
+    val penaltyScore: Int,
+) {
+    companion object {
+        fun from(user: UserJpaEntity) =
+            GetMeResponse(
+                id = user.id,
+                name = user.name,
+                sex = user.sex,
+                email = user.email,
+                studentNumber = user.studentNumber,
+                grade = user.grade,
+                classNumber = user.classNumber,
+                number = user.number,
+                role = user.role,
+                dormitoryRoom = user.dormitoryRoom,
+                dormitoryFloor = user.dormitoryFloor,
+                specialty = user.specialty,
+                penaltyScore = user.penaltyScore,
+            )
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/GetMeService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/GetMeService.kt
@@ -1,0 +1,7 @@
+package team.incube.flooding.domain.user.service
+
+import team.incube.flooding.domain.user.presentation.data.response.GetMeResponse
+
+interface GetMeService {
+    fun execute(): GetMeResponse
+}

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/impl/GetMeServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/impl/GetMeServiceImpl.kt
@@ -1,0 +1,18 @@
+package team.incube.flooding.domain.user.service.impl
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.user.presentation.data.response.GetMeResponse
+import team.incube.flooding.domain.user.service.GetMeService
+import team.incube.flooding.global.security.util.CurrentUserProvider
+
+@Service
+class GetMeServiceImpl(
+    private val currentUserProvider: CurrentUserProvider,
+) : GetMeService {
+    @Transactional(readOnly = true)
+    override fun execute(): GetMeResponse {
+        val user = currentUserProvider.getCurrentUser()
+        return GetMeResponse.from(user)
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

- `GET /me` 엔드포인트를 추가하여 현재 로그인한 유저의 정보를 조회할 수 있도록 구현
- `GetMeService` 인터페이스 및 `GetMeServiceImpl` 서비스 구현체 추가
- `GetMeResponse` DTO를 통해 유저 정보(이름, 성별, 이메일, 학번, 학년, 반, 번호, 역할, 기숙사 정보 등) 반환
- Swagger 문서 포함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음