### PR TITLE
동아리 단건 조회 응답에 leaderId 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/data/response/GetClubResponse.kt
@@ -10,6 +10,7 @@ data class GetClubResponse(
         val id: Long,
         val name: String,
         val type: String,
+        val leaderId: Long?,
         val leader: String?,
         val description: String?,
         val imageUrl: String?,

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
@@ -43,6 +43,7 @@ class GetClubServiceImpl(
                     id = club.id,
                     name = club.name,
                     type = club.type.name,
+                    leaderId = club.leader?.id,
                     leader = club.leader?.name,
                     description = club.description,
                     imageUrl = club.imageUrl,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

GET /clubs/{clubId} 응답의 club.detail에 leaderId 필드를 추가합니다.

기존에는 leader 이름(String)만 반환하고 있어 프론트엔드에서 리더 여부 판별 시 ID를 활용할 수 없었습니다.
leader?.id를 leaderId(Long?)로 함께 반환하도록 GetClubResponse.ClubDetail과 GetClubServiceImpl을 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음