### PR TITLE
안마의자 API 권한을 전체 역할 허용으로 변경

### DIFF
--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -89,8 +89,9 @@ class SecurityConfig(
                     .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
 
                 // massage
-                it.requestMatchers(HttpMethod.POST, "/dormitory/massages").hasRole(Role.GENERAL_STUDENT.name)
-                it.requestMatchers(HttpMethod.DELETE, "/dormitory/massages").hasRole(Role.GENERAL_STUDENT.name)
+                it.requestMatchers(HttpMethod.GET, "/dormitory/massages").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/dormitory/massages").authenticated()
+                it.requestMatchers(HttpMethod.DELETE, "/dormitory/massages").authenticated()
 
                 // penalty
                 it


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- `SecurityConfig`의 안마의자 API 권한을 `GENERAL_STUDENT` 전용에서 인증된 모든 역할로 변경
- `GET /dormitory/massages` 권한 규칙 추가
- `POST`, `DELETE /dormitory/massages` 권한을 `authenticated()`로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음