### PR TITLE
AiSongAdapter 오류 응답 상태코드 및 바디 로깅 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
@@ -36,7 +36,7 @@ class AiSongAdapter(
             .body(request)
             .retrieve()
             .onStatus({ it.isError }) { _, response ->
-                val body = response.bodyTo(String::class.java)
+                val body = response.body.bufferedReader().readText()
                 log.error("AI 음악 추천 서버 오류 - status: {}, body: {}", response.statusCode, body)
                 throw ExpectedException("AI 음악 추천 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
             }.body(RecommendAiSongResponse::class.java)

--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
@@ -36,7 +36,7 @@ class AiSongAdapter(
             .body(request)
             .retrieve()
             .onStatus({ it.isError }) { _, response ->
-                val body = response.body.bufferedReader().readText()
+                val body = response.body.bufferedReader().use { it.readText() }
                 log.error("AI 음악 추천 서버 오류 - status: {}, body: {}", response.statusCode, body)
                 throw ExpectedException("AI 음악 추천 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
             }.body(RecommendAiSongResponse::class.java)

--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.ai.adapter
 
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -14,6 +15,8 @@ import team.themoment.sdk.exception.ExpectedException
 class AiSongAdapter(
     @Value("\${ai.song.base-url}") baseUrl: String,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     private val restClient =
         RestClient
             .builder()
@@ -32,7 +35,9 @@ class AiSongAdapter(
             .contentType(MediaType.APPLICATION_JSON)
             .body(request)
             .retrieve()
-            .onStatus({ it.isError }) { _, _ ->
+            .onStatus({ it.isError }) { _, response ->
+                val body = response.bodyTo(String::class.java)
+                log.error("AI 음악 추천 서버 오류 - status: {}, body: {}", response.statusCode, body)
                 throw ExpectedException("AI 음악 추천 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
             }.body(RecommendAiSongResponse::class.java)
             ?: throw ExpectedException("AI 음악 추천 서버로부터 응답을 받지 못했습니다.", HttpStatus.BAD_GATEWAY)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #86

## 📝작업 내용

AI 음악 추천 서버가 오류 응답을 반환할 때 실제 응답 상태코드와 바디를 로그로 출력하도록 수정하였습니다.
기존에는 오류 발생 시 단순히 502를 반환하여 AI 서버의 실제 오류 원인을 파악하기 어려웠습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음