### PR TITLE
동아리 생성 승인 시 리더를 참여자로 자동 등록

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 import team.incube.flooding.domain.club.entity.ClubJpaEntity
+import team.incube.flooding.domain.club.entity.ClubParticipantId
 import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
 import team.incube.flooding.domain.club.repository.ClubParticipantJpaRepository
 import team.incube.flooding.domain.club.repository.ClubRepository
@@ -56,7 +57,10 @@ class ClubLeaderParticipantSaver(
         club: ClubJpaEntity,
         leader: UserJpaEntity,
     ) {
-        clubParticipantJpaRepository.save(ClubParticipantJpaEntity(club = club, user = leader))
+        val participantId = ClubParticipantId(club = club.id, user = leader.id)
+        if (!clubParticipantJpaRepository.existsById(participantId)) {
+            clubParticipantJpaRepository.save(ClubParticipantJpaEntity(club = club, user = leader))
+        }
     }
 }
 

--- a/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/event/ClubApprovedEventListener.kt
@@ -7,7 +7,11 @@ import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
+import team.incube.flooding.domain.club.entity.ClubJpaEntity
+import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
+import team.incube.flooding.domain.club.repository.ClubParticipantJpaRepository
 import team.incube.flooding.domain.club.repository.ClubRepository
+import team.incube.flooding.domain.user.entity.UserJpaEntity
 import team.incube.flooding.global.client.DataGsmClubClient
 import java.time.LocalDate
 
@@ -16,11 +20,14 @@ class ClubApprovedEventListener(
     private val clubRepository: ClubRepository,
     private val dataGsmClubClient: DataGsmClubClient,
     private val clubDataGsmIdSaver: ClubDataGsmIdSaver,
+    private val clubLeaderParticipantSaver: ClubLeaderParticipantSaver,
 ) {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun handleClubApproved(event: ClubApprovedEvent) {
         val club = clubRepository.findByIdWithLeader(event.clubId) ?: return
+
+        club.leader?.let { clubLeaderParticipantSaver.save(club, it) }
 
         val leaderDataGsmId = club.leader?.let { dataGsmClubClient.getStudentIdByEmail(it.email) }
 
@@ -37,6 +44,19 @@ class ClubApprovedEventListener(
             ) ?: return
 
         clubDataGsmIdSaver.save(event.clubId, dataGsmClubId)
+    }
+}
+
+@Component
+class ClubLeaderParticipantSaver(
+    private val clubParticipantJpaRepository: ClubParticipantJpaRepository,
+) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun save(
+        club: ClubJpaEntity,
+        leader: UserJpaEntity,
+    ) {
+        clubParticipantJpaRepository.save(ClubParticipantJpaEntity(club = club, user = leader))
     }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

동아리 생성 승인(PATCH /clubs/{clubId}/approval) 처리 시 ClubApprovedEvent 이벤트 리스너에서
리더를 tb_club_participant에 자동으로 등록하도록 추가했습니다.

- ClubLeaderParticipantSaver 컴포넌트 추가
- AFTER_COMMIT 이후 REQUIRES_NEW 트랜잭션으로 participant 저장

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음