### PR TITLE
학생 관리 및 내 정보 조회 응답에 자습 금지 여부 필드 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/GetMeResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/GetMeResponse.kt
@@ -18,23 +18,27 @@ data class GetMeResponse(
     val dormitoryFloor: Int,
     val specialty: String?,
     val penaltyScore: Int,
+    val isBanned: Boolean,
 ) {
     companion object {
-        fun from(user: UserJpaEntity) =
-            GetMeResponse(
-                id = user.id,
-                name = user.name,
-                sex = user.sex,
-                email = user.email,
-                studentNumber = user.studentNumber,
-                grade = user.grade,
-                classNumber = user.classNumber,
-                number = user.number,
-                role = user.role,
-                dormitoryRoom = user.dormitoryRoom,
-                dormitoryFloor = user.dormitoryFloor,
-                specialty = user.specialty,
-                penaltyScore = user.penaltyScore,
-            )
+        fun from(
+            user: UserJpaEntity,
+            isBanned: Boolean,
+        ) = GetMeResponse(
+            id = user.id,
+            name = user.name,
+            sex = user.sex,
+            email = user.email,
+            studentNumber = user.studentNumber,
+            grade = user.grade,
+            classNumber = user.classNumber,
+            number = user.number,
+            role = user.role,
+            dormitoryRoom = user.dormitoryRoom,
+            dormitoryFloor = user.dormitoryFloor,
+            specialty = user.specialty,
+            penaltyScore = user.penaltyScore,
+            isBanned = isBanned,
+        )
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/SearchUsersResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/SearchUsersResponse.kt
@@ -11,17 +11,21 @@ data class SearchUsersResponse(
     val grade: Int,
     val classNumber: Int,
     val number: Int,
+    val isBanned: Boolean,
 ) {
     companion object {
-        fun from(user: UserJpaEntity) =
-            SearchUsersResponse(
-                id = user.id,
-                name = user.name,
-                sex = user.sex,
-                studentNumber = user.studentNumber,
-                grade = user.grade,
-                classNumber = user.classNumber,
-                number = user.number,
-            )
+        fun from(
+            user: UserJpaEntity,
+            isBanned: Boolean,
+        ) = SearchUsersResponse(
+            id = user.id,
+            name = user.name,
+            sex = user.sex,
+            studentNumber = user.studentNumber,
+            grade = user.grade,
+            classNumber = user.classNumber,
+            number = user.number,
+            isBanned = isBanned,
+        )
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/impl/GetMeServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/impl/GetMeServiceImpl.kt
@@ -2,17 +2,23 @@ package team.incube.flooding.domain.user.service.impl
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
 import team.incube.flooding.domain.user.presentation.data.response.GetMeResponse
 import team.incube.flooding.domain.user.service.GetMeService
 import team.incube.flooding.global.security.util.CurrentUserProvider
+import java.time.Clock
+import java.time.LocalDateTime
 
 @Service
 class GetMeServiceImpl(
     private val currentUserProvider: CurrentUserProvider,
+    private val studyBanJpaRepository: StudyBanJpaRepository,
+    private val clock: Clock,
 ) : GetMeService {
     @Transactional(readOnly = true)
     override fun execute(): GetMeResponse {
         val user = currentUserProvider.getCurrentUser()
-        return GetMeResponse.from(user)
+        val isBanned = studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now(clock))
+        return GetMeResponse.from(user, isBanned)
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/impl/SearchUsersServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/impl/SearchUsersServiceImpl.kt
@@ -4,14 +4,19 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
 import team.incube.flooding.domain.user.entity.Role
 import team.incube.flooding.domain.user.presentation.data.response.SearchUsersResponse
 import team.incube.flooding.domain.user.repository.UserRepository
 import team.incube.flooding.domain.user.service.SearchUsersService
+import java.time.Clock
+import java.time.LocalDateTime
 
 @Service
 class SearchUsersServiceImpl(
     private val userRepository: UserRepository,
+    private val studyBanJpaRepository: StudyBanJpaRepository,
+    private val clock: Clock,
 ) : SearchUsersService {
     @Transactional(readOnly = true)
     override fun execute(
@@ -21,14 +26,20 @@ class SearchUsersServiceImpl(
     ): Page<SearchUsersResponse> {
         val (start, end) = parseStudentNumberPrefix(studentNumber)
         val nameLike = name?.trim()?.takeIf { it.isNotEmpty() }?.let { "%$it%" } ?: "%"
-        return userRepository
-            .searchUsers(
+        val page =
+            userRepository.searchUsers(
                 nameLike = nameLike,
                 studentNumberStart = start,
                 studentNumberEnd = end,
                 excludedRole = Role.ADMIN,
                 pageable = pageable,
-            ).map(SearchUsersResponse::from)
+            )
+        val bannedUserIds =
+            studyBanJpaRepository
+                .findAllByUserIdInAndBannedUntilAfter(page.map { it.id }.toList(), LocalDateTime.now(clock))
+                .map { it.user.id }
+                .toSet()
+        return page.map { SearchUsersResponse.from(it, it.id in bannedUserIds) }
     }
 
     private fun parseStudentNumberPrefix(input: String?): Pair<Int?, Int?> {


### PR DESCRIPTION
## 요약
- `GET /users` (학생 관리 API) 응답에 `isBanned` 필드 추가
- `GET /users/me` (내 정보 조회 API) 응답에 `isBanned` 필드 추가
- `StudyBanJpaRepository`를 통해 현재 유효한 자습 금지 여부를 조회하여 응답에 포함

## 변경 파일
- `SearchUsersResponse` — `isBanned: Boolean` 필드 추가
- `SearchUsersServiceImpl` — 페이지 내 유저 ban 상태 일괄 조회
- `GetMeResponse` — `isBanned: Boolean` 필드 추가
- `GetMeServiceImpl` — `existsByUserIdAndBannedUntilAfter`로 ban 여부 조회