### PR TITLE
자습 종료 시간 기본값을 03:00으로 조정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
@@ -29,7 +29,15 @@ class StudyApplicationServiceImpl(
 
         val now = LocalTime.now()
 
-        if (now.isBefore(studyProperties.openTime) || now.isAfter(studyProperties.closeTime)) {
+        val crossesMidnight = studyProperties.openTime.isAfter(studyProperties.closeTime)
+        val outOfRange =
+            if (crossesMidnight) {
+                now.isBefore(studyProperties.openTime) && now.isAfter(studyProperties.closeTime)
+            } else {
+                now.isBefore(studyProperties.openTime) || now.isAfter(studyProperties.closeTime)
+            }
+
+        if (outOfRange) {
             throw ExpectedException("자습 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,7 +56,7 @@ sdk:
 
 study:
   open-time: "${STUDY_OPEN_TIME:20:00}"
-  close-time: "${STUDY_CLOSE_TIME:21:00}"
+  close-time: "${STUDY_CLOSE_TIME:03:00}"
   max-count: ${STUDY_MAX_COUNT:50}
   lock-key: ${STUDY_LOCK_KEY:study:lock}
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

`application.yml`의 자습 종료 시간(`study.close-time`) 기본값을 `21:00`에서 `03:00`으로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음