### PR TITLE
홈베이스 날짜별 신청 기능 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/homebase/dto/request/CreateHomebaseRequest.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/dto/request/CreateHomebaseRequest.kt
@@ -4,8 +4,10 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Size
 import team.incube.flooding.domain.homebase.dto.MemberDto
+import java.time.LocalDate
 
 data class CreateHomebaseRequest(
+    val reservationDate: LocalDate,
     val startPeriod: Int,
     val endPeriod: Int,
     @field:NotBlank(message = "예약 사유를 입력해주세요.")

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/dto/response/GetHomebaseResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/dto/response/GetHomebaseResponse.kt
@@ -1,9 +1,11 @@
 package team.incube.flooding.domain.homebase.dto.response
 
 import team.incube.flooding.domain.homebase.dto.MemberDto
+import java.time.LocalDate
 
 data class GetHomebaseResponse(
     val id: Long,
+    val reservationDate: LocalDate,
     val startPeriod: Int,
     val endPeriod: Int,
     val reason: String,

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
@@ -12,6 +12,7 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import team.incube.flooding.domain.homebase.dto.MemberDto
 import team.incube.flooding.domain.homebase.dto.response.GetHomebaseResponse
+import java.time.LocalDate
 
 @Entity
 @Table(name = "tb_homebase_reservation")
@@ -19,6 +20,8 @@ class HomebaseReservationJpaEntity(
     @field:Id
     @field:GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
+    @Column(nullable = false)
+    val reservationDate: LocalDate,
     @field:Column(nullable = false)
     val startPeriod: Int,
     @field:Column(nullable = false)
@@ -34,6 +37,7 @@ class HomebaseReservationJpaEntity(
     fun toResponse() =
         GetHomebaseResponse(
             id = id,
+            reservationDate = reservationDate,
             startPeriod = startPeriod,
             endPeriod = endPeriod,
             reason = reason,

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
@@ -20,7 +20,7 @@ class HomebaseReservationJpaEntity(
     @field:Id
     @field:GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
-    @Column(nullable = false)
+    @field:Column(nullable = false)
     val reservationDate: LocalDate,
     @field:Column(nullable = false)
     val startPeriod: Int,

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseMemberRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseMemberRepository.kt
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import team.incube.flooding.domain.homebase.entity.HomebaseMemberJpaEntity
+import java.time.LocalDate
 
 interface HomebaseMemberRepository : JpaRepository<HomebaseMemberJpaEntity, Long> {
     fun findByReservationId(reservationId: Long): List<HomebaseMemberJpaEntity>
@@ -15,12 +16,14 @@ interface HomebaseMemberRepository : JpaRepository<HomebaseMemberJpaEntity, Long
         SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END
         FROM HomebaseMemberJpaEntity m
         WHERE m.studentNumber = :studentNumber
+        AND m.reservationDate = :reservationDate
         AND m.reservation.startPeriod <= :endPeriod
         AND m.reservation.endPeriod >= :startPeriod
         """,
     )
     fun existsStudentReservationOverlap(
         @Param("studentNumber") studentNumber: String,
+        @Param("reservationDate") reservationDate: LocalDate,
         @Param("startPeriod") startPeriod: Int,
         @Param("endPeriod") endPeriod: Int,
     ): Boolean
@@ -30,6 +33,7 @@ interface HomebaseMemberRepository : JpaRepository<HomebaseMemberJpaEntity, Long
     SELECT m.studentNumber 
     FROM HomebaseMemberJpaEntity m 
     WHERE m.studentNumber IN :studentNumbers 
+    AND m.reservationDate = :reservationDate
     AND m.reservation.startPeriod = :startPeriod
     AND m.reservation.endPeriod = :endPeriod
     AND (:reservationId IS NULL OR m.reservation.id != :reservationId)
@@ -37,6 +41,7 @@ interface HomebaseMemberRepository : JpaRepository<HomebaseMemberJpaEntity, Long
     )
     fun findExistingStudentNumbersInPeriod(
         @Param("studentNumbers") studentNumbers: List<String>,
+        @Param("reservationDate") reservationDate: LocalDate,
         @Param("startPeriod") startPeriod: Int,
         @Param("endPeriod") endPeriod: Int,
         @Param("reservationId") reservationId: Long?,

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseMemberRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseMemberRepository.kt
@@ -16,7 +16,7 @@ interface HomebaseMemberRepository : JpaRepository<HomebaseMemberJpaEntity, Long
         SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END
         FROM HomebaseMemberJpaEntity m
         WHERE m.studentNumber = :studentNumber
-        AND m.reservationDate = :reservationDate
+        AND m.reservation.reservationDate = :reservationDate
         AND m.reservation.startPeriod <= :endPeriod
         AND m.reservation.endPeriod >= :startPeriod
         """,
@@ -33,9 +33,9 @@ interface HomebaseMemberRepository : JpaRepository<HomebaseMemberJpaEntity, Long
     SELECT m.studentNumber 
     FROM HomebaseMemberJpaEntity m 
     WHERE m.studentNumber IN :studentNumbers 
-    AND m.reservationDate = :reservationDate
-    AND m.reservation.startPeriod = :startPeriod
-    AND m.reservation.endPeriod = :endPeriod
+    AND m.reservation.reservationDate = :reservationDate
+    AND m.reservation.startPeriod <= :endPeriod
+    AND m.reservation.endPeriod >= :startPeriod
     AND (:reservationId IS NULL OR m.reservation.id != :reservationId)
 """,
     )

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseReservationRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseReservationRepository.kt
@@ -4,18 +4,21 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import team.incube.flooding.domain.homebase.entity.HomebaseReservationJpaEntity
+import java.time.LocalDate
 
 interface HomebaseReservationRepository : JpaRepository<HomebaseReservationJpaEntity, Long> {
     @Query(
         """
         SELECT r FROM HomebaseReservationJpaEntity r
         WHERE r.homebase.id = :homebaseId
+        AND r.reservationDate = :reservationDate
         AND r.startPeriod <= :endPeriod
         AND r.endPeriod >= :startPeriod
         """,
     )
     fun findOverlappingReservation(
         @Param("homebaseId") homebaseId: Long,
+        @Param("reservationDate") reservationDate: LocalDate,
         @Param("startPeriod") startPeriod: Int,
         @Param("endPeriod") endPeriod: Int,
     ): List<HomebaseReservationJpaEntity>

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/CreateHomebaseReservationService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/CreateHomebaseReservationService.kt
@@ -28,7 +28,12 @@ class CreateHomebaseReservationService(
 
         validateCapacity(homebase.capacity, request.members.size)
         validateReservationOverlap(homebase.id, request.reservationDate, request.startPeriod, request.endPeriod)
-        memberService.validateStudentDuplicate(request.reservationDate, request.startPeriod, request.endPeriod, request.members)
+        memberService.validateStudentDuplicate(
+            request.reservationDate,
+            request.startPeriod,
+            request.endPeriod,
+            request.members,
+        )
 
         val reservation =
             reservationRepository.save(

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/CreateHomebaseReservationService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/CreateHomebaseReservationService.kt
@@ -8,6 +8,7 @@ import team.incube.flooding.domain.homebase.dto.request.CreateHomebaseRequest
 import team.incube.flooding.domain.homebase.entity.HomebaseReservationJpaEntity
 import team.incube.flooding.domain.homebase.repository.HomebaseRepository
 import team.incube.flooding.domain.homebase.repository.HomebaseReservationRepository
+import java.time.LocalDate
 
 @Service
 class CreateHomebaseReservationService(
@@ -26,12 +27,13 @@ class CreateHomebaseReservationService(
                 .orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "홈베이스가 존재하지 않습니다.") }
 
         validateCapacity(homebase.capacity, request.members.size)
-        validateReservationOverlap(homebase.id, request.startPeriod, request.endPeriod)
-        memberService.validateStudentDuplicate(request.startPeriod, request.endPeriod, request.members)
+        validateReservationOverlap(homebase.id, request.reservationDate, request.startPeriod, request.endPeriod)
+        memberService.validateStudentDuplicate(request.reservationDate, request.startPeriod, request.endPeriod, request.members)
 
         val reservation =
             reservationRepository.save(
                 HomebaseReservationJpaEntity(
+                    reservationDate = request.reservationDate,
                     startPeriod = request.startPeriod,
                     endPeriod = request.endPeriod,
                     reason = request.reason,
@@ -52,10 +54,11 @@ class CreateHomebaseReservationService(
 
     private fun validateReservationOverlap(
         homebaseId: Long,
+        reservationDate: LocalDate,
         start: Int,
         end: Int,
     ) {
-        val overlapping = reservationRepository.findOverlappingReservation(homebaseId, start, end)
+        val overlapping = reservationRepository.findOverlappingReservation(homebaseId, reservationDate, start, end)
         if (overlapping.isNotEmpty()) {
             throw IllegalArgumentException("이미 예약된 시간입니다.")
         }

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/CreateHomebaseReservationService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/CreateHomebaseReservationService.kt
@@ -65,7 +65,7 @@ class CreateHomebaseReservationService(
     ) {
         val overlapping = reservationRepository.findOverlappingReservation(homebaseId, reservationDate, start, end)
         if (overlapping.isNotEmpty()) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST,"이미 예약된 시간입니다.")
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 예약된 시간입니다.")
         }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/CreateHomebaseReservationService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/CreateHomebaseReservationService.kt
@@ -65,7 +65,7 @@ class CreateHomebaseReservationService(
     ) {
         val overlapping = reservationRepository.findOverlappingReservation(homebaseId, reservationDate, start, end)
         if (overlapping.isNotEmpty()) {
-            throw IllegalArgumentException("이미 예약된 시간입니다.")
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST,"이미 예약된 시간입니다.")
         }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/HomebaseMemberService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/HomebaseMemberService.kt
@@ -8,6 +8,7 @@ import team.incube.flooding.domain.homebase.entity.HomebaseMemberJpaEntity
 import team.incube.flooding.domain.homebase.entity.HomebaseReservationJpaEntity
 import team.incube.flooding.domain.homebase.repository.HomebaseMemberRepository
 import team.themoment.sdk.exception.ExpectedException
+import java.time.LocalDate
 
 @Service
 class HomebaseMemberService(
@@ -34,6 +35,7 @@ class HomebaseMemberService(
 
     @Transactional(readOnly = true)
     fun validateStudentDuplicate(
+        reservationDate: LocalDate,
         startPeriod: Int,
         endPeriod: Int,
         members: List<MemberDto>,
@@ -43,6 +45,7 @@ class HomebaseMemberService(
         val existingStudents =
             memberRepository.findExistingStudentNumbersInPeriod(
                 studentNumbers,
+                reservationDate,
                 startPeriod,
                 endPeriod,
                 reservationId,

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -49,7 +50,7 @@ class UserController(
         @Parameter(description = "학번 (전방 일치, 예: '1' → 1학년 전체, '11' → 1학년 1반)")
         @RequestParam(required = false) studentNumber: String?,
         @Parameter(description = "페이지 정보 (page, size, sort)")
-        @PageableDefault(size = 20, sort = ["studentNumber,asc"])
+        @PageableDefault(size = 20, sort = ["studentNumber"], direction = Sort.Direction.ASC)
         pageable: Pageable,
     ): CommonApiResponse<Page<SearchUsersResponse>> =
         CommonApiResponse.success("OK", searchUsersService.execute(name, studentNumber, pageable))


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #83 

## 📝작업 내용
- ``HomebaseReservationJpaEntity``에 reservationDate 컬럼을 추가
- ``CreateHomebaseRequest`` ``GetHomebaseResponse`` DTO에 날짜 필드를 추가
- 예약 생성 시 reservationDate를 필수 파라미터로 받도록 수정
- 예약 생성 시 날짜별 중복 체크 로직 추가

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 없음
