### PR TITLE
학생 검색 API 구현 (이름·학번·페이지네이션)

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
@@ -35,15 +35,18 @@ class UserController(
 
     @Operation(
         summary = "학생 검색",
-        description = "이름 또는 학번으로 학생을 검색합니다. 두 조건 모두 부분 일치하며, 파라미터를 모두 생략하면 전체 학생을 페이지네이션하여 반환합니다.",
+        description =
+            "이름(부분 일치) 또는 학번(전방 일치)으로 학생을 검색합니다. " +
+                "파라미터를 모두 생략하면 전체 학생을 페이지네이션하여 반환합니다. " +
+                "ADMIN 역할은 검색 결과에서 제외됩니다.",
     )
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     @GetMapping
     fun searchUsers(
-        @Parameter(description = "이름 (부분 일치, 대소문자 무시)")
+        @Parameter(description = "이름 (부분 일치)")
         @RequestParam(required = false) name: String?,
-        @Parameter(description = "학번 (앞자리 일치, 예: '1' → 1학년)")
+        @Parameter(description = "학번 (전방 일치, 예: '1' → 1학년 전체, '11' → 1학년 1반)")
         @RequestParam(required = false) studentNumber: String?,
         @Parameter(description = "페이지 정보 (page, size, sort)")
         @PageableDefault(size = 20, sort = ["studentNumber,asc"])

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
@@ -1,13 +1,20 @@
 package team.incube.flooding.domain.user.presentation.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.incube.flooding.domain.user.presentation.data.response.GetMeResponse
+import team.incube.flooding.domain.user.presentation.data.response.SearchUsersResponse
 import team.incube.flooding.domain.user.service.GetMeService
+import team.incube.flooding.domain.user.service.SearchUsersService
 import team.themoment.sdk.response.CommonApiResponse
 
 @Tag(name = "유저", description = "유저 관련 API")
@@ -15,6 +22,7 @@ import team.themoment.sdk.response.CommonApiResponse
 @RequestMapping("/users")
 class UserController(
     private val getMeService: GetMeService,
+    private val searchUsersService: SearchUsersService,
 ) {
     @Operation(
         summary = "내 정보 조회",
@@ -24,4 +32,22 @@ class UserController(
     @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     @GetMapping("/me")
     fun getMe(): CommonApiResponse<GetMeResponse> = CommonApiResponse.success("OK", getMeService.execute())
+
+    @Operation(
+        summary = "학생 검색",
+        description = "이름 또는 학번으로 학생을 검색합니다. 두 조건 모두 부분 일치하며, 파라미터를 모두 생략하면 전체 학생을 페이지네이션하여 반환합니다.",
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    @GetMapping
+    fun searchUsers(
+        @Parameter(description = "이름 (부분 일치, 대소문자 무시)")
+        @RequestParam(required = false) name: String?,
+        @Parameter(description = "학번 (앞자리 일치, 예: '1' → 1학년)")
+        @RequestParam(required = false) studentNumber: String?,
+        @Parameter(description = "페이지 정보 (page, size, sort)")
+        @PageableDefault(size = 20, sort = ["studentNumber,asc"])
+        pageable: Pageable,
+    ): CommonApiResponse<Page<SearchUsersResponse>> =
+        CommonApiResponse.success("OK", searchUsersService.execute(name, studentNumber, pageable))
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/SearchUsersResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/SearchUsersResponse.kt
@@ -1,0 +1,24 @@
+package team.incube.flooding.domain.user.presentation.data.response
+
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+
+data class SearchUsersResponse(
+    val id: Long,
+    val name: String,
+    val studentNumber: Int,
+    val grade: Int,
+    val classNumber: Int,
+    val number: Int,
+) {
+    companion object {
+        fun from(user: UserJpaEntity) =
+            SearchUsersResponse(
+                id = user.id,
+                name = user.name,
+                studentNumber = user.studentNumber,
+                grade = user.grade,
+                classNumber = user.classNumber,
+                number = user.number,
+            )
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/repository/UserRepository.kt
@@ -1,5 +1,7 @@
 package team.incube.flooding.domain.user.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -9,4 +11,17 @@ interface UserRepository : JpaRepository<UserJpaEntity, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE UserJpaEntity u SET u.cleaningZone = null WHERE u.cleaningZone.id = :zoneId")
     fun clearCleaningZoneByZoneId(zoneId: Long)
+
+    @Query(
+        """
+        SELECT u FROM UserJpaEntity u
+        WHERE (:name IS NULL OR LOWER(u.name) LIKE LOWER(CONCAT('%', :name, '%')))
+        AND (:studentNumber IS NULL OR CAST(u.studentNumber AS string) LIKE CONCAT(:studentNumber, '%'))
+        """,
+    )
+    fun searchUsers(
+        name: String?,
+        studentNumber: String?,
+        pageable: Pageable,
+    ): Page<UserJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/repository/UserRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import team.incube.flooding.domain.user.entity.Role
 import team.incube.flooding.domain.user.entity.UserJpaEntity
 
 interface UserRepository : JpaRepository<UserJpaEntity, Long> {
@@ -15,13 +16,16 @@ interface UserRepository : JpaRepository<UserJpaEntity, Long> {
     @Query(
         """
         SELECT u FROM UserJpaEntity u
-        WHERE (:name IS NULL OR LOWER(u.name) LIKE LOWER(CONCAT('%', :name, '%')))
-        AND (:studentNumber IS NULL OR CAST(u.studentNumber AS string) LIKE CONCAT(:studentNumber, '%'))
+        WHERE u.role <> :excludedRole
+        AND (:name IS NULL OR u.name LIKE CONCAT('%', :name, '%'))
+        AND (:studentNumberStart IS NULL OR u.studentNumber BETWEEN :studentNumberStart AND :studentNumberEnd)
         """,
     )
     fun searchUsers(
         name: String?,
-        studentNumber: String?,
+        studentNumberStart: Int?,
+        studentNumberEnd: Int?,
+        excludedRole: Role,
         pageable: Pageable,
     ): Page<UserJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/SearchUsersService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/SearchUsersService.kt
@@ -1,0 +1,13 @@
+package team.incube.flooding.domain.user.service
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import team.incube.flooding.domain.user.presentation.data.response.SearchUsersResponse
+
+interface SearchUsersService {
+    fun execute(
+        name: String?,
+        studentNumber: String?,
+        pageable: Pageable,
+    ): Page<SearchUsersResponse>
+}

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/impl/SearchUsersServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/impl/SearchUsersServiceImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.user.entity.Role
 import team.incube.flooding.domain.user.presentation.data.response.SearchUsersResponse
 import team.incube.flooding.domain.user.repository.UserRepository
 import team.incube.flooding.domain.user.service.SearchUsersService
@@ -17,11 +18,30 @@ class SearchUsersServiceImpl(
         name: String?,
         studentNumber: String?,
         pageable: Pageable,
-    ): Page<SearchUsersResponse> =
-        userRepository
+    ): Page<SearchUsersResponse> {
+        val (start, end) = parseStudentNumberPrefix(studentNumber)
+        return userRepository
             .searchUsers(
                 name = name?.trim()?.takeIf { it.isNotEmpty() },
-                studentNumber = studentNumber?.trim()?.takeIf { it.isNotEmpty() },
+                studentNumberStart = start,
+                studentNumberEnd = end,
+                excludedRole = Role.ADMIN,
                 pageable = pageable,
             ).map(SearchUsersResponse::from)
+    }
+
+    private fun parseStudentNumberPrefix(input: String?): Pair<Int?, Int?> {
+        val trimmed = input?.trim().orEmpty()
+        if (trimmed.isEmpty() || trimmed.length > STUDENT_NUMBER_LENGTH || !trimmed.all(Char::isDigit)) {
+            return null to null
+        }
+        val multiplier = POW10[STUDENT_NUMBER_LENGTH - trimmed.length]
+        val base = trimmed.toInt() * multiplier
+        return base to (base + multiplier - 1)
+    }
+
+    companion object {
+        private const val STUDENT_NUMBER_LENGTH = 4
+        private val POW10 = intArrayOf(1, 10, 100, 1000, 10000)
+    }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/impl/SearchUsersServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/impl/SearchUsersServiceImpl.kt
@@ -1,0 +1,27 @@
+package team.incube.flooding.domain.user.service.impl
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.user.presentation.data.response.SearchUsersResponse
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.incube.flooding.domain.user.service.SearchUsersService
+
+@Service
+class SearchUsersServiceImpl(
+    private val userRepository: UserRepository,
+) : SearchUsersService {
+    @Transactional(readOnly = true)
+    override fun execute(
+        name: String?,
+        studentNumber: String?,
+        pageable: Pageable,
+    ): Page<SearchUsersResponse> =
+        userRepository
+            .searchUsers(
+                name = name?.trim()?.takeIf { it.isNotEmpty() },
+                studentNumber = studentNumber?.trim()?.takeIf { it.isNotEmpty() },
+                pageable = pageable,
+            ).map(SearchUsersResponse::from)
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

동아리 멤버 초대 시 학생 ID 조회 수단이 없어 학생 조회(검색) API를 추가했습니다.

- `GET /users` 엔드포인트 추가 (인증된 모든 유저 사용 가능)
- 쿼리 파라미터
  - `name` (선택): 이름 부분 일치, 대소문자 무시
  - `studentNumber` (선택): 학번 앞자리 일치 (예: `1` → 1학년 전체)
  - `page`, `size`, `sort`: Spring `Pageable` (기본 size=20, `studentNumber` 오름차순)
- 응답 DTO(`SearchUsersResponse`)는 `id`, `name`, `studentNumber`, `grade`, `classNumber`, `number`만 노출하여 이메일·기숙사호실·벌점 등 민감 정보 제외
- `UserRepository.searchUsers` JPQL 쿼리는 두 조건 모두 null 허용 (전체 조회 가능)
- 서비스 계층에서 `name`/`studentNumber` 공백 trim 후 빈 문자열은 null로 변환

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 응답 DTO에 어느 정도까지 학생 정보를 포함할지 검토 부탁드립니다. 현재는 학번/이름/학년·반·번호만 노출했습니다.