### PR TITLE
시연을 위한 자습/안마의자 신청 시간 검증 임시 비활성화

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
@@ -23,9 +23,9 @@ class ApplyMassageServiceImpl(
 
         val now = LocalTime.now()
 
-        if (now.isBefore(massageProperties.openTime)) {
-            throw ExpectedException("안마의자 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
-        }
+//        if (now.isBefore(massageProperties.openTime)) {
+//            throw ExpectedException("안마의자 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
+//        }
 
         val lock = redissonClient.getLock(massageProperties.lockKey)
         val acquired = lock.tryLock(5, 3, TimeUnit.SECONDS)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
@@ -39,9 +39,9 @@ class StudyApplicationServiceImpl(
                 now.isBefore(studyProperties.openTime) || now.isAfter(studyProperties.closeTime)
             }
 
-        if (outOfRange) {
-            throw ExpectedException("자습 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
-        }
+//        if (outOfRange) {
+//            throw ExpectedException("자습 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
+//        }
 
         if (studyRedisAdapter.getApplicationStatus(user.id) == StudyApplicationStatus.BANNED ||
             studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now(clock))


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

시연 일정으로 인해 자습 신청 및 안마의자 신청의 시간 제한 검증 로직을 임시로 주석 처리하였습니다.

- StudyApplicationServiceImpl: 자습 신청 가능 시간(20:00~21:00) 검증 주석 처리
- ApplyMassageServiceImpl: 안마의자 신청 가능 시간(20:20~) 검증 주석 처리

시연 완료 후 주석을 해제해야 합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 시연 완료 후 반드시 주석 해제 및 해당 브랜치 머지 없이 삭제해주세요