### PR TITLE
학생 검색 결과에 성별 정보 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/SearchUsersResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/SearchUsersResponse.kt
@@ -1,10 +1,12 @@
 package team.incube.flooding.domain.user.presentation.data.response
 
+import team.incube.flooding.domain.user.entity.Sex
 import team.incube.flooding.domain.user.entity.UserJpaEntity
 
 data class SearchUsersResponse(
     val id: Long,
     val name: String,
+    val sex: Sex,
     val studentNumber: Int,
     val grade: Int,
     val classNumber: Int,
@@ -15,6 +17,7 @@ data class SearchUsersResponse(
             SearchUsersResponse(
                 id = user.id,
                 name = user.name,
+                sex = user.sex,
                 studentNumber = user.studentNumber,
                 grade = user.grade,
                 classNumber = user.classNumber,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

학생 검색 API(`GET /users`)의 응답 DTO인 `SearchUsersResponse`에 `sex` 필드를 추가했습니다.
기존에는 id, 이름, 학번, 학년, 반, 번호만 반환하고 있었으나, 성별 정보(`MAN` / `WOMAN`)도 함께 응답하도록 스펙을 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음