### PR TITLE
new-branch 스킬 develop 최신화 및 변경사항 체크 추가

### DIFF
--- a/.claude/skills/new-branch/SKILL.md
+++ b/.claude/skills/new-branch/SKILL.md
@@ -7,9 +7,15 @@ Create a new git branch and switch to it, following the project branch naming co
 
 Steps:
 1. If the purpose of the branch is unclear, ask the user before proceeding
-2. Determine the appropriate type and write a concise kebab-case description in English
-3. Run `git checkout -b type/description`
-4. Confirm with `git branch --show-current`
+2. Check for uncommitted changes with `git status --porcelain`
+   - If output is non-empty, stop immediately and print:
+     "uncommitted changes가 있습니다. 커밋하거나 stash 후 다시 실행하세요."
+3. Switch to develop and pull the latest changes:
+   `git checkout develop`
+   `git pull --rebase origin develop`
+4. Determine the appropriate type and write a concise kebab-case description in English
+5. Run `git checkout -b type/description`
+6. Confirm with `git branch --show-current`
 
 Branch name format: `type/description`
 

--- a/.claude/skills/new-branch/SKILL.md
+++ b/.claude/skills/new-branch/SKILL.md
@@ -7,7 +7,7 @@ Create a new git branch and switch to it, following the project branch naming co
 
 Steps:
 1. If the purpose of the branch is unclear, ask the user before proceeding
-2. Check for uncommitted changes with `git status --porcelain`
+2. Check for uncommitted changes with `git status --porcelain -uno`
    - If output is non-empty, stop immediately and print:
      "uncommitted changes가 있습니다. 커밋하거나 stash 후 다시 실행하세요."
 3. Switch to develop and pull the latest changes:


### PR DESCRIPTION
## #️⃣연관된 이슈

> #98

## 📝작업 내용

new-branch 스킬 실행 시 아래 두 가지 동작을 추가했습니다.

1. uncommitted changes 체크: `git status --porcelain` 출력이 비어있지 않으면 에러 메시지와 함께 즉시 중단
2. develop 최신화: `git checkout develop` → `git pull --rebase origin develop` 후 새 브랜치 생성

기존에는 현재 브랜치 기준으로 바로 `git checkout -b`를 실행해 develop 최신 코드가 반영되지 않은 채 브랜치가 생성되는 문제가 있었습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음