### PR TITLE
자습 신청자 목록 조회 응답에 자습 금지 여부 필드 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
@@ -5,4 +5,5 @@ data class GetStudyResponse(
     val name: String,
     val studentNumber: Int,
     val isBanned: Boolean,
+    val isChecked: Boolean,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
@@ -4,4 +4,5 @@ data class GetStudyResponse(
     val userId: Long,
     val name: String,
     val studentNumber: Int,
+    val isBanned: Boolean,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/repository/StudyBanJpaRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/repository/StudyBanJpaRepository.kt
@@ -9,4 +9,9 @@ interface StudyBanJpaRepository : JpaRepository<StudyBanJpaEntity, Long> {
         userId: Long,
         now: LocalDateTime,
     ): Boolean
+
+    fun findAllByUserIdInAndBannedUntilAfter(
+        userIds: Collection<Long>,
+        now: LocalDateTime,
+    ): List<StudyBanJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
@@ -24,6 +24,7 @@ class GetStudyServiceImpl(
                 .findAllByUserIdInAndBannedUntilAfter(applicantIds, LocalDateTime.now())
                 .map { it.user.id }
                 .toSet()
+        val checkedUserIds = studyRedisAdapter.getAttendanceIds()
         return userRepository
             .findAllById(applicantIds)
             .sortedBy { it.studentNumber }
@@ -32,8 +33,8 @@ class GetStudyServiceImpl(
                     userId = it.id,
                     name = it.name,
                     studentNumber = it.studentNumber,
-                    isBanned =
-                        it.id in bannedUserIds,
+                    isBanned = it.id in bannedUserIds,
+                    isChecked = it.id in checkedUserIds,
                 )
             }
     }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
@@ -7,6 +7,7 @@ import team.incube.flooding.domain.dormitory.study.presentation.data.response.Ge
 import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
 import team.incube.flooding.domain.dormitory.study.service.GetStudyService
 import team.incube.flooding.domain.user.repository.UserRepository
+import java.time.Clock
 import java.time.LocalDateTime
 
 @Service
@@ -15,13 +16,14 @@ class GetStudyServiceImpl(
     private val studyRedisAdapter: StudyRedisAdapter,
     private val userRepository: UserRepository,
     private val studyBanJpaRepository: StudyBanJpaRepository,
+    private val clock: Clock,
 ) : GetStudyService {
     override fun execute(): List<GetStudyResponse> {
         val applicantIds = studyRedisAdapter.getApplicantIds()
         if (applicantIds.isEmpty()) return emptyList()
         val bannedUserIds =
             studyBanJpaRepository
-                .findAllByUserIdInAndBannedUntilAfter(applicantIds, LocalDateTime.now())
+                .findAllByUserIdInAndBannedUntilAfter(applicantIds, LocalDateTime.now(clock))
                 .map { it.user.id }
                 .toSet()
         val checkedUserIds = studyRedisAdapter.getAttendanceIds()

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
@@ -4,21 +4,37 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.GetStudyResponse
+import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
 import team.incube.flooding.domain.dormitory.study.service.GetStudyService
 import team.incube.flooding.domain.user.repository.UserRepository
+import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true)
 class GetStudyServiceImpl(
     private val studyRedisAdapter: StudyRedisAdapter,
     private val userRepository: UserRepository,
+    private val studyBanJpaRepository: StudyBanJpaRepository,
 ) : GetStudyService {
     override fun execute(): List<GetStudyResponse> {
         val applicantIds = studyRedisAdapter.getApplicantIds()
         if (applicantIds.isEmpty()) return emptyList()
+        val bannedUserIds =
+            studyBanJpaRepository
+                .findAllByUserIdInAndBannedUntilAfter(applicantIds, LocalDateTime.now())
+                .map { it.user.id }
+                .toSet()
         return userRepository
             .findAllById(applicantIds)
             .sortedBy { it.studentNumber }
-            .map { GetStudyResponse(userId = it.id, name = it.name, studentNumber = it.studentNumber) }
+            .map {
+                GetStudyResponse(
+                    userId = it.id,
+                    name = it.name,
+                    studentNumber = it.studentNumber,
+                    isBanned =
+                        it.id in bannedUserIds,
+                )
+            }
     }
 }

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/CreateAutonomousClubApplicationServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/CreateAutonomousClubApplicationServiceTest.kt
@@ -95,7 +95,7 @@ class CreateAutonomousClubApplicationServiceTest :
                 email = "other$id@test.com",
                 studentNumber = (10000 + id).toInt(),
                 role = Role.GENERAL_STUDENT,
-                dormitoryRoom = null,
+                dormitoryRoom = 101,
             )
 
         given("존재하지 않는 동아리일 때") {

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
@@ -1,0 +1,174 @@
+package team.incube.flooding.domain.dormitory.study.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
+import team.incube.flooding.domain.dormitory.study.entity.StudyBanJpaEntity
+import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
+import team.incube.flooding.domain.dormitory.study.service.impl.GetStudyServiceImpl
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.domain.user.repository.UserRepository
+import java.time.LocalDateTime
+
+class GetStudyServiceTest :
+    BehaviorSpec({
+        val studyRedisAdapter = mockk<StudyRedisAdapter>()
+        val userRepository = mockk<UserRepository>()
+        val studyBanJpaRepository = mockk<StudyBanJpaRepository>()
+
+        val service = GetStudyServiceImpl(studyRedisAdapter, userRepository, studyBanJpaRepository)
+
+        fun user(
+            id: Long,
+            studentNumber: Int,
+        ) = UserJpaEntity(
+            id = id,
+            name = "학생$id",
+            sex = Sex.MAN,
+            email = "student$id@test.com",
+            studentNumber = studentNumber,
+            role = Role.GENERAL_STUDENT,
+            dormitoryRoom = 101,
+        )
+
+        given("신청자가 없을 때") {
+            `when`("자습 신청자 목록을 조회하면") {
+                then("빈 리스트를 반환한다") {
+                    every { studyRedisAdapter.getApplicantIds() } returns emptySet()
+
+                    val result = service.execute()
+
+                    result.shouldBeEmpty()
+                }
+            }
+        }
+
+        given("신청자 2명이 있을 때") {
+            val user1 = user(id = 1L, studentNumber = 1101)
+            val user2 = user(id = 2L, studentNumber = 1102)
+
+            `when`("아무도 자습체크를 하지 않았으면") {
+                then("모든 isChecked가 false다") {
+                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L)
+                    every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
+                        emptyList()
+                    every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
+                    every { userRepository.findAllById(any()) } returns listOf(user1, user2)
+
+                    val result = service.execute()
+
+                    result shouldHaveSize 2
+                    result.all { !it.isChecked } shouldBe true
+                }
+            }
+
+            `when`("한 명만 자습체크를 했으면") {
+                then("체크한 학생의 isChecked는 true, 나머지는 false다") {
+                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L)
+                    every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
+                        emptyList()
+                    every { studyRedisAdapter.getAttendanceIds() } returns setOf(1L)
+                    every { userRepository.findAllById(any()) } returns listOf(user1, user2)
+
+                    val result = service.execute().sortedBy { it.userId }
+
+                    result[0].isChecked shouldBe true
+                    result[1].isChecked shouldBe false
+                }
+            }
+
+            `when`("모두 자습체크를 했으면") {
+                then("모든 isChecked가 true다") {
+                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L)
+                    every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
+                        emptyList()
+                    every { studyRedisAdapter.getAttendanceIds() } returns setOf(1L, 2L)
+                    every { userRepository.findAllById(any()) } returns listOf(user1, user2)
+
+                    val result = service.execute()
+
+                    result shouldHaveSize 2
+                    result.all { it.isChecked } shouldBe true
+                }
+            }
+        }
+
+        given("신청자 중 금지된 학생이 있을 때") {
+            val user1 = user(id = 1L, studentNumber = 1101)
+            val user2 = user(id = 2L, studentNumber = 1102)
+            val banEntity =
+                StudyBanJpaEntity(
+                    user = user2,
+                    bannedAt = LocalDateTime.now().minusDays(1),
+                    bannedUntil = LocalDateTime.now().plusDays(6),
+                )
+
+            `when`("자습 신청자 목록을 조회하면") {
+                then("금지된 학생의 isBanned는 true다") {
+                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L)
+                    every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
+                        listOf(banEntity)
+                    every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
+                    every { userRepository.findAllById(any()) } returns listOf(user1, user2)
+
+                    val result = service.execute().sortedBy { it.userId }
+
+                    result[0].isBanned shouldBe false
+                    result[1].isBanned shouldBe true
+                }
+            }
+        }
+
+        given("금지되고 체크도 된 학생이 있을 때") {
+            val user1 = user(id = 1L, studentNumber = 1101)
+            val banEntity =
+                StudyBanJpaEntity(
+                    user = user1,
+                    bannedAt = LocalDateTime.now().minusDays(1),
+                    bannedUntil = LocalDateTime.now().plusDays(6),
+                )
+
+            `when`("자습 신청자 목록을 조회하면") {
+                then("isBanned와 isChecked가 모두 true다") {
+                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L)
+                    every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
+                        listOf(banEntity)
+                    every { studyRedisAdapter.getAttendanceIds() } returns setOf(1L)
+                    every { userRepository.findAllById(any()) } returns listOf(user1)
+
+                    val result = service.execute()
+
+                    result[0].isBanned shouldBe true
+                    result[0].isChecked shouldBe true
+                }
+            }
+        }
+
+        given("신청자 3명이 studentNumber 순서가 섞여 있을 때") {
+            val user1 = user(id = 1L, studentNumber = 1103)
+            val user2 = user(id = 2L, studentNumber = 1101)
+            val user3 = user(id = 3L, studentNumber = 1102)
+
+            `when`("자습 신청자 목록을 조회하면") {
+                then("studentNumber 오름차순으로 정렬된다") {
+                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L, 3L)
+                    every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
+                        emptyList()
+                    every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
+                    every { userRepository.findAllById(any()) } returns listOf(user1, user2, user3)
+
+                    val result = service.execute()
+
+                    result[0].studentNumber shouldBe 1101
+                    result[1].studentNumber shouldBe 1102
+                    result[2].studentNumber shouldBe 1103
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
@@ -14,15 +14,19 @@ import team.incube.flooding.domain.user.entity.Role
 import team.incube.flooding.domain.user.entity.Sex
 import team.incube.flooding.domain.user.entity.UserJpaEntity
 import team.incube.flooding.domain.user.repository.UserRepository
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 class GetStudyServiceTest :
     BehaviorSpec({
         val studyRedisAdapter = mockk<StudyRedisAdapter>()
         val userRepository = mockk<UserRepository>()
         val studyBanJpaRepository = mockk<StudyBanJpaRepository>()
+        val clock = Clock.fixed(Instant.parse("2026-04-29T12:00:00Z"), ZoneId.of("Asia/Seoul"))
 
-        val service = GetStudyServiceImpl(studyRedisAdapter, userRepository, studyBanJpaRepository)
+        val service = GetStudyServiceImpl(studyRedisAdapter, userRepository, studyBanJpaRepository, clock)
 
         fun user(
             id: Long,
@@ -100,13 +104,14 @@ class GetStudyServiceTest :
         }
 
         given("신청자 중 금지된 학생이 있을 때") {
+            val now = LocalDateTime.now(clock)
             val user1 = user(id = 1L, studentNumber = 1101)
             val user2 = user(id = 2L, studentNumber = 1102)
             val banEntity =
                 StudyBanJpaEntity(
                     user = user2,
-                    bannedAt = LocalDateTime.now().minusDays(1),
-                    bannedUntil = LocalDateTime.now().plusDays(6),
+                    bannedAt = now.minusDays(1),
+                    bannedUntil = now.plusDays(6),
                 )
 
             `when`("자습 신청자 목록을 조회하면") {
@@ -126,12 +131,13 @@ class GetStudyServiceTest :
         }
 
         given("금지되고 체크도 된 학생이 있을 때") {
+            val now = LocalDateTime.now(clock)
             val user1 = user(id = 1L, studentNumber = 1101)
             val banEntity =
                 StudyBanJpaEntity(
                     user = user1,
-                    bannedAt = LocalDateTime.now().minusDays(1),
-                    bannedUntil = LocalDateTime.now().plusDays(6),
+                    bannedAt = now.minusDays(1),
+                    bannedUntil = now.plusDays(6),
                 )
 
             `when`("자습 신청자 목록을 조회하면") {


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

`GET /dormitory/studies` 응답에 `isBanned` 필드 추가

- 기자위가 자습 신청자 목록을 볼 때 각 학생의 자습 금지 여부 확인 가능
- `StudyBanJpaRepository`에 `findAllByUserIdInAndBannedUntilAfter` 추가로 N+1 없이 한 번에 조회

## 💬리뷰 요구사항(선택)