### PR TITLE
특정 학생 자습 금지 해제 기능 구현

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
@@ -20,6 +20,7 @@ import team.incube.flooding.domain.dormitory.study.service.CheckStudyAttendanceS
 import team.incube.flooding.domain.dormitory.study.service.GetStudyService
 import team.incube.flooding.domain.dormitory.study.service.StudyApplicationService
 import team.incube.flooding.domain.dormitory.study.service.SubscribeStudyAttendanceService
+import team.incube.flooding.domain.dormitory.study.service.UnbanStudyService
 import team.themoment.sdk.response.CommonApiResponse
 
 @Tag(name = "자습", description = "자습 신청 관련 API")
@@ -29,6 +30,7 @@ class StudyController(
     private val studyApplicationService: StudyApplicationService,
     private val cancelStudyService: CancelStudyService,
     private val banStudyService: BanStudyService,
+    private val unbanStudyService: UnbanStudyService,
     private val getStudyService: GetStudyService,
     private val subscribeStudyAttendanceService: SubscribeStudyAttendanceService,
     private val checkStudyAttendanceService: CheckStudyAttendanceService,
@@ -117,6 +119,22 @@ class StudyController(
         @Parameter(description = "금지할 학생의 ID") @PathVariable userId: Long,
     ): CommonApiResponse<Nothing> {
         banStudyService.execute(userId)
+        return CommonApiResponse.success("OK")
+    }
+
+    @Operation(
+        summary = "자습 금지 해제",
+        description = "특정 학생의 자습 금지 상태를 해제합니다. 관리자 또는 기자위 권한이 필요합니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "자습 금지 해제 성공"),
+        ApiResponse(responseCode = "404", description = "존재하지 않는 유저 또는 자습 금지 내역 없음"),
+    )
+    @DeleteMapping("/ban/{userId}")
+    fun unban(
+        @Parameter(description = "금지 해제할 학생의 ID") @PathVariable userId: Long,
+    ): CommonApiResponse<Nothing> {
+        unbanStudyService.execute(userId)
         return CommonApiResponse.success("OK")
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/repository/StudyBanJpaRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/repository/StudyBanJpaRepository.kt
@@ -10,6 +10,11 @@ interface StudyBanJpaRepository : JpaRepository<StudyBanJpaEntity, Long> {
         now: LocalDateTime,
     ): Boolean
 
+    fun findByUserIdAndBannedUntilAfter(
+        userId: Long,
+        now: LocalDateTime,
+    ): StudyBanJpaEntity?
+
     fun findAllByUserIdInAndBannedUntilAfter(
         userIds: Collection<Long>,
         now: LocalDateTime,

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/UnbanStudyService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/UnbanStudyService.kt
@@ -1,0 +1,5 @@
+package team.incube.flooding.domain.dormitory.study.service
+
+interface UnbanStudyService {
+    fun execute(targetUserId: Long)
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UnbanStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UnbanStudyServiceImpl.kt
@@ -18,15 +18,15 @@ class UnbanStudyServiceImpl(
     private val clock: Clock,
 ) : UnbanStudyService {
     override fun execute(targetUserId: Long) {
-        if (!userRepository.existsById(targetUserId)) {
-            throw ExpectedException("존재하지 않는 유저입니다.", HttpStatus.NOT_FOUND)
-        }
-
         val studyBan =
             studyBanJpaRepository.findByUserIdAndBannedUntilAfter(
                 targetUserId,
                 LocalDateTime.now(clock),
-            ) ?: throw ExpectedException("자습 금지 내역이 없습니다.", HttpStatus.NOT_FOUND)
+            ) ?: if (!userRepository.existsById(targetUserId)) {
+                throw ExpectedException("존재하지 않는 유저입니다.", HttpStatus.NOT_FOUND)
+            } else {
+                throw ExpectedException("자습 금지 내역이 없습니다.", HttpStatus.NOT_FOUND)
+            }
 
         studyBanJpaRepository.delete(studyBan)
     }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UnbanStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UnbanStudyServiceImpl.kt
@@ -1,0 +1,33 @@
+package team.incube.flooding.domain.dormitory.study.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
+import team.incube.flooding.domain.dormitory.study.service.UnbanStudyService
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.themoment.sdk.exception.ExpectedException
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+@Transactional
+class UnbanStudyServiceImpl(
+    private val userRepository: UserRepository,
+    private val studyBanJpaRepository: StudyBanJpaRepository,
+    private val clock: Clock,
+) : UnbanStudyService {
+    override fun execute(targetUserId: Long) {
+        if (!userRepository.existsById(targetUserId)) {
+            throw ExpectedException("존재하지 않는 유저입니다.", HttpStatus.NOT_FOUND)
+        }
+
+        val studyBan =
+            studyBanJpaRepository.findByUserIdAndBannedUntilAfter(
+                targetUserId,
+                LocalDateTime.now(clock),
+            ) ?: throw ExpectedException("자습 금지 내역이 없습니다.", HttpStatus.NOT_FOUND)
+
+        studyBanJpaRepository.delete(studyBan)
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -77,6 +77,11 @@ class SecurityConfig(
                         "/dormitory/studies/ban/**",
                     ).hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
                 it
+                    .requestMatchers(
+                        HttpMethod.DELETE,
+                        "/dormitory/studies/ban/**",
+                    ).hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
+                it
                     .requestMatchers(HttpMethod.GET, "/dormitory/studies/attendance")
                     .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
                 it

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/UnbanStudyServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/UnbanStudyServiceTest.kt
@@ -1,0 +1,95 @@
+package team.incube.flooding.domain.dormitory.study.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpStatus
+import team.incube.flooding.domain.dormitory.study.entity.StudyBanJpaEntity
+import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
+import team.incube.flooding.domain.dormitory.study.service.impl.UnbanStudyServiceImpl
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.themoment.sdk.exception.ExpectedException
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class UnbanStudyServiceTest :
+    BehaviorSpec({
+        val userRepository = mockk<UserRepository>()
+        val studyBanJpaRepository = mockk<StudyBanJpaRepository>()
+        val clock = Clock.fixed(Instant.parse("2026-04-29T12:00:00Z"), ZoneId.of("Asia/Seoul"))
+        val service = UnbanStudyServiceImpl(userRepository, studyBanJpaRepository, clock)
+
+        beforeEach { clearAllMocks() }
+
+        fun user(id: Long) =
+            UserJpaEntity(
+                id = id,
+                name = "학생$id",
+                sex = Sex.MAN,
+                email = "student$id@test.com",
+                studentNumber = 1101,
+                role = Role.GENERAL_STUDENT,
+                dormitoryRoom = 101,
+            )
+
+        given("존재하지 않는 학생 ID로 요청할 때") {
+            `when`("자습 금지를 해제하면") {
+                then("NOT_FOUND 예외가 발생한다") {
+                    every { userRepository.existsById(1L) } returns false
+
+                    val exception = shouldThrow<ExpectedException> { service.execute(1L) }
+
+                    exception.statusCode shouldBe HttpStatus.NOT_FOUND
+                    exception.message shouldBe "존재하지 않는 유저입니다."
+                }
+            }
+        }
+
+        given("학생은 존재하지만 활성 자습 금지 내역이 없을 때") {
+            `when`("자습 금지를 해제하면") {
+                then("NOT_FOUND 예외가 발생한다") {
+                    val now = LocalDateTime.now(clock)
+                    every { userRepository.existsById(1L) } returns true
+                    every { studyBanJpaRepository.findByUserIdAndBannedUntilAfter(1L, now) } returns null
+
+                    val exception = shouldThrow<ExpectedException> { service.execute(1L) }
+
+                    exception.statusCode shouldBe HttpStatus.NOT_FOUND
+                    exception.message shouldBe "자습 금지 내역이 없습니다."
+                }
+            }
+        }
+
+        given("활성 자습 금지 상태인 학생이 있을 때") {
+            `when`("자습 금지를 해제하면") {
+                then("자습 금지 내역을 삭제한다") {
+                    val targetUser = user(1L)
+                    val now = LocalDateTime.now(clock)
+                    val studyBan =
+                        StudyBanJpaEntity(
+                            id = 1L,
+                            user = targetUser,
+                            bannedAt = now.minusDays(1),
+                            bannedUntil = now.plusDays(6),
+                        )
+                    every { userRepository.existsById(1L) } returns true
+                    every { studyBanJpaRepository.findByUserIdAndBannedUntilAfter(1L, now) } returns studyBan
+                    justRun { studyBanJpaRepository.delete(studyBan) }
+
+                    service.execute(1L)
+
+                    verify(exactly = 1) { studyBanJpaRepository.delete(studyBan) }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/UnbanStudyServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/UnbanStudyServiceTest.kt
@@ -42,9 +42,11 @@ class UnbanStudyServiceTest :
                 dormitoryRoom = 101,
             )
 
-        given("존재하지 않는 학생 ID로 요청할 때") {
+        given("활성 자습 금지 내역이 없고 유저도 존재하지 않을 때") {
             `when`("자습 금지를 해제하면") {
-                then("NOT_FOUND 예외가 발생한다") {
+                then("NOT_FOUND 예외 - 존재하지 않는 유저") {
+                    val now = LocalDateTime.now(clock)
+                    every { studyBanJpaRepository.findByUserIdAndBannedUntilAfter(1L, now) } returns null
                     every { userRepository.existsById(1L) } returns false
 
                     val exception = shouldThrow<ExpectedException> { service.execute(1L) }
@@ -57,10 +59,10 @@ class UnbanStudyServiceTest :
 
         given("학생은 존재하지만 활성 자습 금지 내역이 없을 때") {
             `when`("자습 금지를 해제하면") {
-                then("NOT_FOUND 예외가 발생한다") {
+                then("NOT_FOUND 예외 - 자습 금지 내역 없음") {
                     val now = LocalDateTime.now(clock)
-                    every { userRepository.existsById(1L) } returns true
                     every { studyBanJpaRepository.findByUserIdAndBannedUntilAfter(1L, now) } returns null
+                    every { userRepository.existsById(1L) } returns true
 
                     val exception = shouldThrow<ExpectedException> { service.execute(1L) }
 
@@ -82,7 +84,6 @@ class UnbanStudyServiceTest :
                             bannedAt = now.minusDays(1),
                             bannedUntil = now.plusDays(6),
                         )
-                    every { userRepository.existsById(1L) } returns true
                     every { studyBanJpaRepository.findByUserIdAndBannedUntilAfter(1L, now) } returns studyBan
                     justRun { studyBanJpaRepository.delete(studyBan) }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- `DELETE /dormitory/studies/ban/{userId}` 엔드포인트 추가
- `UnbanStudyService` / `UnbanStudyServiceImpl` 구현 — 활성 자습 금지 내역 조회 후 삭제
- `StudyBanJpaRepository`에 `findByUserIdAndBannedUntilAfter` 쿼리 메서드 추가
- `SecurityConfig`에 DELETE /ban/** 관리자/기자위 권한 설정 추가
- 서비스 단위 테스트 3케이스 작성 (유저 없음 / 금지 내역 없음 / 정상 해제)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음