### PR TITLE
DataGSM 프로젝트 조회 캐싱 전략을 스케줄러 기반으로 개선

### DIFF
--- a/src/main/kotlin/team/incube/flooding/FloodingServerV2Application.kt
+++ b/src/main/kotlin/team/incube/flooding/FloodingServerV2Application.kt
@@ -3,9 +3,11 @@ package team.incube.flooding
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 class FloodingServerV2Application
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
@@ -24,4 +24,6 @@ interface ClubRepository : JpaRepository<ClubJpaEntity, Long> {
         type: ClubType,
         keyword: String,
     ): List<ClubJpaEntity>
+
+    fun findAllByDataGsmClubIdIsNotNull(): List<ClubJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
@@ -10,7 +10,6 @@ import org.springframework.web.client.RestClient
 import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
 import tools.jackson.core.type.TypeReference
 import tools.jackson.databind.json.JsonMapper
-import java.time.Duration
 
 @Component
 class DataGsmProjectClient(
@@ -32,16 +31,18 @@ class DataGsmProjectClient(
             .build()
     }
 
-    suspend fun getProjectsByClubId(clubId: Long): List<GetClubResponse.ProjectSummary> {
-        val cacheKey = "$CACHE_PREFIX$clubId"
-        val cached = redisTemplate.opsForValue().get(cacheKey)
-        if (cached != null) {
-            return jsonMapper.readValue(cached, object : TypeReference<List<GetClubResponse.ProjectSummary>>() {})
+    suspend fun getProjectsByClubId(clubId: Long): List<GetClubResponse.ProjectSummary> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val cacheKey = "$CACHE_PREFIX$clubId"
+                val cached = redisTemplate.opsForValue().get(cacheKey)
+                if (cached != null) {
+                    jsonMapper.readValue(cached, object : TypeReference<List<GetClubResponse.ProjectSummary>>() {})
+                } else {
+                    warmCache(clubId) ?: emptyList()
+                }
+            }.getOrElse { emptyList() }
         }
-        return withContext(Dispatchers.IO) {
-            warmCache(clubId) ?: emptyList()
-        }
-    }
 
     fun warmCache(clubId: Long): List<GetClubResponse.ProjectSummary>? {
         val projects =
@@ -50,7 +51,7 @@ class DataGsmProjectClient(
                 return null
             }
         val cacheKey = "$CACHE_PREFIX$clubId"
-        redisTemplate.opsForValue().set(cacheKey, jsonMapper.writeValueAsString(projects), Duration.ofHours(1))
+        redisTemplate.opsForValue().set(cacheKey, jsonMapper.writeValueAsString(projects))
         return projects
     }
 

--- a/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
@@ -1,4 +1,8 @@
 package team.incube.flooding.global.client
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
@@ -6,7 +10,6 @@ import org.springframework.web.client.RestClient
 import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
 import tools.jackson.core.type.TypeReference
 import tools.jackson.databind.json.JsonMapper
-import java.time.Duration
 
 @Component
 class DataGsmProjectClient(
@@ -15,29 +18,44 @@ class DataGsmProjectClient(
     private val restClientBuilder: RestClient.Builder,
     @Value("\${datagsm.open-api-key}") private val apiKey: String,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     companion object {
         private const val CACHE_PREFIX = "club:projects:"
-        private val CACHE_TTL = Duration.ofMinutes(30)
     }
 
     private val restClient: RestClient by lazy {
         restClientBuilder
-            .baseUrl("https://api.datagsm.com")
+            .baseUrl("https://openapi.datagsm.kr")
             .defaultHeader("X-API-KEY", apiKey)
             .build()
     }
 
-    fun getProjectsByClubId(clubId: Long): List<GetClubResponse.ProjectSummary> {
+    suspend fun getProjectsByClubId(clubId: Long): List<GetClubResponse.ProjectSummary> {
         val cacheKey = "$CACHE_PREFIX$clubId"
-        redisTemplate.opsForValue().get(cacheKey)?.let {
-            return jsonMapper.readValue(it, object : TypeReference<List<GetClubResponse.ProjectSummary>>() {})
+        val cached = redisTemplate.opsForValue().get(cacheKey)
+        if (cached != null) {
+            return jsonMapper.readValue(cached, object : TypeReference<List<GetClubResponse.ProjectSummary>>() {})
         }
-        val projects = fetchFromApi(clubId)
-        redisTemplate.opsForValue().set(cacheKey, jsonMapper.writeValueAsString(projects), CACHE_TTL)
-        return projects
+        return withContext(Dispatchers.IO) {
+            warmCache(clubId)
+            redisTemplate.opsForValue().get(cacheKey)?.let {
+                jsonMapper.readValue(it, object : TypeReference<List<GetClubResponse.ProjectSummary>>() {})
+            } ?: emptyList()
+        }
     }
 
-    private fun fetchFromApi(clubId: Long): List<GetClubResponse.ProjectSummary> =
+    fun warmCache(clubId: Long) {
+        val projects =
+            fetchFromApi(clubId) ?: run {
+                log.warn("DataGSM API 응답 없음, 기존 캐시 유지: clubId=$clubId")
+                return
+            }
+        val cacheKey = "$CACHE_PREFIX$clubId"
+        redisTemplate.opsForValue().set(cacheKey, jsonMapper.writeValueAsString(projects))
+    }
+
+    private fun fetchFromApi(clubId: Long): List<GetClubResponse.ProjectSummary>? =
         runCatching {
             restClient
                 .get()
@@ -47,7 +65,8 @@ class DataGsmProjectClient(
                 ?.data
                 ?.projects
                 ?.map { it.toSummary() }
-        }.getOrNull() ?: emptyList()
+        }.onFailure { log.error("DataGSM 프로젝트 조회 실패: clubId=$clubId", it) }
+            .getOrNull()
 
     data class DataGsmResponse(
         val data: ProjectData,

--- a/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
@@ -10,6 +10,7 @@ import org.springframework.web.client.RestClient
 import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
 import tools.jackson.core.type.TypeReference
 import tools.jackson.databind.json.JsonMapper
+import java.time.Duration
 
 @Component
 class DataGsmProjectClient(
@@ -38,21 +39,19 @@ class DataGsmProjectClient(
             return jsonMapper.readValue(cached, object : TypeReference<List<GetClubResponse.ProjectSummary>>() {})
         }
         return withContext(Dispatchers.IO) {
-            warmCache(clubId)
-            redisTemplate.opsForValue().get(cacheKey)?.let {
-                jsonMapper.readValue(it, object : TypeReference<List<GetClubResponse.ProjectSummary>>() {})
-            } ?: emptyList()
+            warmCache(clubId) ?: emptyList()
         }
     }
 
-    fun warmCache(clubId: Long) {
+    fun warmCache(clubId: Long): List<GetClubResponse.ProjectSummary>? {
         val projects =
             fetchFromApi(clubId) ?: run {
                 log.warn("DataGSM API 응답 없음, 기존 캐시 유지: clubId=$clubId")
-                return
+                return null
             }
         val cacheKey = "$CACHE_PREFIX$clubId"
-        redisTemplate.opsForValue().set(cacheKey, jsonMapper.writeValueAsString(projects))
+        redisTemplate.opsForValue().set(cacheKey, jsonMapper.writeValueAsString(projects), Duration.ofHours(1))
+        return projects
     }
 
     private fun fetchFromApi(clubId: Long): List<GetClubResponse.ProjectSummary>? =

--- a/src/main/kotlin/team/incube/flooding/global/scheduler/DataGsmProjectCacheScheduler.kt
+++ b/src/main/kotlin/team/incube/flooding/global/scheduler/DataGsmProjectCacheScheduler.kt
@@ -16,16 +16,19 @@ class DataGsmProjectCacheScheduler(
     private val log = LoggerFactory.getLogger(javaClass)
 
     @EventListener(ApplicationReadyEvent::class)
-    fun warmUpOnStartup() = warmAll()
+    fun warmUpOnStartup() {
+        Thread.startVirtualThread { warmAll() }
+    }
 
-    @Scheduled(fixedRate = 30 * 60 * 1000)
+    @Scheduled(fixedRate = 30 * 60 * 1000, initialDelay = 30 * 60 * 1000)
     fun warmUpScheduled() = warmAll()
 
     private fun warmAll() {
         val clubs = clubRepository.findAllByDataGsmClubIdIsNotNull()
         log.info("DataGSM 프로젝트 캐시 워밍 시작: {}개 동아리", clubs.size)
         clubs.forEach { club ->
-            runCatching { dataGsmProjectClient.warmCache(club.dataGsmClubId!!) }
+            val dataGsmClubId = club.dataGsmClubId ?: return@forEach
+            runCatching { dataGsmProjectClient.warmCache(dataGsmClubId) }
                 .onFailure { log.error("캐시 워밍 실패: clubId=${club.id}", it) }
         }
         log.info("DataGSM 프로젝트 캐시 워밍 완료")

--- a/src/main/kotlin/team/incube/flooding/global/scheduler/DataGsmProjectCacheScheduler.kt
+++ b/src/main/kotlin/team/incube/flooding/global/scheduler/DataGsmProjectCacheScheduler.kt
@@ -1,7 +1,8 @@
 package team.incube.flooding.global.scheduler
 
-import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import team.incube.flooding.domain.club.repository.ClubRepository
@@ -14,7 +15,7 @@ class DataGsmProjectCacheScheduler(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    @PostConstruct
+    @EventListener(ApplicationReadyEvent::class)
     fun warmUpOnStartup() = warmAll()
 
     @Scheduled(fixedRate = 30 * 60 * 1000)

--- a/src/main/kotlin/team/incube/flooding/global/scheduler/DataGsmProjectCacheScheduler.kt
+++ b/src/main/kotlin/team/incube/flooding/global/scheduler/DataGsmProjectCacheScheduler.kt
@@ -1,0 +1,32 @@
+package team.incube.flooding.global.scheduler
+
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import team.incube.flooding.domain.club.repository.ClubRepository
+import team.incube.flooding.global.client.DataGsmProjectClient
+
+@Component
+class DataGsmProjectCacheScheduler(
+    private val clubRepository: ClubRepository,
+    private val dataGsmProjectClient: DataGsmProjectClient,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @PostConstruct
+    fun warmUpOnStartup() = warmAll()
+
+    @Scheduled(fixedRate = 30 * 60 * 1000)
+    fun warmUpScheduled() = warmAll()
+
+    private fun warmAll() {
+        val clubs = clubRepository.findAllByDataGsmClubIdIsNotNull()
+        log.info("DataGSM 프로젝트 캐시 워밍 시작: {}개 동아리", clubs.size)
+        clubs.forEach { club ->
+            runCatching { dataGsmProjectClient.warmCache(club.dataGsmClubId!!) }
+                .onFailure { log.error("캐시 워밍 실패: clubId=${club.id}", it) }
+        }
+        log.info("DataGSM 프로젝트 캐시 워밍 완료")
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #84

## 📝작업 내용

기존 DataGSM 프로젝트 조회는 요청이 오면 Redis를 확인하고 캐시 미스 시 외부 API를 호출하는 lazy cache 방식으로 동작했습니다.
이를 스케줄러 기반 pre-cache 방식으로 전환하여 요청 시점에 외부 API 호출이 발생하지 않도록 개선했습니다.

- `DataGsmProjectCacheScheduler` 추가: 서버 시작 시 및 30분마다 dataGsmClubId가 있는 전체 동아리의 프로젝트를 선제적으로 캐싱
- `DataGsmProjectClient.getProjectsByClubId`를 suspend 함수로 전환: 캐시 미스 발생 시 suspend하여 API를 호출하고 캐시 저장 후 반환
- `warmCache` 메서드 추가: API 실패 시 기존 캐시를 유지하고 성공 시에만 Redis 갱신 (TTL 제거, 스케줄러가 freshness 관리)
- `fetchFromApi` 반환 타입을 `List?`로 변경: API 실패(null)와 프로젝트 없음(emptyList) 구분
- DataGSM API base URL 수정: `api.datagsm.com` (도메인 만료) → `openapi.datagsm.kr`
- `ClubRepository`에 `findAllByDataGsmClubIdIsNotNull()` 추가
- `@EnableScheduling` 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음