### PR TITLE
내 정보 조회 시 동아리 신청 여부 반환

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubAutonomousApplicationRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubAutonomousApplicationRepository.kt
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 import team.incube.flooding.domain.club.entity.ClubAutonomousApplicationJpaEntity
 
 interface ClubAutonomousApplicationRepository : JpaRepository<ClubAutonomousApplicationJpaEntity, Long> {
+    fun existsByUserId(userId: Long): Boolean
+
     fun existsByClubIdAndUserId(
         clubId: Long,
         userId: Long,

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormSubmissionRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormSubmissionRepository.kt
@@ -7,6 +7,8 @@ import team.incube.flooding.domain.club.entity.ClubFormSubmissionJpaEntity
 interface ClubFormSubmissionRepository : JpaRepository<ClubFormSubmissionJpaEntity, Long> {
     fun existsByFormId(formId: Long): Boolean
 
+    fun existsByUserId(userId: Long): Boolean
+
     fun existsByFormIdAndUserId(
         formId: Long,
         userId: Long,

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/GetMeResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/GetMeResponse.kt
@@ -19,11 +19,13 @@ data class GetMeResponse(
     val specialty: String?,
     val penaltyScore: Int,
     val isBanned: Boolean,
+    val hasClubApplication: Boolean,
 ) {
     companion object {
         fun from(
             user: UserJpaEntity,
             isBanned: Boolean,
+            hasClubApplication: Boolean,
         ) = GetMeResponse(
             id = user.id,
             name = user.name,
@@ -39,6 +41,7 @@ data class GetMeResponse(
             specialty = user.specialty,
             penaltyScore = user.penaltyScore,
             isBanned = isBanned,
+            hasClubApplication = hasClubApplication,
         )
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/impl/GetMeServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/impl/GetMeServiceImpl.kt
@@ -2,6 +2,8 @@ package team.incube.flooding.domain.user.service.impl
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.club.repository.ClubAutonomousApplicationRepository
+import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
 import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
 import team.incube.flooding.domain.user.presentation.data.response.GetMeResponse
 import team.incube.flooding.domain.user.service.GetMeService
@@ -13,12 +15,17 @@ import java.time.LocalDateTime
 class GetMeServiceImpl(
     private val currentUserProvider: CurrentUserProvider,
     private val studyBanJpaRepository: StudyBanJpaRepository,
+    private val clubFormSubmissionRepository: ClubFormSubmissionRepository,
+    private val clubAutonomousApplicationRepository: ClubAutonomousApplicationRepository,
     private val clock: Clock,
 ) : GetMeService {
     @Transactional(readOnly = true)
     override fun execute(): GetMeResponse {
         val user = currentUserProvider.getCurrentUser()
         val isBanned = studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now(clock))
-        return GetMeResponse.from(user, isBanned)
+        val hasClubApplication =
+            clubFormSubmissionRepository.existsByUserId(user.id) ||
+                clubAutonomousApplicationRepository.existsByUserId(user.id)
+        return GetMeResponse.from(user, isBanned, hasClubApplication)
     }
 }

--- a/src/test/kotlin/team/incube/flooding/domain/user/service/GetMeServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/user/service/GetMeServiceTest.kt
@@ -1,0 +1,105 @@
+package team.incube.flooding.domain.user.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import team.incube.flooding.domain.club.repository.ClubAutonomousApplicationRepository
+import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
+import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.domain.user.service.impl.GetMeServiceImpl
+import team.incube.flooding.global.security.util.CurrentUserProvider
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+class GetMeServiceTest :
+    BehaviorSpec({
+        val currentUserProvider = mockk<CurrentUserProvider>()
+        val studyBanJpaRepository = mockk<StudyBanJpaRepository>()
+        val clubFormSubmissionRepository = mockk<ClubFormSubmissionRepository>()
+        val clubAutonomousApplicationRepository = mockk<ClubAutonomousApplicationRepository>()
+        val clock = Clock.fixed(Instant.parse("2026-05-01T00:00:00Z"), ZoneId.of("UTC"))
+
+        val service =
+            GetMeServiceImpl(
+                currentUserProvider,
+                studyBanJpaRepository,
+                clubFormSubmissionRepository,
+                clubAutonomousApplicationRepository,
+                clock,
+            )
+
+        fun user() =
+            UserJpaEntity(
+                id = 1L,
+                name = "테스트",
+                sex = Sex.MAN,
+                email = "test@test.com",
+                studentNumber = 10101,
+                role = Role.GENERAL_STUDENT,
+                dormitoryRoom = 101,
+            )
+
+        fun stubUserContext(user: UserJpaEntity) {
+            every { currentUserProvider.getCurrentUser() } returns user
+            every { studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, any()) } returns false
+        }
+
+        beforeTest {
+            clearMocks(
+                currentUserProvider,
+                studyBanJpaRepository,
+                clubFormSubmissionRepository,
+                clubAutonomousApplicationRepository,
+            )
+        }
+
+        given("정규 동아리 신청 기록이 있는 사용자가") {
+            `when`("내 정보를 조회하면") {
+                then("hasClubApplication이 true다") {
+                    val currentUser = user()
+                    stubUserContext(currentUser)
+                    every { clubFormSubmissionRepository.existsByUserId(currentUser.id) } returns true
+
+                    val response = service.execute()
+
+                    response.hasClubApplication shouldBe true
+                }
+            }
+        }
+
+        given("자율 동아리 신청 기록이 있는 사용자가") {
+            `when`("내 정보를 조회하면") {
+                then("hasClubApplication이 true다") {
+                    val currentUser = user()
+                    stubUserContext(currentUser)
+                    every { clubFormSubmissionRepository.existsByUserId(currentUser.id) } returns false
+                    every { clubAutonomousApplicationRepository.existsByUserId(currentUser.id) } returns true
+
+                    val response = service.execute()
+
+                    response.hasClubApplication shouldBe true
+                }
+            }
+        }
+
+        given("동아리 신청 기록이 없는 사용자가") {
+            `when`("내 정보를 조회하면") {
+                then("hasClubApplication이 false다") {
+                    val currentUser = user()
+                    stubUserContext(currentUser)
+                    every { clubFormSubmissionRepository.existsByUserId(currentUser.id) } returns false
+                    every { clubAutonomousApplicationRepository.existsByUserId(currentUser.id) } returns false
+
+                    val response = service.execute()
+
+                    response.hasClubApplication shouldBe false
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/team/incube/flooding/domain/user/service/GetMeServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/user/service/GetMeServiceTest.kt
@@ -65,6 +65,7 @@ class GetMeServiceTest :
                     val currentUser = user()
                     stubUserContext(currentUser)
                     every { clubFormSubmissionRepository.existsByUserId(currentUser.id) } returns true
+                    every { clubAutonomousApplicationRepository.existsByUserId(currentUser.id) } returns false
 
                     val response = service.execute()
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #120

## 📝작업 내용

`/users/me` API 응답에 현재 사용자의 동아리 신청 여부를 나타내는 `hasClubApplication` 필드를 추가했습니다.

- `ClubFormSubmissionRepository`, `ClubAutonomousApplicationRepository`에 `existsByUserId` 쿼리 메서드 추가
- `GetMeServiceImpl`에서 정규 동아리 폼 신청 또는 자율 동아리 신청 이력이 있으면 `hasClubApplication = true` 반환
- `GetMeResponse`에 `hasClubApplication` 필드 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음