### PR TITLE
DG 로그인 권한 초기화 및 기상음악 신청 응답 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/auth/service/SignInService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/auth/service/SignInService.kt
@@ -42,7 +42,7 @@ class SignInService(
 
         val student =
             oauthUser.student ?: throw ExpectedException("학생 정보를 가져올 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
-        val user = userRepository.findById(student.id).orElse(createUserService.execute(oauthUser))
+        val user = userRepository.findById(student.id).orElseGet { createUserService.execute(oauthUser) }
 
         val accessToken = jwtProvider.generateAccessToken(user.id)
         val refreshToken = jwtProvider.generateRefreshToken(user.id)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
@@ -60,10 +60,8 @@ class WakeUpMusicController(
     @PostMapping
     fun applyWakeUpMusic(
         @RequestBody request: ApplyWakeUpMusicByUrlRequest,
-    ): CommonApiResponse<Nothing> {
-        applyWakeUpMusicService.execute(request)
-        return CommonApiResponse.success("OK")
-    }
+    ): CommonApiResponse<WakeUpMusicResponse> =
+        CommonApiResponse.success("OK", applyWakeUpMusicService.execute(request))
 
     @Operation(
         summary = "기상음악 취소",

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicService.kt
@@ -1,7 +1,8 @@
 package team.incube.flooding.domain.dormitory.music.service
 
 import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicByUrlRequest
+import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
 
 interface ApplyWakeUpMusicService {
-    fun execute(request: ApplyWakeUpMusicByUrlRequest)
+    fun execute(request: ApplyWakeUpMusicByUrlRequest): WakeUpMusicResponse
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.music.entity.WakeUpMusicJpaEntity
 import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicByUrlRequest
+import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRepository
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.domain.dormitory.music.service.ApplyWakeUpMusicService
@@ -20,7 +21,7 @@ class ApplyWakeUpMusicServiceImpl(
     }
 
     @Transactional
-    override fun execute(request: ApplyWakeUpMusicByUrlRequest) {
+    override fun execute(request: ApplyWakeUpMusicByUrlRequest): WakeUpMusicResponse {
         val user = currentUserProvider.getCurrentUser()
 
         val histories = wakeUpMusicRepository.findAllByUserIdOrderByAppliedAtAsc(user.id)
@@ -30,11 +31,19 @@ class ApplyWakeUpMusicServiceImpl(
             wakeUpMusicRepository.deleteAllInBatch(toDelete)
         }
 
-        wakeUpMusicRepository.save(
-            WakeUpMusicJpaEntity(
-                user = user,
-                musicUrl = request.musicUrl,
-            ),
+        val saved =
+            wakeUpMusicRepository.save(
+                WakeUpMusicJpaEntity(
+                    user = user,
+                    musicUrl = request.musicUrl,
+                ),
+            )
+
+        return WakeUpMusicResponse(
+            id = saved.id,
+            musicUrl = saved.musicUrl,
+            appliedAt = saved.appliedAt,
+            likeCount = 0,
         )
     }
 }

--- a/src/test/kotlin/team/incube/flooding/domain/auth/service/SignInServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/auth/service/SignInServiceTest.kt
@@ -1,0 +1,79 @@
+package team.incube.flooding.domain.auth.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import team.incube.flooding.domain.auth.adapter.RefreshTokenRedisAdapter
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.incube.flooding.domain.user.service.CreateUserService
+import team.incube.flooding.global.auth.provider.JwtProvider
+import team.themoment.datagsm.sdk.oauth.DataGsmOAuthClient
+import team.themoment.datagsm.sdk.oauth.model.Student
+import team.themoment.datagsm.sdk.oauth.model.TokenResponse
+import team.themoment.datagsm.sdk.oauth.model.UserInfo
+import java.util.Optional
+
+class SignInServiceTest :
+    BehaviorSpec({
+        val dataGsmClient = mockk<DataGsmOAuthClient>()
+        val userRepository = mockk<UserRepository>()
+        val createUserService = mockk<CreateUserService>()
+        val jwtProvider = mockk<JwtProvider>()
+        val refreshTokenRedisAdapter = mockk<RefreshTokenRedisAdapter>()
+
+        val service =
+            SignInService(
+                dataGsmClient = dataGsmClient,
+                userRepository = userRepository,
+                createUserService = createUserService,
+                jwtProvider = jwtProvider,
+                refreshTokenRedisAdapter = refreshTokenRedisAdapter,
+            )
+
+        given("이미 가입된 학생이 DG 로그인할 때") {
+            val studentId = 1L
+            val student =
+                Student().apply {
+                    id = studentId
+                }
+            val oauthUser =
+                UserInfo().apply {
+                    setIsStudent(true)
+                    setStudent(student)
+                }
+            val user =
+                UserJpaEntity(
+                    id = studentId,
+                    name = "기존 유저",
+                    sex = Sex.MAN,
+                    email = "student@test.com",
+                    studentNumber = 1101,
+                    role = Role.ADMIN,
+                    dormitoryRoom = 101,
+                )
+
+            every { dataGsmClient.exchangeCodeForToken("code", "redirect") } returns
+                TokenResponse("dg-access-token", "Bearer", 3600, null, null)
+            every { dataGsmClient.getUserInfo("dg-access-token") } returns oauthUser
+            every { userRepository.findById(studentId) } returns Optional.of(user)
+            every { jwtProvider.generateAccessToken(studentId) } returns "access-token"
+            every { jwtProvider.generateRefreshToken(studentId) } returns "refresh-token"
+            every { refreshTokenRedisAdapter.save(studentId, "refresh-token") } returns Unit
+
+            `when`("로그인을 처리하면") {
+                val response = service.execute("code", "redirect")
+
+                then("유저 생성 로직을 실행하지 않고 기존 권한을 유지한다") {
+                    response.accessToken shouldBe "access-token"
+                    response.refreshToken shouldBe "refresh-token"
+                    user.role shouldBe Role.ADMIN
+                    verify(exactly = 0) { createUserService.execute(any()) }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicControllerTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicControllerTest.kt
@@ -1,0 +1,59 @@
+package team.incube.flooding.domain.dormitory.music.presentation.controller
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpStatus
+import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicByUrlRequest
+import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
+import team.incube.flooding.domain.dormitory.music.service.ApplyWakeUpMusicService
+import team.incube.flooding.domain.dormitory.music.service.CancelLikeWakeUpMusicService
+import team.incube.flooding.domain.dormitory.music.service.CancelWakeUpMusicService
+import team.incube.flooding.domain.dormitory.music.service.GetWakeUpMusicService
+import team.incube.flooding.domain.dormitory.music.service.LikeWakeUpMusicService
+import java.time.LocalDateTime
+
+class WakeUpMusicControllerTest :
+    BehaviorSpec({
+        val applyWakeUpMusicService = mockk<ApplyWakeUpMusicService>()
+        val cancelWakeUpMusicService = mockk<CancelWakeUpMusicService>()
+        val getWakeUpMusicService = mockk<GetWakeUpMusicService>()
+        val likeWakeUpMusicService = mockk<LikeWakeUpMusicService>()
+        val cancelLikeWakeUpMusicService = mockk<CancelLikeWakeUpMusicService>()
+
+        val controller =
+            WakeUpMusicController(
+                applyWakeUpMusicService = applyWakeUpMusicService,
+                cancelWakeUpMusicService = cancelWakeUpMusicService,
+                getWakeUpMusicService = getWakeUpMusicService,
+                likeWakeUpMusicService = likeWakeUpMusicService,
+                cancelLikeWakeUpMusicService = cancelLikeWakeUpMusicService,
+            )
+
+        given("기상음악 신청이 성공할 때") {
+            val request = ApplyWakeUpMusicByUrlRequest("https://youtube.com/watch?v=test")
+            val appliedAt = LocalDateTime.of(2026, 4, 30, 8, 0)
+            val serviceResponse =
+                WakeUpMusicResponse(
+                    id = 1L,
+                    musicUrl = request.musicUrl,
+                    appliedAt = appliedAt,
+                    likeCount = 0,
+                )
+            every { applyWakeUpMusicService.execute(request) } returns serviceResponse
+
+            `when`("컨트롤러가 응답을 만들면") {
+                val response = controller.applyWakeUpMusic(request)
+
+                then("신청된 기상음악 데이터가 응답에 포함된다") {
+                    response.status shouldBe HttpStatus.OK
+                    response.code shouldBe 200
+                    response.message shouldBe "OK"
+                    response.data shouldBe serviceResponse
+                    verify(exactly = 1) { applyWakeUpMusicService.execute(request) }
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음


## 📝작업 내용

- DG 로그인 시 기존 유저도 `createUserService.execute(oauthUser)`가 즉시 실행되어 DG 권한으로 덮어써지던 문제를 수정했습니다.
- `orElse(createUserService.execute(oauthUser))`를 `orElseGet { createUserService.execute(oauthUser) }`으로 변경해 DB에 유저가 없을 때만 생성 로직이 실행되도록 했습니다.
- 기상음악 신청 API가 200 응답만 내려주고 응답 데이터가 비어 있던 문제를 수정했습니다.
- 기상음악 신청 서비스가 저장된 `WakeUpMusicResponse`를 반환하고, 컨트롤러가 이를 `CommonApiResponse.data`에 담아 반환하도록 변경했습니다.
- DG 로그인 권한 유지와 기상음악 신청 응답 데이터 포함 여부를 검증하는 테스트를 추가했습니다.

### 스크린샷 (선택)

없음


## 💬리뷰 요구사항(선택)

- `./gradlew test` 통과
- `./gradlew ktlintCheck` 통과
