### PR TITLE
기상송 신청 request URL 전용으로 변경

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/ai/service/impl/RecommendAiSongServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/service/impl/RecommendAiSongServiceImpl.kt
@@ -25,7 +25,12 @@ class RecommendAiSongServiceImpl(
         if (history.isEmpty()) {
             throw ExpectedException("추천을 위한 기상송 신청 내역이 존재하지 않습니다.", HttpStatus.NOT_FOUND)
         }
-        val recentSongs = history.map { SongRequest(title = it.title, artist = it.artist) }
+        val recentSongs =
+            history.mapNotNull { entity ->
+                val title = entity.title ?: return@mapNotNull null
+                val artist = entity.artist ?: return@mapNotNull null
+                SongRequest(title = title, artist = artist)
+            }
         return aiSongAdapter.recommend(RecommendAiSongRequest(recentSongs = recentSongs))
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
@@ -23,10 +23,6 @@ class WakeUpMusicJpaEntity(
     val user: UserJpaEntity,
     @field:Column(name = "music_url", nullable = false)
     val musicUrl: String,
-    @field:Column(name = "title", nullable = false)
-    val title: String,
-    @field:Column(name = "artist", nullable = false)
-    val artist: String,
     @field:Column(name = "applied_at", nullable = false)
     val appliedAt: LocalDateTime = LocalDateTime.now(),
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
@@ -23,6 +23,10 @@ class WakeUpMusicJpaEntity(
     val user: UserJpaEntity,
     @field:Column(name = "music_url", nullable = false)
     val musicUrl: String,
+    @field:Column(name = "title")
+    val title: String? = null,
+    @field:Column(name = "artist")
+    val artist: String? = null,
     @field:Column(name = "applied_at", nullable = false)
     val appliedAt: LocalDateTime = LocalDateTime.now(),
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicRequest
+import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicByUrlRequest
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
 import team.incube.flooding.domain.dormitory.music.service.ApplyWakeUpMusicService
 import team.incube.flooding.domain.dormitory.music.service.CancelLikeWakeUpMusicService
@@ -59,7 +59,7 @@ class WakeUpMusicController(
     )
     @PostMapping
     fun applyWakeUpMusic(
-        @RequestBody request: ApplyWakeUpMusicRequest,
+        @RequestBody request: ApplyWakeUpMusicByUrlRequest,
     ): CommonApiResponse<Nothing> {
         applyWakeUpMusicService.execute(request)
         return CommonApiResponse.success("OK")

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/request/ApplyWakeUpMusicByUrlRequest.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/request/ApplyWakeUpMusicByUrlRequest.kt
@@ -1,0 +1,8 @@
+package team.incube.flooding.domain.dormitory.music.presentation.data.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class ApplyWakeUpMusicByUrlRequest(
+    @field:NotBlank
+    val musicUrl: String,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/request/ApplyWakeUpMusicRequest.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/request/ApplyWakeUpMusicRequest.kt
@@ -5,8 +5,4 @@ import jakarta.validation.constraints.NotBlank
 data class ApplyWakeUpMusicRequest(
     @field:NotBlank
     val musicUrl: String,
-    @field:NotBlank
-    val title: String,
-    @field:NotBlank
-    val artist: String,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicService.kt
@@ -1,7 +1,7 @@
 package team.incube.flooding.domain.dormitory.music.service
 
-import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicRequest
+import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicByUrlRequest
 
 interface ApplyWakeUpMusicService {
-    fun execute(request: ApplyWakeUpMusicRequest)
+    fun execute(request: ApplyWakeUpMusicByUrlRequest)
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -33,9 +33,7 @@ class ApplyWakeUpMusicServiceImpl(
         wakeUpMusicRepository.save(
             WakeUpMusicJpaEntity(
                 user = user,
-                musicUrl = request.musicUrl,
-                title = request.title,
-                artist = request.artist,
+                musicUrl = request.musicUrl
             ),
         )
     }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -3,7 +3,7 @@ package team.incube.flooding.domain.dormitory.music.service.impl
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.music.entity.WakeUpMusicJpaEntity
-import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicRequest
+import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicByUrlRequest
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRepository
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.domain.dormitory.music.service.ApplyWakeUpMusicService
@@ -20,7 +20,7 @@ class ApplyWakeUpMusicServiceImpl(
     }
 
     @Transactional
-    override fun execute(request: ApplyWakeUpMusicRequest) {
+    override fun execute(request: ApplyWakeUpMusicByUrlRequest) {
         val user = currentUserProvider.getCurrentUser()
 
         val histories = wakeUpMusicRepository.findAllByUserIdOrderByAppliedAtAsc(user.id)
@@ -33,7 +33,7 @@ class ApplyWakeUpMusicServiceImpl(
         wakeUpMusicRepository.save(
             WakeUpMusicJpaEntity(
                 user = user,
-                musicUrl = request.musicUrl
+                musicUrl = request.musicUrl,
             ),
         )
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- `ApplyWakeUpMusicByUrlRequest` 추가 — 기상송 신청 시 `musicUrl`만 받도록 변경
- `WakeUpMusicJpaEntity`의 `title`, `artist` 필드를 nullable로 변경
- `ApplyWakeUpMusicService` / `ServiceImpl` / `Controller`를 새 request로 교체
- `RecommendAiSongServiceImpl`에서 nullable `title`/`artist`를 `mapNotNull`로 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음