### PR TITLE
자습 조회 응답에 sex 필드 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
@@ -1,9 +1,12 @@
 package team.incube.flooding.domain.dormitory.study.presentation.data.response
 
+import team.incube.flooding.domain.user.entity.Sex
+
 data class GetStudyResponse(
     val userId: Long,
     val name: String,
     val studentNumber: Int,
+    val sex: Sex,
     val isBanned: Boolean,
     val isChecked: Boolean,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
@@ -35,6 +35,7 @@ class GetStudyServiceImpl(
                     userId = it.id,
                     name = it.name,
                     studentNumber = it.studentNumber,
+                    sex = it.sex,
                     isBanned = it.id in bannedUserIds,
                     isChecked = it.id in checkedUserIds,
                 )

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
@@ -31,10 +31,11 @@ class GetStudyServiceTest :
         fun user(
             id: Long,
             studentNumber: Int,
+            sex: Sex = Sex.MAN,
         ) = UserJpaEntity(
             id = id,
             name = "학생$id",
-            sex = Sex.MAN,
+            sex = sex,
             email = "student$id@test.com",
             studentNumber = studentNumber,
             role = Role.GENERAL_STUDENT,
@@ -152,6 +153,26 @@ class GetStudyServiceTest :
 
                     result[0].isBanned shouldBe true
                     result[0].isChecked shouldBe true
+                }
+            }
+        }
+
+        given("성별이 다른 학생 2명이 신청했을 때") {
+            val manUser = user(id = 1L, studentNumber = 1101, sex = Sex.MAN)
+            val womanUser = user(id = 2L, studentNumber = 1102, sex = Sex.WOMAN)
+
+            `when`("자습 신청자 목록을 조회하면") {
+                then("sex 필드가 올바르게 매핑된다") {
+                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L)
+                    every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
+                        emptyList()
+                    every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
+                    every { userRepository.findAllById(any()) } returns listOf(manUser, womanUser)
+
+                    val result = service.execute().sortedBy { it.userId }
+
+                    result[0].sex shouldBe Sex.MAN
+                    result[1].sex shouldBe Sex.WOMAN
                 }
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- `GetStudyResponse`에 `sex` 필드 추가
- `GetStudyServiceImpl`에서 유저의 `sex` 값을 응답에 매핑

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음