### PR TITLE
동아리 승인 시 DataGSM 동아리 생성 이벤트 연동

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/entity/ClubJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/entity/ClubJpaEntity.kt
@@ -33,6 +33,8 @@ class ClubJpaEntity(
     @field:ManyToOne(fetch = FetchType.LAZY)
     @field:JoinColumn(name = "club_room_id")
     var clubRoom: ClubRoomJpaEntity? = null,
+    @field:Column(name = "data_gsm_club_id")
+    var dataGsmClubId: Long? = null,
 ) {
     fun isModifiableBy(user: UserJpaEntity): Boolean {
         val isAdminOrCouncil = user.role == Role.ADMIN || user.role == Role.STUDENT_COUNCIL

--- a/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEvent.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEvent.kt
@@ -1,0 +1,5 @@
+package team.incube.flooding.domain.club.event
+
+data class ClubApprovedEvent(
+    val clubId: Long,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.club.event
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
@@ -48,7 +49,7 @@ class ClubDataGsmIdSaver(
         clubId: Long,
         dataGsmClubId: Long,
     ) {
-        val club = clubRepository.findById(clubId).orElse(null) ?: return
+        val club = clubRepository.findByIdOrNull(clubId) ?: return
         club.dataGsmClubId = dataGsmClubId
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
@@ -13,9 +13,9 @@ import java.time.LocalDate
 class ClubApprovedEventListener(
     private val clubRepository: ClubRepository,
     private val dataGsmClubClient: DataGsmClubClient,
+    private val clubDataGsmIdSaver: ClubDataGsmIdSaver,
 ) {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun handleClubApproved(event: ClubApprovedEvent) {
         val club = clubRepository.findByIdWithLeader(event.clubId) ?: return
 
@@ -29,12 +29,24 @@ class ClubApprovedEventListener(
                     leaderId = leaderDataGsmId,
                     participantIds = emptyList(),
                     foundedYear = LocalDate.now().year,
-                    status = "ACTIVE",
+                    status = club.status.name,
                 ),
-            )
+            ) ?: return
 
-        if (dataGsmClubId != null) {
-            club.dataGsmClubId = dataGsmClubId
-        }
+        clubDataGsmIdSaver.save(event.clubId, dataGsmClubId)
+    }
+}
+
+@Component
+class ClubDataGsmIdSaver(
+    private val clubRepository: ClubRepository,
+) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun save(
+        clubId: Long,
+        dataGsmClubId: Long,
+    ) {
+        val club = clubRepository.findById(clubId).orElse(null) ?: return
+        club.dataGsmClubId = dataGsmClubId
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
@@ -1,0 +1,40 @@
+package team.incube.flooding.domain.club.event
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import team.incube.flooding.domain.club.repository.ClubRepository
+import team.incube.flooding.global.client.DataGsmClubClient
+import java.time.LocalDate
+
+@Component
+class ClubApprovedEventListener(
+    private val clubRepository: ClubRepository,
+    private val dataGsmClubClient: DataGsmClubClient,
+) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun handleClubApproved(event: ClubApprovedEvent) {
+        val club = clubRepository.findByIdWithLeader(event.clubId) ?: return
+
+        val leaderDataGsmId = club.leader?.let { dataGsmClubClient.getStudentIdByEmail(it.email) }
+
+        val dataGsmClubId =
+            dataGsmClubClient.createClub(
+                DataGsmClubClient.ClubReqDto(
+                    name = club.name,
+                    type = club.type.name,
+                    leaderId = leaderDataGsmId,
+                    participantIds = emptyList(),
+                    foundedYear = LocalDate.now().year,
+                    status = "ACTIVE",
+                ),
+            )
+
+        if (dataGsmClubId != null) {
+            club.dataGsmClubId = dataGsmClubId
+        }
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.club.event
 
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -15,6 +16,7 @@ class ClubApprovedEventListener(
     private val dataGsmClubClient: DataGsmClubClient,
     private val clubDataGsmIdSaver: ClubDataGsmIdSaver,
 ) {
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun handleClubApproved(event: ClubApprovedEvent) {
         val club = clubRepository.findByIdWithLeader(event.clubId) ?: return

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
@@ -33,15 +33,15 @@ class GetClubServiceImpl(
                         )
                     }
                 }
+            val projectsDeferred =
+                async(Dispatchers.IO) {
+                    val dgId = clubDeferred.await()?.dataGsmClubId ?: return@async emptyList()
+                    runCatching { dataGsmProjectClient.getProjectsByClubId(dgId) }.getOrElse { emptyList() }
+                }
+
             val club =
                 clubDeferred.await()
                     ?: throw ExpectedException("존재하지 않는 동아리입니다.", HttpStatus.NOT_FOUND)
-
-            val projectsDeferred =
-                async(Dispatchers.IO) {
-                    val dgId = club.dataGsmClubId ?: return@async emptyList()
-                    runCatching { dataGsmProjectClient.getProjectsByClubId(dgId) }.getOrElse { emptyList() }
-                }
 
             GetClubResponse(
                 club =

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
@@ -33,14 +33,15 @@ class GetClubServiceImpl(
                         )
                     }
                 }
-            val projectsDeferred =
-                async(Dispatchers.IO) {
-                    dataGsmProjectClient.getProjectsByClubId(clubId)
-                }
-
             val club =
                 clubDeferred.await()
                     ?: throw ExpectedException("존재하지 않는 동아리입니다.", HttpStatus.NOT_FOUND)
+
+            val projectsDeferred =
+                async(Dispatchers.IO) {
+                    val dgId = club.dataGsmClubId ?: return@async emptyList()
+                    runCatching { dataGsmProjectClient.getProjectsByClubId(dgId) }.getOrElse { emptyList() }
+                }
 
             GetClubResponse(
                 club =

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/PatchClubApprovalServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/PatchClubApprovalServiceImpl.kt
@@ -1,9 +1,11 @@
 package team.incube.flooding.domain.club.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.club.entity.ClubApprovalStatus
+import team.incube.flooding.domain.club.event.ClubApprovedEvent
 import team.incube.flooding.domain.club.presentation.data.request.PatchClubApprovalRequest
 import team.incube.flooding.domain.club.presentation.data.response.PatchClubApprovalResponse
 import team.incube.flooding.domain.club.repository.ClubRepository
@@ -13,6 +15,7 @@ import team.themoment.sdk.exception.ExpectedException
 @Service
 class PatchClubApprovalServiceImpl(
     private val clubRepository: ClubRepository,
+    private val eventPublisher: ApplicationEventPublisher,
 ) : PatchClubApprovalService {
     @Transactional
     override fun execute(
@@ -30,6 +33,10 @@ class PatchClubApprovalServiceImpl(
 
         val newApprovalStatus = if (request.approved) ClubApprovalStatus.APPROVED else ClubApprovalStatus.REJECTED
         club.approvalStatus = newApprovalStatus
+
+        if (newApprovalStatus == ClubApprovalStatus.APPROVED) {
+            eventPublisher.publishEvent(ClubApprovedEvent(clubId))
+        }
 
         return PatchClubApprovalResponse(clubId = clubId, status = newApprovalStatus)
     }

--- a/src/main/kotlin/team/incube/flooding/global/client/DataGsmClubClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/DataGsmClubClient.kt
@@ -9,13 +9,14 @@ import org.springframework.web.client.RestClient
 @Component
 class DataGsmClubClient(
     private val restClientBuilder: RestClient.Builder,
+    @Value("\${datagsm.base-url}") private val baseUrl: String,
     @Value("\${datagsm.open-api-key}") private val apiKey: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     private val restClient: RestClient by lazy {
         restClientBuilder
-            .baseUrl("https://api.datagsm.com")
+            .baseUrl(baseUrl)
             .defaultHeader("X-API-KEY", apiKey)
             .build()
     }

--- a/src/main/kotlin/team/incube/flooding/global/client/DataGsmClubClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/DataGsmClubClient.kt
@@ -8,14 +8,14 @@ import org.springframework.web.client.RestClient
 
 @Component
 class DataGsmClubClient(
-    private val restClientBuilder: RestClient.Builder,
     @Value("\${datagsm.base-url}") private val baseUrl: String,
     @Value("\${datagsm.open-api-key}") private val apiKey: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     private val restClient: RestClient by lazy {
-        restClientBuilder
+        RestClient
+            .builder()
             .baseUrl(baseUrl)
             .defaultHeader("X-API-KEY", apiKey)
             .build()

--- a/src/main/kotlin/team/incube/flooding/global/client/DataGsmClubClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/DataGsmClubClient.kt
@@ -1,0 +1,79 @@
+package team.incube.flooding.global.client
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+
+@Component
+class DataGsmClubClient(
+    private val restClientBuilder: RestClient.Builder,
+    @Value("\${datagsm.open-api-key}") private val apiKey: String,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val restClient: RestClient by lazy {
+        restClientBuilder
+            .baseUrl("https://api.datagsm.com")
+            .defaultHeader("X-API-KEY", apiKey)
+            .build()
+    }
+
+    fun createClub(request: ClubReqDto): Long? =
+        runCatching {
+            restClient
+                .post()
+                .uri("/v1/clubs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(ClubResponse::class.java)
+                ?.data
+                ?.id
+        }.onFailure { log.error("DataGSM 동아리 생성 실패: name=${request.name}", it) }
+            .getOrNull()
+
+    fun getStudentIdByEmail(email: String): Long? =
+        runCatching {
+            restClient
+                .get()
+                .uri { it.path("/v1/students").queryParam("email", email).build() }
+                .retrieve()
+                .body(StudentListResponse::class.java)
+                ?.data
+                ?.students
+                ?.firstOrNull()
+                ?.id
+        }.getOrNull()
+
+    data class ClubReqDto(
+        val name: String,
+        val type: String,
+        val leaderId: Long?,
+        val participantIds: List<Long>,
+        val foundedYear: Int,
+        val status: String,
+    )
+
+    data class ClubResponse(
+        val data: ClubData,
+    ) {
+        data class ClubData(
+            val id: Long,
+        )
+    }
+
+    data class StudentListResponse(
+        val data: StudentListData,
+    ) {
+        data class StudentListData(
+            val students: List<StudentData>,
+        )
+
+        data class StudentData(
+            val id: Long,
+            val email: String,
+        )
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/global/config/AsyncConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/AsyncConfig.kt
@@ -1,0 +1,22 @@
+package team.incube.flooding.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@Configuration
+@EnableAsync
+class AsyncConfig {
+    @Bean(name = ["taskExecutor"])
+    fun taskExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 2
+        executor.maxPoolSize = 10
+        executor.queueCapacity = 50
+        executor.setThreadNamePrefix("async-event-")
+        executor.initialize()
+        return executor
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,7 @@ oauth:
   client-secret: ${OAUTH_CLIENT_SECRET}
 
 datagsm:
+  base-url: ${DATAGSM_BASE_URL:https://api.datagsm.com}
   open-api-key: ${DATAGSM_OPEN_API_KEY}
 
 ai:

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/PatchClubApprovalServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/PatchClubApprovalServiceTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import team.incube.flooding.domain.club.entity.ClubApprovalStatus
 import team.incube.flooding.domain.club.entity.ClubJpaEntity
@@ -19,7 +20,8 @@ import java.util.Optional
 class PatchClubApprovalServiceTest :
     BehaviorSpec({
         val clubRepository = mockk<ClubRepository>()
-        val service = PatchClubApprovalServiceImpl(clubRepository)
+        val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
+        val service = PatchClubApprovalServiceImpl(clubRepository, eventPublisher)
 
         fun club(approvalStatus: ClubApprovalStatus) =
             ClubJpaEntity(


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

### 동아리 승인 시 DataGSM 동아리 생성 이벤트 연동
- `PATCH /clubs/{clubId}/approval`에서 `approved=true`일 때 `ClubApprovedEvent` 발행
- `@TransactionalEventListener(AFTER_COMMIT)`으로 승인 트랜잭션과 분리하여 외부 API 실패가 롤백에 영향 없도록 처리
- DataGSM `POST /v1/clubs` 호출 후 반환된 ID를 `ClubJpaEntity.dataGsmClubId`에 저장
- 이후 프로젝트 조회 시 `dataGsmClubId` 기준으로 DataGSM API 호출
- 외부 API 호출은 트랜잭션 밖에서 수행하고, DB 저장(`dataGsmClubId`)만 `ClubDataGsmIdSaver`에서 별도 트랜잭션으로 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음