### PR TITLE
fix : 기상음악 API 권한 제한 제거

### DIFF
--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -69,29 +69,6 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/dormitory/massages").hasRole(Role.GENERAL_STUDENT.name)
                 it.requestMatchers(HttpMethod.DELETE, "/dormitory/massages").hasRole(Role.GENERAL_STUDENT.name)
 
-                // music
-                it
-                    .requestMatchers(
-                        HttpMethod.GET,
-                        "/dormitory/music",
-                    ).hasAnyRole(Role.GENERAL_STUDENT.name, Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
-                it.requestMatchers(HttpMethod.POST, "/dormitory/music").hasRole(Role.GENERAL_STUDENT.name)
-                it
-                    .requestMatchers(
-                        HttpMethod.DELETE,
-                        "/dormitory/music/{musicId}",
-                    ).hasAnyRole(Role.GENERAL_STUDENT.name, Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
-                it
-                    .requestMatchers(
-                        HttpMethod.POST,
-                        "/dormitory/music/{musicId}/like",
-                    ).hasRole(Role.GENERAL_STUDENT.name)
-                it
-                    .requestMatchers(
-                        HttpMethod.DELETE,
-                        "/dormitory/music/{musicId}/like",
-                    ).hasRole(Role.GENERAL_STUDENT.name)
-
                 // penalty
                 it
                     .requestMatchers(HttpMethod.GET, "/dormitory/penalties")


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

기상음악 관련 API(`POST`, `DELETE`, `GET /dormitory/music/**`)에 설정된 Role 기반 접근 제한을 제거하여 로그인한 모든 사용자가 접근 가능하도록 수정

- `GENERAL_STUDENT`, `DORMITORY_MANAGER`, `ADMIN` 등 Role에 관계없이 인증된 사용자라면 모두 접근 가능
- 기존 설정으로 인해 `STUDENT_COUNCIL` 등 일부 Role에서 403 오류 발생하던 문제 해결

## 💬리뷰 요구사항(선택)