### PR TITLE
자습 신청 시간 비교 시 KST 타임존 명시

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
@@ -3,6 +3,7 @@ package team.incube.flooding.domain.dormitory.study.adapter
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
+import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -11,6 +12,7 @@ import java.time.LocalTime
 @Component
 class StudyRedisAdapter(
     private val redisTemplate: RedisTemplate<String, String>,
+    private val clock: Clock,
 ) {
     companion object {
         private const val APPLICATION_KEY = "study:application"
@@ -19,8 +21,8 @@ class StudyRedisAdapter(
     }
 
     private fun ttlUntilMidnight(): Duration {
-        val midnight = LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.MIDNIGHT)
-        return Duration.between(LocalDateTime.now(), midnight)
+        val midnight = LocalDateTime.of(LocalDate.now(clock).plusDays(1), LocalTime.MIDNIGHT)
+        return Duration.between(LocalDateTime.now(clock), midnight)
     }
 
     fun saveApplication(

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
@@ -11,9 +11,9 @@ import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaReposit
 import team.incube.flooding.domain.dormitory.study.service.StudyApplicationService
 import team.incube.flooding.global.security.util.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
+import java.time.Clock
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
 @Service
@@ -24,11 +24,12 @@ class StudyApplicationServiceImpl(
     private val currentUserProvider: CurrentUserProvider,
     private val studyProperties: StudyProperties,
     private val redissonClient: RedissonClient,
+    private val clock: Clock,
 ) : StudyApplicationService {
     override fun execute() {
         val user = currentUserProvider.getCurrentUser()
 
-        val now = LocalTime.now(ZoneId.of("Asia/Seoul"))
+        val now = LocalTime.now(clock)
 
         val crossesMidnight = studyProperties.openTime.isAfter(studyProperties.closeTime)
         val outOfRange =
@@ -43,7 +44,7 @@ class StudyApplicationServiceImpl(
         }
 
         if (studyRedisAdapter.getApplicationStatus(user.id) == StudyApplicationStatus.BANNED ||
-            studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now())
+            studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now(clock))
         ) {
             throw ExpectedException("자습 금지 상태입니다.", HttpStatus.FORBIDDEN)
         }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
@@ -13,6 +13,7 @@ import team.incube.flooding.global.security.util.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
 @Service
@@ -27,7 +28,7 @@ class StudyApplicationServiceImpl(
     override fun execute() {
         val user = currentUserProvider.getCurrentUser()
 
-        val now = LocalTime.now()
+        val now = LocalTime.now(ZoneId.of("Asia/Seoul"))
 
         val crossesMidnight = studyProperties.openTime.isAfter(studyProperties.closeTime)
         val outOfRange =

--- a/src/main/kotlin/team/incube/flooding/global/config/ClockConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/ClockConfig.kt
@@ -1,0 +1,12 @@
+package team.incube.flooding.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+import java.time.ZoneId
+
+@Configuration
+class ClockConfig {
+    @Bean
+    fun clock(): Clock = Clock.system(ZoneId.of("Asia/Seoul"))
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

`LocalTime.now()`는 JVM 기본 타임존(UTC)을 사용하기 때문에 Docker 환경에서 KST 기준 시간이 아닌 UTC 시간으로 자습 신청 가능 여부를 판단하는 문제가 있었음

`LocalTime.now(ZoneId.of("Asia/Seoul"))`로 변경하여 KST 기준으로 시간 비교하도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음