### PR TITLE
자습/기상음악 버그 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
@@ -28,5 +28,5 @@ class WakeUpMusicJpaEntity(
     @field:Column(name = "artist")
     val artist: String? = null,
     @field:Column(name = "applied_at", nullable = false)
-    val appliedAt: LocalDateTime = LocalDateTime.now(),
+    val appliedAt: LocalDateTime,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -9,12 +9,15 @@ import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRep
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.domain.dormitory.music.service.ApplyWakeUpMusicService
 import team.incube.flooding.global.security.util.CurrentUserProvider
+import java.time.Clock
+import java.time.LocalDateTime
 
 @Service
 class ApplyWakeUpMusicServiceImpl(
     private val wakeUpMusicRepository: WakeUpMusicRepository,
     private val wakeUpMusicLikeRepository: WakeUpMusicLikeRepository,
     private val currentUserProvider: CurrentUserProvider,
+    private val clock: Clock,
 ) : ApplyWakeUpMusicService {
     companion object {
         private const val MAX_HISTORY_SIZE = 5
@@ -36,6 +39,7 @@ class ApplyWakeUpMusicServiceImpl(
                 WakeUpMusicJpaEntity(
                     user = user,
                     musicUrl = request.musicUrl,
+                    appliedAt = LocalDateTime.now(clock),
                 ),
             )
 

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -69,8 +69,8 @@ class SecurityConfig(
                     ).hasAnyRole(Role.GENERAL_STUDENT.name, Role.STUDENT_COUNCIL.name, Role.ADMIN.name)
 
                 // study
-                it.requestMatchers(HttpMethod.POST, "/dormitory/studies").hasRole(Role.GENERAL_STUDENT.name)
-                it.requestMatchers(HttpMethod.DELETE, "/dormitory/studies").hasRole(Role.GENERAL_STUDENT.name)
+                it.requestMatchers(HttpMethod.POST, "/dormitory/studies").authenticated()
+                it.requestMatchers(HttpMethod.DELETE, "/dormitory/studies").authenticated()
                 it
                     .requestMatchers(
                         HttpMethod.POST,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

### 자습 신청/취소 403 오류 수정
- `SecurityConfig`에서 `POST /dormitory/studies`, `DELETE /dormitory/studies` 접근 권한을 `hasRole(GENERAL_STUDENT)` → `authenticated()`로 변경
- `STUDENT_COUNCIL` 등 GENERAL_STUDENT 이외의 Role을 가진 학생도 자습 신청/취소가 가능하도록 수정
- 마사지, AI 엔드포인트와 동일한 방식으로 통일

### 기상음악 GET 빈값 수정
- `WakeUpMusicJpaEntity.appliedAt`의 기본값 `LocalDateTime.now()`(JVM 타임존 의존)를 제거
- `ApplyWakeUpMusicServiceImpl`에 `Clock` 빈을 주입하여 `LocalDateTime.now(clock)`(KST)으로 저장
- GET 조회의 날짜 범위 쿼리와 저장 시점의 타임존을 일치시켜 빈값 반환 문제 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음