### PR TITLE
fix : 미인증 요청 401 반환 및 동아리 단건 조회 403 오류 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubController.kt
@@ -86,7 +86,7 @@ class ClubController(
 
     @Operation(summary = "동아리 단건 조회", description = "동아리 상세 정보를 조회합니다.")
     @GetMapping("/{clubId}")
-    suspend fun getClub(
+    fun getClub(
         @PathVariable clubId: Long,
     ): CommonApiResponse<GetClubResponse> = CommonApiResponse.success("OK", getClubService.execute(clubId))
 

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/GetClubService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/GetClubService.kt
@@ -3,5 +3,5 @@ package team.incube.flooding.domain.club.service
 import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
 
 interface GetClubService {
-    suspend fun execute(clubId: Long): GetClubResponse
+    fun execute(clubId: Long): GetClubResponse
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
@@ -1,8 +1,5 @@
 package team.incube.flooding.domain.club.service.impl
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
@@ -22,45 +19,38 @@ class GetClubServiceImpl(
 ) : GetClubService {
     override fun execute(clubId: Long): GetClubResponse {
         val currentUser = currentUserProvider.getCurrentUser()
-        return runBlocking {
-            val clubDeferred = async(Dispatchers.IO) { clubRepository.findByIdWithLeader(clubId) }
-            val membersDeferred =
-                async(Dispatchers.IO) {
-                    clubParticipantRepository.findAllByClubId(clubId).map { p ->
-                        GetClubResponse.MemberSummary(
-                            id = p.user.id,
-                            name = p.user.name,
-                            studentNumber = p.user.studentNumber,
-                            sex = p.user.sex.name,
-                            specialty = p.user.specialty,
-                        )
-                    }
-                }
-            val projectsDeferred =
-                async(Dispatchers.IO) {
-                    val dgId = clubDeferred.await()?.dataGsmClubId ?: return@async emptyList()
-                    runCatching { dataGsmProjectClient.getProjectsByClubId(dgId) }.getOrElse { emptyList() }
-                }
+        val club =
+            clubRepository.findByIdWithLeader(clubId)
+                ?: throw ExpectedException("존재하지 않는 동아리입니다.", HttpStatus.NOT_FOUND)
+        val members =
+            clubParticipantRepository.findAllByClubId(clubId).map { p ->
+                GetClubResponse.MemberSummary(
+                    id = p.user.id,
+                    name = p.user.name,
+                    studentNumber = p.user.studentNumber,
+                    sex = p.user.sex.name,
+                    specialty = p.user.specialty,
+                )
+            }
+        val projects =
+            club.dataGsmClubId?.let { dgId ->
+                runCatching { dataGsmProjectClient.getProjectsByClubId(dgId) }.getOrElse { emptyList() }
+            } ?: emptyList()
 
-            val club =
-                clubDeferred.await()
-                    ?: throw ExpectedException("존재하지 않는 동아리입니다.", HttpStatus.NOT_FOUND)
-
-            GetClubResponse(
-                club =
-                    GetClubResponse.ClubDetail(
-                        id = club.id,
-                        name = club.name,
-                        type = club.type.name,
-                        leader = club.leader?.name,
-                        description = club.description,
-                        imageUrl = club.imageUrl,
-                        maxMember = club.maxMember,
-                    ),
-                members = membersDeferred.await(),
-                projects = projectsDeferred.await(),
-                isLeader = club.leader?.id == currentUser.id,
-            )
-        }
+        return GetClubResponse(
+            club =
+                GetClubResponse.ClubDetail(
+                    id = club.id,
+                    name = club.name,
+                    type = club.type.name,
+                    leader = club.leader?.name,
+                    description = club.description,
+                    imageUrl = club.imageUrl,
+                    maxMember = club.maxMember,
+                ),
+            members = members,
+            projects = projects,
+            isLeader = club.leader?.id == currentUser.id,
+        )
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
@@ -2,7 +2,7 @@ package team.incube.flooding.domain.club.service.impl
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
@@ -20,9 +20,9 @@ class GetClubServiceImpl(
     private val dataGsmProjectClient: DataGsmProjectClient,
     private val currentUserProvider: CurrentUserProvider,
 ) : GetClubService {
-    override suspend fun execute(clubId: Long): GetClubResponse {
+    override fun execute(clubId: Long): GetClubResponse {
         val currentUser = currentUserProvider.getCurrentUser()
-        return coroutineScope {
+        return runBlocking {
             val clubDeferred = async(Dispatchers.IO) { clubRepository.findByIdWithLeader(clubId) }
             val membersDeferred =
                 async(Dispatchers.IO) {

--- a/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/DataGsmProjectClient.kt
@@ -1,7 +1,5 @@
 package team.incube.flooding.global.client
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.redis.core.RedisTemplate
@@ -31,18 +29,16 @@ class DataGsmProjectClient(
             .build()
     }
 
-    suspend fun getProjectsByClubId(clubId: Long): List<GetClubResponse.ProjectSummary> =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val cacheKey = "$CACHE_PREFIX$clubId"
-                val cached = redisTemplate.opsForValue().get(cacheKey)
-                if (cached != null) {
-                    jsonMapper.readValue(cached, object : TypeReference<List<GetClubResponse.ProjectSummary>>() {})
-                } else {
-                    warmCache(clubId) ?: emptyList()
-                }
-            }.getOrElse { emptyList() }
-        }
+    fun getProjectsByClubId(clubId: Long): List<GetClubResponse.ProjectSummary> =
+        runCatching {
+            val cacheKey = "$CACHE_PREFIX$clubId"
+            val cached = redisTemplate.opsForValue().get(cacheKey)
+            if (cached != null) {
+                jsonMapper.readValue(cached, object : TypeReference<List<GetClubResponse.ProjectSummary>>() {})
+            } else {
+                warmCache(clubId) ?: emptyList()
+            }
+        }.getOrElse { emptyList() }
 
     fun warmCache(clubId: Long): List<GetClubResponse.ProjectSummary>? {
         val projects =

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -44,6 +44,7 @@ class SecurityConfig(
             .httpBasic { it.disable() }
             .authorizeHttpRequests {
                 it.requestMatchers("/actuator/**").permitAll()
+                it.requestMatchers("/error").permitAll()
                 it.requestMatchers("/auth/signin", "/auth/reissue").permitAll()
                 it.requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
                 // ai

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.global.security.config
 
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -102,6 +103,10 @@ class SecurityConfig(
                     .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
 
                 it.anyRequest().authenticated()
+            }.exceptionHandling {
+                it.authenticationEntryPoint { _, response, _ ->
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED)
+                }
             }.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
 }


### PR DESCRIPTION
## 원인

### 1. 미인증 요청 시 403 반환 문제
`formLogin`과 `httpBasic`이 모두 `disable()`된 상태에서 Spring Security의 기본 `AuthenticationEntryPoint`가 `Http403ForbiddenEntryPoint`로 설정됩니다.
이로 인해 토큰이 없거나 만료된 요청에 401이 아닌 **403**이 반환되었습니다.

### 2. 동아리 단건 조회(`GET /clubs/{clubId}`) 403 오류
컨트롤러와 서비스의 `execute`가 `suspend fun`으로 선언되어 있었습니다.
Spring MVC는 `suspend` 컨트롤러 메서드를 비동기 dispatch로 처리하는데, `SessionCreationPolicy.STATELESS` 설정으로 인해
async dispatch 시 Spring Security가 보안 컨텍스트를 복원하지 못하고 인증된 사용자에게도 **403**을 반환했습니다.
다른 API는 모두 일반 함수(`suspend` 없음)이기 때문에 이 엔드포인트에서만 발생했습니다.

## 변경 사항

### AuthenticationEntryPoint 설정
- `SecurityConfig`에 `exceptionHandling` 추가
- `AuthenticationEntryPoint`를 `401 Unauthorized`를 반환하도록 명시적 설정

### 동아리 단건 조회 suspend 제거
- `GetClubService` 인터페이스, `GetClubServiceImpl`, `ClubController.getClub`에서 `suspend` 제거
- `coroutineScope` → `runBlocking`으로 변경 (병렬 IO 실행은 그대로 유지)

## 수정 전 / 후
| 상황 | 수정 전 | 수정 후 |
|------|--------|--------|
| 토큰 없음 | 403 | 401 |
| 토큰 만료 | 403 | 401 |
| 유효한 토큰으로 `GET /clubs/{clubId}` 조회 | 403 | 200 |
| 유효한 토큰이지만 권한 부족 | 403 | 403 (유지) |