### PR TITLE
동아리 단건 조회 isLeader 필드 및 엔드포인트 권한 설정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubResponse.kt
@@ -4,6 +4,7 @@ data class GetClubResponse(
     val club: ClubDetail,
     val members: List<MemberSummary>,
     val projects: List<ProjectSummary>,
+    val isLeader: Boolean,
 ) {
     data class ClubDetail(
         val id: Long,

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
@@ -10,6 +10,7 @@ import team.incube.flooding.domain.club.repository.ClubParticipantRepository
 import team.incube.flooding.domain.club.repository.ClubRepository
 import team.incube.flooding.domain.club.service.GetClubService
 import team.incube.flooding.global.client.DataGsmProjectClient
+import team.incube.flooding.global.security.util.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
 
 @Service
@@ -17,9 +18,11 @@ class GetClubServiceImpl(
     private val clubRepository: ClubRepository,
     private val clubParticipantRepository: ClubParticipantRepository,
     private val dataGsmProjectClient: DataGsmProjectClient,
+    private val currentUserProvider: CurrentUserProvider,
 ) : GetClubService {
-    override suspend fun execute(clubId: Long): GetClubResponse =
-        coroutineScope {
+    override suspend fun execute(clubId: Long): GetClubResponse {
+        val currentUser = currentUserProvider.getCurrentUser()
+        return coroutineScope {
             val clubDeferred = async(Dispatchers.IO) { clubRepository.findByIdWithLeader(clubId) }
             val membersDeferred =
                 async(Dispatchers.IO) {
@@ -56,6 +59,8 @@ class GetClubServiceImpl(
                     ),
                 members = membersDeferred.await(),
                 projects = projectsDeferred.await(),
+                isLeader = club.leader?.id == currentUser.id,
             )
         }
+    }
 }

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -58,13 +58,13 @@ class SecurityConfig(
                     .hasAnyRole(Role.ADMIN.name, Role.STUDENT_COUNCIL.name)
                 it
                     .requestMatchers(HttpMethod.PUT, "/clubs/*")
-                    .hasAnyRole(Role.ADMIN.name, Role.GENERAL_STUDENT.name)
+                    .hasAnyRole(Role.ADMIN.name, Role.GENERAL_STUDENT.name, Role.STUDENT_COUNCIL.name)
                 it
                     .requestMatchers(HttpMethod.POST, "/clubs/*/autonomous/applications")
-                    .hasRole(Role.GENERAL_STUDENT.name)
+                    .hasAnyRole(Role.GENERAL_STUDENT.name, Role.STUDENT_COUNCIL.name, Role.ADMIN.name)
                 it
                     .requestMatchers(HttpMethod.POST, "/clubs/*/applications")
-                    .hasRole(Role.GENERAL_STUDENT.name)
+                    .hasAnyRole(Role.GENERAL_STUDENT.name, Role.STUDENT_COUNCIL.name, Role.ADMIN.name)
 
                 // study
                 it.requestMatchers(HttpMethod.POST, "/dormitory/studies").hasRole(Role.GENERAL_STUDENT.name)

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -51,10 +51,20 @@ class SecurityConfig(
 
                 // club
                 it
-                    .requestMatchers(
-                        HttpMethod.PATCH,
-                        "/clubs/*/approval",
-                    ).hasAnyRole(Role.ADMIN.name, Role.STUDENT_COUNCIL.name)
+                    .requestMatchers(HttpMethod.GET, "/clubs/opening/requests")
+                    .hasAnyRole(Role.ADMIN.name, Role.STUDENT_COUNCIL.name)
+                it
+                    .requestMatchers(HttpMethod.PATCH, "/clubs/*/approval")
+                    .hasAnyRole(Role.ADMIN.name, Role.STUDENT_COUNCIL.name)
+                it
+                    .requestMatchers(HttpMethod.PUT, "/clubs/*")
+                    .hasAnyRole(Role.ADMIN.name, Role.GENERAL_STUDENT.name)
+                it
+                    .requestMatchers(HttpMethod.POST, "/clubs/*/autonomous/applications")
+                    .hasRole(Role.GENERAL_STUDENT.name)
+                it
+                    .requestMatchers(HttpMethod.POST, "/clubs/*/applications")
+                    .hasRole(Role.GENERAL_STUDENT.name)
 
                 // study
                 it.requestMatchers(HttpMethod.POST, "/dormitory/studies").hasRole(Role.GENERAL_STUDENT.name)

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -60,11 +60,11 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.PUT, "/clubs/*")
                     .hasAnyRole(Role.ADMIN.name, Role.GENERAL_STUDENT.name, Role.STUDENT_COUNCIL.name)
                 it
-                    .requestMatchers(HttpMethod.POST, "/clubs/*/autonomous/applications")
-                    .hasAnyRole(Role.GENERAL_STUDENT.name, Role.STUDENT_COUNCIL.name, Role.ADMIN.name)
-                it
-                    .requestMatchers(HttpMethod.POST, "/clubs/*/applications")
-                    .hasAnyRole(Role.GENERAL_STUDENT.name, Role.STUDENT_COUNCIL.name, Role.ADMIN.name)
+                    .requestMatchers(
+                        HttpMethod.POST,
+                        "/clubs/*/autonomous/applications",
+                        "/clubs/*/applications",
+                    ).hasAnyRole(Role.GENERAL_STUDENT.name, Role.STUDENT_COUNCIL.name, Role.ADMIN.name)
 
                 // study
                 it.requestMatchers(HttpMethod.POST, "/dormitory/studies").hasRole(Role.GENERAL_STUDENT.name)


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

**동아리 단건 조회 isLeader 필드 추가**
- `GetClubResponse`에 `isLeader: Boolean` 필드 추가
- 현재 로그인 사용자가 해당 동아리의 리더인지 여부를 응답에 포함
- SecurityContextHolder thread-local 특성상 coroutineScope 진입 전에 getCurrentUser() 호출

**동아리 API 엔드포인트 접근 권한 설정 (SecurityConfig)**
- `GET /clubs/opening/requests` → ADMIN, STUDENT_COUNCIL
- `PUT /clubs/*` → ADMIN, GENERAL_STUDENT
- `POST /clubs/*/autonomous/applications` → GENERAL_STUDENT
- `POST /clubs/*/applications` → GENERAL_STUDENT

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음