### PR TITLE
동아리 신청 중복 가입 방지 및 정원 카운트 기준 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantJpaRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantJpaRepository.kt
@@ -12,4 +12,6 @@ interface ClubParticipantJpaRepository : JpaRepository<ClubParticipantJpaEntity,
     fun findAllByClubType(
         @Param("clubType") clubType: ClubType,
     ): List<ClubParticipantJpaEntity>
+
+    fun countByClubId(clubId: Long): Long
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantJpaRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantJpaRepository.kt
@@ -13,5 +13,5 @@ interface ClubParticipantJpaRepository : JpaRepository<ClubParticipantJpaEntity,
         @Param("clubType") clubType: ClubType,
     ): List<ClubParticipantJpaEntity>
 
-    fun countByClubId(clubId: Long): Long
+    fun findAllByClubId(clubId: Long): List<ClubParticipantJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateAutonomousClubApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateAutonomousClubApplicationServiceImpl.kt
@@ -5,7 +5,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import team.incube.flooding.domain.club.entity.ClubAutonomousApplicationJpaEntity
-import team.incube.flooding.domain.club.entity.ClubParticipantId
 import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
 import team.incube.flooding.domain.club.entity.ClubType
 import team.incube.flooding.domain.club.presentation.data.response.CreateAutonomousClubApplicationResponse
@@ -51,7 +50,9 @@ class CreateAutonomousClubApplicationServiceImpl(
                     club.maxMember
                         ?: throw ExpectedException("정원이 설정되지 않은 동아리입니다.", HttpStatus.BAD_REQUEST)
 
-                if (clubParticipantJpaRepository.existsById(ClubParticipantId(club = clubId, user = user.id))) {
+                val participants = clubParticipantJpaRepository.findAllByClubId(clubId)
+
+                if (participants.any { it.user.id == user.id }) {
                     throw ExpectedException("이미 가입된 동아리입니다.", HttpStatus.CONFLICT)
                 }
 
@@ -59,7 +60,7 @@ class CreateAutonomousClubApplicationServiceImpl(
                     throw ExpectedException("이미 신청한 동아리입니다.", HttpStatus.CONFLICT)
                 }
 
-                if (clubParticipantJpaRepository.countByClubId(clubId) >= maxMember) {
+                if (participants.size >= maxMember) {
                     throw ExpectedException("신청 정원이 마감되었습니다.", HttpStatus.CONFLICT)
                 }
 

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateAutonomousClubApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateAutonomousClubApplicationServiceImpl.kt
@@ -5,9 +5,12 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import team.incube.flooding.domain.club.entity.ClubAutonomousApplicationJpaEntity
+import team.incube.flooding.domain.club.entity.ClubParticipantId
+import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
 import team.incube.flooding.domain.club.entity.ClubType
 import team.incube.flooding.domain.club.presentation.data.response.CreateAutonomousClubApplicationResponse
 import team.incube.flooding.domain.club.repository.ClubAutonomousApplicationRepository
+import team.incube.flooding.domain.club.repository.ClubParticipantJpaRepository
 import team.incube.flooding.domain.club.repository.ClubRepository
 import team.incube.flooding.domain.club.service.CreateAutonomousClubApplicationService
 import team.incube.flooding.global.security.util.CurrentUserProvider
@@ -18,6 +21,7 @@ import java.util.concurrent.TimeUnit
 class CreateAutonomousClubApplicationServiceImpl(
     private val clubRepository: ClubRepository,
     private val clubAutonomousApplicationRepository: ClubAutonomousApplicationRepository,
+    private val clubParticipantJpaRepository: ClubParticipantJpaRepository,
     private val currentUserProvider: CurrentUserProvider,
     private val redissonClient: RedissonClient,
     private val transactionTemplate: TransactionTemplate,
@@ -47,11 +51,15 @@ class CreateAutonomousClubApplicationServiceImpl(
                     club.maxMember
                         ?: throw ExpectedException("정원이 설정되지 않은 동아리입니다.", HttpStatus.BAD_REQUEST)
 
+                if (clubParticipantJpaRepository.existsById(ClubParticipantId(club = clubId, user = user.id))) {
+                    throw ExpectedException("이미 가입된 동아리입니다.", HttpStatus.CONFLICT)
+                }
+
                 if (clubAutonomousApplicationRepository.existsByClubIdAndUserId(clubId, user.id)) {
                     throw ExpectedException("이미 신청한 동아리입니다.", HttpStatus.CONFLICT)
                 }
 
-                if (clubAutonomousApplicationRepository.countByClubId(clubId) >= maxMember) {
+                if (clubParticipantJpaRepository.countByClubId(clubId) >= maxMember) {
                     throw ExpectedException("신청 정원이 마감되었습니다.", HttpStatus.CONFLICT)
                 }
 
@@ -59,6 +67,8 @@ class CreateAutonomousClubApplicationServiceImpl(
                     clubAutonomousApplicationRepository.save(
                         ClubAutonomousApplicationJpaEntity(club = club, user = user),
                     )
+
+                clubParticipantJpaRepository.save(ClubParticipantJpaEntity(club = club, user = user))
 
                 CreateAutonomousClubApplicationResponse(applicationId = application.id)
             }!!

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateClubApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/CreateClubApplicationServiceImpl.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.club.entity.ClubFormAnswerJpaEntity
 import team.incube.flooding.domain.club.entity.ClubFormSubmissionJpaEntity
+import team.incube.flooding.domain.club.entity.ClubParticipantId
 import team.incube.flooding.domain.club.entity.ClubType
 import team.incube.flooding.domain.club.presentation.data.request.CreateClubApplicationRequest
 import team.incube.flooding.domain.club.presentation.data.response.CreateClubApplicationResponse
@@ -12,6 +13,7 @@ import team.incube.flooding.domain.club.repository.ClubFormAnswerRepository
 import team.incube.flooding.domain.club.repository.ClubFormFieldRepository
 import team.incube.flooding.domain.club.repository.ClubFormRepository
 import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
+import team.incube.flooding.domain.club.repository.ClubParticipantJpaRepository
 import team.incube.flooding.domain.club.service.CreateClubApplicationService
 import team.incube.flooding.global.security.util.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
@@ -22,6 +24,7 @@ class CreateClubApplicationServiceImpl(
     private val clubFormFieldRepository: ClubFormFieldRepository,
     private val clubFormSubmissionRepository: ClubFormSubmissionRepository,
     private val clubFormAnswerRepository: ClubFormAnswerRepository,
+    private val clubParticipantJpaRepository: ClubParticipantJpaRepository,
     private val currentUserProvider: CurrentUserProvider,
 ) : CreateClubApplicationService {
     @Transactional
@@ -37,6 +40,10 @@ class CreateClubApplicationServiceImpl(
 
         if (form.club.type != ClubType.MAJOR_CLUB) {
             throw ExpectedException("전공 동아리만 폼으로 신청할 수 있습니다.", HttpStatus.BAD_REQUEST)
+        }
+
+        if (clubParticipantJpaRepository.existsById(ClubParticipantId(club = form.club.id, user = user.id))) {
+            throw ExpectedException("이미 가입된 동아리입니다.", HttpStatus.CONFLICT)
         }
 
         if (clubFormSubmissionRepository.existsByFormIdAndUserId(form.id, user.id)) {

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/CreateAutonomousClubApplicationServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/CreateAutonomousClubApplicationServiceTest.kt
@@ -13,7 +13,6 @@ import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionTemplate
 import team.incube.flooding.domain.club.entity.ClubAutonomousApplicationJpaEntity
 import team.incube.flooding.domain.club.entity.ClubJpaEntity
-import team.incube.flooding.domain.club.entity.ClubParticipantId
 import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
 import team.incube.flooding.domain.club.entity.ClubStatus
 import team.incube.flooding.domain.club.entity.ClubType
@@ -88,6 +87,17 @@ class CreateAutonomousClubApplicationServiceTest :
                 maxMember = null,
             )
 
+        fun otherUser(id: Long) =
+            UserJpaEntity(
+                id = id,
+                name = "다른 유저",
+                sex = Sex.MAN,
+                email = "other$id@test.com",
+                studentNumber = (10000 + id).toInt(),
+                role = Role.GENERAL_STUDENT,
+                dormitoryRoom = null,
+            )
+
         given("존재하지 않는 동아리일 때") {
             `when`("신청하면") {
                 then("NOT_FOUND 예외가 발생한다") {
@@ -143,13 +153,14 @@ class CreateAutonomousClubApplicationServiceTest :
         given("이미 가입된 사용자가") {
             `when`("다시 신청하면") {
                 then("CONFLICT 예외가 발생한다") {
+                    val club = autonomousClub()
                     every { currentUserProvider.getCurrentUser() } returns user
-                    every { clubRepository.findById(1L) } returns Optional.of(autonomousClub())
+                    every { clubRepository.findById(1L) } returns Optional.of(club)
                     every { redissonClient.getLock(any<String>()) } returns lock
                     every { lock.tryLock(any<Long>(), any<Long>(), any<TimeUnit>()) } returns true
 
-                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
-                        true
+                    every { clubParticipantJpaRepository.findAllByClubId(1L) } returns
+                        listOf(ClubParticipantJpaEntity(club = club, user = user))
 
                     val exception = shouldThrow<ExpectedException> { service.execute(1L) }
                     exception.statusCode shouldBe HttpStatus.CONFLICT
@@ -165,8 +176,7 @@ class CreateAutonomousClubApplicationServiceTest :
                     every { redissonClient.getLock(any<String>()) } returns lock
                     every { lock.tryLock(any<Long>(), any<Long>(), any<TimeUnit>()) } returns true
 
-                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
-                        false
+                    every { clubParticipantJpaRepository.findAllByClubId(1L) } returns emptyList()
                     every { clubAutonomousApplicationRepository.existsByClubIdAndUserId(1L, 1L) } returns true
 
                     val exception = shouldThrow<ExpectedException> { service.execute(1L) }
@@ -178,15 +188,15 @@ class CreateAutonomousClubApplicationServiceTest :
         given("정원이 마감된 동아리에") {
             `when`("신청하면") {
                 then("CONFLICT 예외가 발생한다") {
+                    val club = autonomousClub(maxMember = 5)
                     every { currentUserProvider.getCurrentUser() } returns user
-                    every { clubRepository.findById(1L) } returns Optional.of(autonomousClub(maxMember = 5))
+                    every { clubRepository.findById(1L) } returns Optional.of(club)
                     every { redissonClient.getLock(any<String>()) } returns lock
                     every { lock.tryLock(any<Long>(), any<Long>(), any<TimeUnit>()) } returns true
 
-                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
-                        false
+                    every { clubParticipantJpaRepository.findAllByClubId(1L) } returns
+                        (2L..6L).map { ClubParticipantJpaEntity(club = club, user = otherUser(it)) }
                     every { clubAutonomousApplicationRepository.existsByClubIdAndUserId(1L, 1L) } returns false
-                    every { clubParticipantJpaRepository.countByClubId(1L) } returns 5L
 
                     val exception = shouldThrow<ExpectedException> { service.execute(1L) }
                     exception.statusCode shouldBe HttpStatus.CONFLICT
@@ -205,10 +215,9 @@ class CreateAutonomousClubApplicationServiceTest :
                     every { redissonClient.getLock(any<String>()) } returns lock
                     every { lock.tryLock(any<Long>(), any<Long>(), any<TimeUnit>()) } returns true
 
-                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
-                        false
+                    every { clubParticipantJpaRepository.findAllByClubId(1L) } returns
+                        listOf(ClubParticipantJpaEntity(club = club, user = otherUser(2L)))
                     every { clubAutonomousApplicationRepository.existsByClubIdAndUserId(1L, 1L) } returns false
-                    every { clubParticipantJpaRepository.countByClubId(1L) } returns 3L
                     every { clubAutonomousApplicationRepository.save(any()) } returns savedApplication
                     every { clubParticipantJpaRepository.save(any<ClubParticipantJpaEntity>()) } returns mockk()
 

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/CreateAutonomousClubApplicationServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/CreateAutonomousClubApplicationServiceTest.kt
@@ -13,9 +13,12 @@ import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionTemplate
 import team.incube.flooding.domain.club.entity.ClubAutonomousApplicationJpaEntity
 import team.incube.flooding.domain.club.entity.ClubJpaEntity
+import team.incube.flooding.domain.club.entity.ClubParticipantId
+import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
 import team.incube.flooding.domain.club.entity.ClubStatus
 import team.incube.flooding.domain.club.entity.ClubType
 import team.incube.flooding.domain.club.repository.ClubAutonomousApplicationRepository
+import team.incube.flooding.domain.club.repository.ClubParticipantJpaRepository
 import team.incube.flooding.domain.club.repository.ClubRepository
 import team.incube.flooding.domain.club.service.impl.CreateAutonomousClubApplicationServiceImpl
 import team.incube.flooding.domain.user.entity.Role
@@ -30,6 +33,7 @@ class CreateAutonomousClubApplicationServiceTest :
     BehaviorSpec({
         val clubRepository = mockk<ClubRepository>()
         val clubAutonomousApplicationRepository = mockk<ClubAutonomousApplicationRepository>()
+        val clubParticipantJpaRepository = mockk<ClubParticipantJpaRepository>()
         val currentUserProvider = mockk<CurrentUserProvider>()
         val redissonClient = mockk<RedissonClient>()
         val lock = mockk<RLock>(relaxed = true)
@@ -43,6 +47,7 @@ class CreateAutonomousClubApplicationServiceTest :
             CreateAutonomousClubApplicationServiceImpl(
                 clubRepository,
                 clubAutonomousApplicationRepository,
+                clubParticipantJpaRepository,
                 currentUserProvider,
                 redissonClient,
                 transactionTemplate,
@@ -135,6 +140,23 @@ class CreateAutonomousClubApplicationServiceTest :
             }
         }
 
+        given("이미 가입된 사용자가") {
+            `when`("다시 신청하면") {
+                then("CONFLICT 예외가 발생한다") {
+                    every { currentUserProvider.getCurrentUser() } returns user
+                    every { clubRepository.findById(1L) } returns Optional.of(autonomousClub())
+                    every { redissonClient.getLock(any<String>()) } returns lock
+                    every { lock.tryLock(any<Long>(), any<Long>(), any<TimeUnit>()) } returns true
+
+                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
+                        true
+
+                    val exception = shouldThrow<ExpectedException> { service.execute(1L) }
+                    exception.statusCode shouldBe HttpStatus.CONFLICT
+                }
+            }
+        }
+
         given("이미 신청한 사용자가") {
             `when`("다시 신청하면") {
                 then("CONFLICT 예외가 발생한다") {
@@ -143,6 +165,8 @@ class CreateAutonomousClubApplicationServiceTest :
                     every { redissonClient.getLock(any<String>()) } returns lock
                     every { lock.tryLock(any<Long>(), any<Long>(), any<TimeUnit>()) } returns true
 
+                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
+                        false
                     every { clubAutonomousApplicationRepository.existsByClubIdAndUserId(1L, 1L) } returns true
 
                     val exception = shouldThrow<ExpectedException> { service.execute(1L) }
@@ -159,8 +183,10 @@ class CreateAutonomousClubApplicationServiceTest :
                     every { redissonClient.getLock(any<String>()) } returns lock
                     every { lock.tryLock(any<Long>(), any<Long>(), any<TimeUnit>()) } returns true
 
+                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
+                        false
                     every { clubAutonomousApplicationRepository.existsByClubIdAndUserId(1L, 1L) } returns false
-                    every { clubAutonomousApplicationRepository.countByClubId(1L) } returns 5L
+                    every { clubParticipantJpaRepository.countByClubId(1L) } returns 5L
 
                     val exception = shouldThrow<ExpectedException> { service.execute(1L) }
                     exception.statusCode shouldBe HttpStatus.CONFLICT
@@ -179,13 +205,17 @@ class CreateAutonomousClubApplicationServiceTest :
                     every { redissonClient.getLock(any<String>()) } returns lock
                     every { lock.tryLock(any<Long>(), any<Long>(), any<TimeUnit>()) } returns true
 
+                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
+                        false
                     every { clubAutonomousApplicationRepository.existsByClubIdAndUserId(1L, 1L) } returns false
-                    every { clubAutonomousApplicationRepository.countByClubId(1L) } returns 3L
+                    every { clubParticipantJpaRepository.countByClubId(1L) } returns 3L
                     every { clubAutonomousApplicationRepository.save(any()) } returns savedApplication
+                    every { clubParticipantJpaRepository.save(any<ClubParticipantJpaEntity>()) } returns mockk()
 
                     val response = service.execute(1L)
                     response.applicationId shouldBe 100L
                     verify(exactly = 1) { clubAutonomousApplicationRepository.save(any()) }
+                    verify(exactly = 1) { clubParticipantJpaRepository.save(any<ClubParticipantJpaEntity>()) }
                 }
             }
         }

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/CreateClubApplicationServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/CreateClubApplicationServiceTest.kt
@@ -14,6 +14,7 @@ import team.incube.flooding.domain.club.entity.ClubFormFieldType
 import team.incube.flooding.domain.club.entity.ClubFormJpaEntity
 import team.incube.flooding.domain.club.entity.ClubFormSubmissionJpaEntity
 import team.incube.flooding.domain.club.entity.ClubJpaEntity
+import team.incube.flooding.domain.club.entity.ClubParticipantId
 import team.incube.flooding.domain.club.entity.ClubStatus
 import team.incube.flooding.domain.club.entity.ClubType
 import team.incube.flooding.domain.club.presentation.data.request.CreateClubApplicationAnswerRequest
@@ -22,6 +23,7 @@ import team.incube.flooding.domain.club.repository.ClubFormAnswerRepository
 import team.incube.flooding.domain.club.repository.ClubFormFieldRepository
 import team.incube.flooding.domain.club.repository.ClubFormRepository
 import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
+import team.incube.flooding.domain.club.repository.ClubParticipantJpaRepository
 import team.incube.flooding.domain.club.service.impl.CreateClubApplicationServiceImpl
 import team.incube.flooding.domain.user.entity.Role
 import team.incube.flooding.domain.user.entity.Sex
@@ -35,6 +37,7 @@ class CreateClubApplicationServiceTest :
         val clubFormFieldRepository = mockk<ClubFormFieldRepository>()
         val clubFormSubmissionRepository = mockk<ClubFormSubmissionRepository>()
         val clubFormAnswerRepository = mockk<ClubFormAnswerRepository>()
+        val clubParticipantJpaRepository = mockk<ClubParticipantJpaRepository>()
         val currentUserProvider = mockk<CurrentUserProvider>()
 
         val service =
@@ -43,6 +46,7 @@ class CreateClubApplicationServiceTest :
                 clubFormFieldRepository,
                 clubFormSubmissionRepository,
                 clubFormAnswerRepository,
+                clubParticipantJpaRepository,
                 currentUserProvider,
             )
 
@@ -108,11 +112,30 @@ class CreateClubApplicationServiceTest :
             }
         }
 
+        given("이미 가입된 구성원이") {
+            `when`("폼을 신청하면") {
+                then("CONFLICT 예외가 발생한다") {
+                    every { currentUserProvider.getCurrentUser() } returns user
+                    every { clubFormRepository.findByClubIdAndIsActiveTrue(1L) } returns form
+                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
+                        true
+
+                    val exception =
+                        shouldThrow<ExpectedException> {
+                            service.execute(1L, CreateClubApplicationRequest(emptyList()))
+                        }
+                    exception.statusCode shouldBe HttpStatus.CONFLICT
+                }
+            }
+        }
+
         given("이미 신청한 사용자가") {
             `when`("다시 신청하면") {
                 then("CONFLICT 예외가 발생한다") {
                     every { currentUserProvider.getCurrentUser() } returns user
                     every { clubFormRepository.findByClubIdAndIsActiveTrue(1L) } returns form
+                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
+                        false
                     every { clubFormSubmissionRepository.existsByFormIdAndUserId(10L, 1L) } returns true
 
                     val exception =
@@ -129,6 +152,8 @@ class CreateClubApplicationServiceTest :
                 then("BAD_REQUEST 예외가 발생한다") {
                     every { currentUserProvider.getCurrentUser() } returns user
                     every { clubFormRepository.findByClubIdAndIsActiveTrue(1L) } returns form
+                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
+                        false
                     every { clubFormSubmissionRepository.existsByFormIdAndUserId(10L, 1L) } returns false
                     every { clubFormFieldRepository.findAllByFormIdOrderByFieldOrder(10L) } returns
                         listOf(requiredField, optionalField)
@@ -154,6 +179,8 @@ class CreateClubApplicationServiceTest :
 
                     every { currentUserProvider.getCurrentUser() } returns user
                     every { clubFormRepository.findByClubIdAndIsActiveTrue(1L) } returns form
+                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
+                        false
                     every { clubFormSubmissionRepository.existsByFormIdAndUserId(10L, 1L) } returns false
                     every { clubFormFieldRepository.findAllByFormIdOrderByFieldOrder(10L) } returns
                         listOf(requiredField, optionalField)
@@ -182,6 +209,8 @@ class CreateClubApplicationServiceTest :
 
                     every { currentUserProvider.getCurrentUser() } returns user
                     every { clubFormRepository.findByClubIdAndIsActiveTrue(1L) } returns form
+                    every { clubParticipantJpaRepository.existsById(ClubParticipantId(club = 1L, user = 1L)) } returns
+                        false
                     every { clubFormSubmissionRepository.existsByFormIdAndUserId(10L, 1L) } returns false
                     every { clubFormFieldRepository.findAllByFormIdOrderByFieldOrder(10L) } returns
                         listOf(optionalField)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

동아리 구성원 도메인에서 발견된 버그 3가지를 수정합니다.

1. 자율 동아리 정원 체크 기준 오류
   - 기존: ClubAutonomousApplicationJpaEntity 개수로 카운트 → 리더가 정원에 포함되지 않아 실제 정원보다 1명 더 입장 가능
   - 수정: ClubParticipantJpaEntity 기준으로 카운트하여 리더를 포함한 실제 구성원 수로 비교

2. 자율 동아리 신청 시 구성원 미등록
   - 기존: 선착순 신청 성공 시 ClubAutonomousApplicationJpaEntity만 저장 → GetClub 구성원 목록에 미노출
   - 수정: 신청 성공 시 ClubParticipantJpaEntity에도 즉시 등록

3. 이미 가입된 구성원의 재신청 방지 누락
   - 기존: 폼 중복 제출만 체크 → 기가입 구성원도 폼 신청 가능
   - 수정: 전공/자율 동아리 신청 시 ClubParticipantJpaEntity 존재 여부 선행 체크

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 자율 동아리의 경우 선착순 신청이 곧 가입 확정이라는 가정 하에 신청 시 ClubParticipantJpaEntity에 바로 등록하도록 수정했습니다. 의도한 도메인 흐름인지 확인 부탁드립니다.