### PR TITLE
유저 검색 빈 응답 및 Jackson 버전 불일치 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,12 +16,6 @@ ext {
     set("spring-security.version", "7.0.4")
 }
 
-dependencyManagement {
-    dependencies {
-        dependency("tools.jackson.core:jackson-core:3.1.1")
-    }
-}
-
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(24)

--- a/src/main/kotlin/team/incube/flooding/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/repository/UserRepository.kt
@@ -14,15 +14,21 @@ interface UserRepository : JpaRepository<UserJpaEntity, Long> {
     fun clearCleaningZoneByZoneId(zoneId: Long)
 
     @Query(
-        """
+        value = """
         SELECT u FROM UserJpaEntity u
         WHERE u.role <> :excludedRole
-        AND (:name IS NULL OR u.name LIKE CONCAT('%', :name, '%'))
+        AND u.name LIKE :nameLike
+        AND (:studentNumberStart IS NULL OR u.studentNumber BETWEEN :studentNumberStart AND :studentNumberEnd)
+        """,
+        countQuery = """
+        SELECT count(u) FROM UserJpaEntity u
+        WHERE u.role <> :excludedRole
+        AND u.name LIKE :nameLike
         AND (:studentNumberStart IS NULL OR u.studentNumber BETWEEN :studentNumberStart AND :studentNumberEnd)
         """,
     )
     fun searchUsers(
-        name: String?,
+        nameLike: String,
         studentNumberStart: Int?,
         studentNumberEnd: Int?,
         excludedRole: Role,

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/impl/SearchUsersServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/impl/SearchUsersServiceImpl.kt
@@ -20,9 +20,10 @@ class SearchUsersServiceImpl(
         pageable: Pageable,
     ): Page<SearchUsersResponse> {
         val (start, end) = parseStudentNumberPrefix(studentNumber)
+        val nameLike = name?.trim()?.takeIf { it.isNotEmpty() }?.let { "%$it%" } ?: "%"
         return userRepository
             .searchUsers(
-                name = name?.trim()?.takeIf { it.isNotEmpty() },
+                nameLike = nameLike,
                 studentNumberStart = start,
                 studentNumberEnd = end,
                 excludedRole = Role.ADMIN,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

GET /users 호출 시 200 OK와 함께 응답 본문이 비어있는 버그를 수정합니다.

**원인 1 — Jackson 버전 불일치 (`build.gradle.kts`)**
- `dependencyManagement`에서 `jackson-core`만 3.1.1로 강제 지정하여 `jackson-databind(3.0.4)`와 버전 불일치 발생 → 직렬화 오류 가능성
- 해당 블록 제거로 Spring Boot BOM 기본 버전(전 모듈 3.0.4)으로 통일

**원인 2 — Hibernate 7 null String LIKE 바인딩 오류 (`UserRepository`, `SearchUsersServiceImpl`)**
- Hibernate 7 + PostgreSQL 환경에서 JPQL의 `CONCAT('%', :name, '%')` 안에 null이 바인딩되면 타입이 `bytea`로 추론되어 `operator does not exist: character varying ~~ bytea` 에러 발생
- SDK의 `LoggingFilter`가 해당 예외를 삼켜서 겉으로는 200 + 빈 본문으로 노출됨
- JPQL을 `u.name LIKE :nameLike`로 변경하고, 서비스에서 와일드카드를 미리 붙인 non-null String(`"%keyword%"` 또는 `"%"`)을 전달하도록 수정
- 명시적 `countQuery`도 함께 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> `nameLike`에 빈 검색 시 `"%"`를 기본값으로 전달하는 방식이 적절한지 확인 부탁드립니다.