### PR TITLE
AI 엔드포인트 접근 권한 오류 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -48,8 +48,8 @@ class SecurityConfig(
                 it.requestMatchers("/auth/signin", "/auth/reissue").permitAll()
                 it.requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
                 // ai
-                it.requestMatchers(HttpMethod.POST, "/ai/chat").hasRole(Role.GENERAL_STUDENT.name)
-                it.requestMatchers(HttpMethod.POST, "/ai/song").hasRole(Role.GENERAL_STUDENT.name)
+                it.requestMatchers(HttpMethod.POST, "/ai/chat").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/ai/song").authenticated()
 
                 // club
                 it


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

/ai/chat, /ai/song 엔드포인트의 접근 권한이 GENERAL_STUDENT로만 제한되어 있어
학생회, 관리자 등 다른 권한을 가진 사용자가 403 오류를 받는 문제가 있었습니다.
해당 엔드포인트는 로그인한 모든 사용자가 사용할 수 있어야 하므로 authenticated()로 변경하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음