### PR TITLE
SSE 기반 자습 체크인 API 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -20,7 +20,6 @@ class StudyAttendanceSseEmitterRegistry {
 
     @Async
     fun broadcast(event: StudyAttendanceEventResponse) {
-        val deadEmitters = mutableListOf<SseEmitter>()
         emitters.forEach { emitter ->
             try {
                 emitter.send(
@@ -30,9 +29,8 @@ class StudyAttendanceSseEmitterRegistry {
                         .data(event),
                 )
             } catch (e: Exception) {
-                deadEmitters.add(emitter)
+                emitter.completeWithError(e)
             }
         }
-        emitters.removeAll(deadEmitters)
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -1,0 +1,36 @@
+package team.incube.flooding.domain.dormitory.study.adapter
+
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
+import java.util.concurrent.CopyOnWriteArrayList
+
+@Component
+class StudyAttendanceSseEmitterRegistry {
+    private val emitters = CopyOnWriteArrayList<SseEmitter>()
+
+    fun register(emitter: SseEmitter): SseEmitter {
+        emitters.add(emitter)
+        emitter.onCompletion { emitters.remove(emitter) }
+        emitter.onTimeout { emitters.remove(emitter) }
+        emitter.onError { emitters.remove(emitter) }
+        return emitter
+    }
+
+    fun broadcast(event: StudyAttendanceEventResponse) {
+        val deadEmitters = mutableListOf<SseEmitter>()
+        emitters.forEach { emitter ->
+            try {
+                emitter.send(
+                    SseEmitter
+                        .event()
+                        .name("attendance")
+                        .data(event),
+                )
+            } catch (e: Exception) {
+                deadEmitters.add(emitter)
+            }
+        }
+        emitters.removeAll(deadEmitters)
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.dormitory.study.adapter
 
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
@@ -17,6 +18,7 @@ class StudyAttendanceSseEmitterRegistry {
         return emitter
     }
 
+    @Async
     fun broadcast(event: StudyAttendanceEventResponse) {
         val deadEmitters = mutableListOf<SseEmitter>()
         emitters.forEach { emitter ->

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
@@ -75,10 +75,7 @@ class StudyRedisAdapter(
 
     fun checkAttendance(userId: Long) {
         redisTemplate.opsForSet().add(ATTENDANCE_KEY, userId.toString())
-        val size = redisTemplate.opsForSet().size(ATTENDANCE_KEY) ?: 0L
-        if (size == 1L) {
-            redisTemplate.expire(ATTENDANCE_KEY, ttlUntilMidnight())
-        }
+        redisTemplate.expire(ATTENDANCE_KEY, ttlUntilMidnight())
     }
 
     fun isAttendanceChecked(userId: Long): Boolean =

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
@@ -18,6 +18,7 @@ class StudyRedisAdapter(
         private const val APPLICATION_KEY = "study:application"
         private const val COUNT_KEY = "study:count"
         private const val APPLICANTS_KEY = "study:applicants"
+        private const val ATTENDANCE_KEY = "study:attendance"
     }
 
     private fun ttlUntilMidnight(): Duration {
@@ -69,6 +70,24 @@ class StudyRedisAdapter(
         redisTemplate
             .opsForSet()
             .members(APPLICANTS_KEY)
+            ?.map { it.toLong() }
+            ?.toSet() ?: emptySet()
+
+    fun checkAttendance(userId: Long) {
+        redisTemplate.opsForSet().add(ATTENDANCE_KEY, userId.toString())
+        val size = redisTemplate.opsForSet().size(ATTENDANCE_KEY) ?: 0L
+        if (size == 1L) {
+            redisTemplate.expire(ATTENDANCE_KEY, ttlUntilMidnight())
+        }
+    }
+
+    fun isAttendanceChecked(userId: Long): Boolean =
+        redisTemplate.opsForSet().isMember(ATTENDANCE_KEY, userId.toString()) ?: false
+
+    fun getAttendanceIds(): Set<Long> =
+        redisTemplate
+            .opsForSet()
+            .members(ATTENDANCE_KEY)
             ?.map { it.toLong() }
             ?.toSet() ?: emptySet()
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
@@ -5,17 +5,21 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.GetStudyResponse
 import team.incube.flooding.domain.dormitory.study.service.BanStudyService
 import team.incube.flooding.domain.dormitory.study.service.CancelStudyService
+import team.incube.flooding.domain.dormitory.study.service.CheckStudyAttendanceService
 import team.incube.flooding.domain.dormitory.study.service.GetStudyService
 import team.incube.flooding.domain.dormitory.study.service.StudyApplicationService
+import team.incube.flooding.domain.dormitory.study.service.SubscribeStudyAttendanceService
 import team.themoment.sdk.response.CommonApiResponse
 
 @Tag(name = "자습", description = "자습 신청 관련 API")
@@ -26,6 +30,8 @@ class StudyController(
     private val cancelStudyService: CancelStudyService,
     private val banStudyService: BanStudyService,
     private val getStudyService: GetStudyService,
+    private val subscribeStudyAttendanceService: SubscribeStudyAttendanceService,
+    private val checkStudyAttendanceService: CheckStudyAttendanceService,
 ) {
     @Operation(
         summary = "자습 신청자 목록 조회",
@@ -65,6 +71,33 @@ class StudyController(
     @DeleteMapping
     fun cancel(): CommonApiResponse<Nothing> {
         cancelStudyService.execute()
+        return CommonApiResponse.success("OK")
+    }
+
+    @Operation(
+        summary = "자습 체크인 SSE 구독",
+        description = "자습 체크인 이벤트를 실시간으로 수신합니다. 연결 시 현재까지 체크된 목록을 init 이벤트로 전송합니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "SSE 구독 성공"),
+        ApiResponse(responseCode = "401", description = "인증 실패"),
+        ApiResponse(responseCode = "403", description = "권한 없음"),
+    )
+    @GetMapping("/attendance", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    fun subscribeAttendance(): SseEmitter = subscribeStudyAttendanceService.execute()
+
+    @Operation(
+        summary = "자습 체크인",
+        description = "자습을 신청한 학생이 자습실에 도착했음을 체크합니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "체크인 성공"),
+        ApiResponse(responseCode = "404", description = "자습 신청 내역 없음"),
+        ApiResponse(responseCode = "409", description = "이미 체크인 완료"),
+    )
+    @PostMapping("/attendance")
+    fun checkAttendance(): CommonApiResponse<Nothing> {
+        checkStudyAttendanceService.execute()
         return CommonApiResponse.success("OK")
     }
 

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
@@ -88,16 +88,18 @@ class StudyController(
 
     @Operation(
         summary = "자습 체크인",
-        description = "자습을 신청한 학생이 자습실에 도착했음을 체크합니다.",
+        description = "자습을 신청한 학생의 자습실 도착을 체크합니다. 관리자 또는 기자위 권한이 필요합니다.",
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "체크인 성공"),
-        ApiResponse(responseCode = "404", description = "자습 신청 내역 없음"),
+        ApiResponse(responseCode = "404", description = "존재하지 않는 학생 또는 자습 신청 내역 없음"),
         ApiResponse(responseCode = "409", description = "이미 체크인 완료"),
     )
-    @PostMapping("/attendance")
-    fun checkAttendance(): CommonApiResponse<Nothing> {
-        checkStudyAttendanceService.execute()
+    @PostMapping("/attendance/{userId}")
+    fun checkAttendance(
+        @Parameter(description = "체크인할 학생의 ID") @PathVariable userId: Long,
+    ): CommonApiResponse<Nothing> {
+        checkStudyAttendanceService.execute(userId)
         return CommonApiResponse.success("OK")
     }
 

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
@@ -1,6 +1,7 @@
 package team.incube.flooding.domain.dormitory.study.presentation.data.response
 
 data class GetStudyResponse(
+    val userId: Long,
     val name: String,
     val studentNumber: Int,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/StudyAttendanceEventResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/StudyAttendanceEventResponse.kt
@@ -1,0 +1,6 @@
+package team.incube.flooding.domain.dormitory.study.presentation.data.response
+
+data class StudyAttendanceEventResponse(
+    val name: String,
+    val studentNumber: Int,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/CheckStudyAttendanceService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/CheckStudyAttendanceService.kt
@@ -1,5 +1,5 @@
 package team.incube.flooding.domain.dormitory.study.service
 
 interface CheckStudyAttendanceService {
-    fun execute()
+    fun execute(userId: Long)
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/CheckStudyAttendanceService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/CheckStudyAttendanceService.kt
@@ -1,0 +1,5 @@
+package team.incube.flooding.domain.dormitory.study.service
+
+interface CheckStudyAttendanceService {
+    fun execute()
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/SubscribeStudyAttendanceService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/SubscribeStudyAttendanceService.kt
@@ -1,0 +1,7 @@
+package team.incube.flooding.domain.dormitory.study.service
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+
+interface SubscribeStudyAttendanceService {
+    fun execute(): SseEmitter
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/CheckStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/CheckStudyAttendanceServiceImpl.kt
@@ -2,32 +2,37 @@ package team.incube.flooding.domain.dormitory.study.service.impl
 
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.study.adapter.StudyAttendanceSseEmitterRegistry
 import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
 import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
 import team.incube.flooding.domain.dormitory.study.service.CheckStudyAttendanceService
-import team.incube.flooding.global.security.util.CurrentUserProvider
+import team.incube.flooding.domain.user.repository.UserRepository
 import team.themoment.sdk.exception.ExpectedException
 
 @Service
+@Transactional(readOnly = true)
 class CheckStudyAttendanceServiceImpl(
     private val studyRedisAdapter: StudyRedisAdapter,
-    private val currentUserProvider: CurrentUserProvider,
+    private val userRepository: UserRepository,
     private val sseEmitterRegistry: StudyAttendanceSseEmitterRegistry,
 ) : CheckStudyAttendanceService {
-    override fun execute() {
-        val user = currentUserProvider.getCurrentUser()
+    override fun execute(userId: Long) {
+        val user =
+            userRepository
+                .findById(userId)
+                .orElseThrow { ExpectedException("존재하지 않는 학생입니다.", HttpStatus.NOT_FOUND) }
 
-        if (studyRedisAdapter.getApplicationStatus(user.id) != StudyApplicationStatus.APPROVED) {
+        if (studyRedisAdapter.getApplicationStatus(userId) != StudyApplicationStatus.APPROVED) {
             throw ExpectedException("자습을 신청하지 않은 학생입니다.", HttpStatus.NOT_FOUND)
         }
 
-        if (studyRedisAdapter.isAttendanceChecked(user.id)) {
+        if (studyRedisAdapter.isAttendanceChecked(userId)) {
             throw ExpectedException("이미 자습 체크를 완료했습니다.", HttpStatus.CONFLICT)
         }
 
-        studyRedisAdapter.checkAttendance(user.id)
+        studyRedisAdapter.checkAttendance(userId)
         sseEmitterRegistry.broadcast(
             StudyAttendanceEventResponse(name = user.name, studentNumber = user.studentNumber),
         )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/CheckStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/CheckStudyAttendanceServiceImpl.kt
@@ -1,0 +1,35 @@
+package team.incube.flooding.domain.dormitory.study.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import team.incube.flooding.domain.dormitory.study.adapter.StudyAttendanceSseEmitterRegistry
+import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
+import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
+import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
+import team.incube.flooding.domain.dormitory.study.service.CheckStudyAttendanceService
+import team.incube.flooding.global.security.util.CurrentUserProvider
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class CheckStudyAttendanceServiceImpl(
+    private val studyRedisAdapter: StudyRedisAdapter,
+    private val currentUserProvider: CurrentUserProvider,
+    private val sseEmitterRegistry: StudyAttendanceSseEmitterRegistry,
+) : CheckStudyAttendanceService {
+    override fun execute() {
+        val user = currentUserProvider.getCurrentUser()
+
+        if (studyRedisAdapter.getApplicationStatus(user.id) != StudyApplicationStatus.APPROVED) {
+            throw ExpectedException("자습을 신청하지 않은 학생입니다.", HttpStatus.NOT_FOUND)
+        }
+
+        if (studyRedisAdapter.isAttendanceChecked(user.id)) {
+            throw ExpectedException("이미 자습 체크를 완료했습니다.", HttpStatus.CONFLICT)
+        }
+
+        studyRedisAdapter.checkAttendance(user.id)
+        sseEmitterRegistry.broadcast(
+            StudyAttendanceEventResponse(name = user.name, studentNumber = user.studentNumber),
+        )
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
@@ -19,6 +19,6 @@ class GetStudyServiceImpl(
         return userRepository
             .findAllById(applicantIds)
             .sortedBy { it.studentNumber }
-            .map { GetStudyResponse(name = it.name, studentNumber = it.studentNumber) }
+            .map { GetStudyResponse(userId = it.id, name = it.name, studentNumber = it.studentNumber) }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
@@ -1,0 +1,43 @@
+package team.incube.flooding.domain.dormitory.study.service.impl
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import team.incube.flooding.domain.dormitory.study.adapter.StudyAttendanceSseEmitterRegistry
+import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
+import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
+import team.incube.flooding.domain.dormitory.study.service.SubscribeStudyAttendanceService
+import team.incube.flooding.domain.user.repository.UserRepository
+
+@Service
+@Transactional(readOnly = true)
+class SubscribeStudyAttendanceServiceImpl(
+    private val studyRedisAdapter: StudyRedisAdapter,
+    private val userRepository: UserRepository,
+    private val sseEmitterRegistry: StudyAttendanceSseEmitterRegistry,
+) : SubscribeStudyAttendanceService {
+    override fun execute(): SseEmitter {
+        val emitter = SseEmitter(1_800_000L)
+        sseEmitterRegistry.register(emitter)
+
+        val attendanceIds = studyRedisAdapter.getAttendanceIds()
+        val initList =
+            if (attendanceIds.isEmpty()) {
+                emptyList()
+            } else {
+                userRepository
+                    .findAllById(attendanceIds)
+                    .sortedBy { it.studentNumber }
+                    .map { StudyAttendanceEventResponse(name = it.name, studentNumber = it.studentNumber) }
+            }
+
+        emitter.send(
+            SseEmitter
+                .event()
+                .name("init")
+                .data(initList),
+        )
+
+        return emitter
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
@@ -18,6 +18,7 @@ class SubscribeStudyAttendanceServiceImpl(
 ) : SubscribeStudyAttendanceService {
     override fun execute(): SseEmitter {
         val emitter = SseEmitter(1_800_000L)
+        emitter.send(SseEmitter.event().name("connect").data("connected"))
         sseEmitterRegistry.register(emitter)
 
         val attendanceIds = studyRedisAdapter.getAttendanceIds()

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -78,8 +78,8 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.GET, "/dormitory/studies/attendance")
                     .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
                 it
-                    .requestMatchers(HttpMethod.POST, "/dormitory/studies/attendance")
-                    .hasRole(Role.GENERAL_STUDENT.name)
+                    .requestMatchers(HttpMethod.POST, "/dormitory/studies/attendance/*")
+                    .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
 
                 // massage
                 it.requestMatchers(HttpMethod.POST, "/dormitory/massages").hasRole(Role.GENERAL_STUDENT.name)

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -74,6 +74,12 @@ class SecurityConfig(
                         HttpMethod.POST,
                         "/dormitory/studies/ban/**",
                     ).hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
+                it
+                    .requestMatchers(HttpMethod.GET, "/dormitory/studies/attendance")
+                    .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
+                it
+                    .requestMatchers(HttpMethod.POST, "/dormitory/studies/attendance")
+                    .hasRole(Role.GENERAL_STUDENT.name)
 
                 // massage
                 it.requestMatchers(HttpMethod.POST, "/dormitory/massages").hasRole(Role.GENERAL_STUDENT.name)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #100 

## 📝작업 내용

자습실 입실 체크를 실시간으로 확인할 수 있도록 SSE 기반 체크인 API를 구현했습니다.

- `GET /dormitory/studies/attendance` (DORMITORY_MANAGER, ADMIN 권한)
  - SSE 구독 엔드포인트
  - 연결 즉시 당일 기존 체크인 목록을 `init` 이벤트로 전송
  - 이후 체크인 발생마다 `attendance` 이벤트로 실시간 수신
- `POST /dormitory/studies/attendance` (GENERAL_STUDENT 권한)
  - 학생 체크인 엔드포인트
  - 자습 신청(APPROVED) 상태가 아니면 404
  - 이미 체크인한 경우 409
  - 체크인 성공 시 구독 중인 모든 클라이언트에 SSE 이벤트 브로드캐스트
- Redis `study:attendance` 키로 당일 체크인 상태 저장 (자정 만료)
- `StudyAttendanceSseEmitterRegistry`로 emitter 목록 관리 (timeout/error 시 자동 제거)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음