### PR TITLE
suspend 컨트롤러 빈 응답 버그 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.9.0")
 
     // External SDK
     implementation("com.github.themoment-team:datagsm-oauth-sdk-java:1.4.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,8 +55,8 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
     // Coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
     // External SDK
     implementation("com.github.themoment-team:datagsm-oauth-sdk-java:1.4.1")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

동아리 단건 조회 GET /clubs/{clubId} 에서 HTTP 200이지만 응답 바디가 비어있는 버그를 수정합니다.

원인: Spring MVC에서 suspend 함수로 선언된 컨트롤러가 정상 동작하려면 kotlinx-coroutines-reactor 의존성이 필요합니다.
Spring 내부적으로 suspend 함수의 결과를 Reactor의 Mono로 변환하여 응답에 쓰는데, 해당 의존성이 없으면 변환 과정이 누락되어 빈 바디가 반환됩니다.
기존에는 kotlinx-coroutines-core만 포함되어 있어 이 문제가 발생했습니다.

수정: build.gradle.kts에 kotlinx-coroutines-reactor:1.9.0 의존성을 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음