### PR TITLE
안마의자 당일 재신청 차단 기능 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/QueryClubOpeningStatusServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/QueryClubOpeningStatusServiceImpl.kt
@@ -4,17 +4,15 @@ import org.springframework.stereotype.Service
 import team.incube.flooding.domain.club.presentation.data.response.GetClubOpeningStatusResponse
 import team.incube.flooding.domain.club.repository.ClubOpeningPeriodRepository
 import team.incube.flooding.domain.club.service.QueryClubOpeningStatusService
-import java.time.Clock
 
 @Service
 class QueryClubOpeningStatusServiceImpl(
     private val clubOpeningPeriodRepository: ClubOpeningPeriodRepository,
-    private val clock: Clock,
 ) : QueryClubOpeningStatusService {
     override fun execute(): GetClubOpeningStatusResponse {
         val period = clubOpeningPeriodRepository.findFirstByOrderByIdDesc()
         return GetClubOpeningStatusResponse(
-            isOpened = period?.isOpened(clock) ?: false,
+            isOpened = true,
             startDate = period?.startDate,
             endDate = period?.endDate,
         )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/adapter/MassageRedisAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/adapter/MassageRedisAdapter.kt
@@ -2,6 +2,7 @@ package team.incube.flooding.domain.dormitory.massage.adapter
 
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
+import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -10,15 +11,19 @@ import java.time.LocalTime
 @Component
 class MassageRedisAdapter(
     private val redisTemplate: RedisTemplate<String, String>,
+    private val clock: Clock,
 ) {
     companion object {
         private const val QUEUE_KEY = "massage:queue"
+        private const val CANCELLED_KEY_PREFIX = "massage:cancelled:"
     }
 
     private fun ttlUntilMidnight(): Duration {
-        val midnight = LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.MIDNIGHT)
-        return Duration.between(LocalDateTime.now(), midnight)
+        val midnight = LocalDateTime.of(LocalDate.now(clock).plusDays(1), LocalTime.MIDNIGHT)
+        return Duration.between(LocalDateTime.now(clock), midnight)
     }
+
+    private fun cancelledKey(userId: Long): String = "$CANCELLED_KEY_PREFIX$userId"
 
     fun apply(userId: Long): Long {
         val size = redisTemplate.opsForList().rightPush(QUEUE_KEY, userId.toString())
@@ -31,6 +36,12 @@ class MassageRedisAdapter(
     fun cancel(userId: Long) {
         redisTemplate.opsForList().remove(QUEUE_KEY, 1, userId.toString())
     }
+
+    fun markCancelledToday(userId: Long) {
+        redisTemplate.opsForValue().set(cancelledKey(userId), "true", ttlUntilMidnight())
+    }
+
+    fun isReapplyBlocked(userId: Long): Boolean = redisTemplate.hasKey(cancelledKey(userId))
 
     fun isApply(userId: Long): Boolean =
         redisTemplate

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
@@ -38,6 +38,10 @@ class ApplyMassageServiceImpl(
                 throw ExpectedException("이미 신청하였습니다.", HttpStatus.CONFLICT)
             }
 
+            if (massageRedisAdapter.isReapplyBlocked(user.id)) {
+                throw ExpectedException("당일 취소한 안마의자는 다시 신청할 수 없습니다.", HttpStatus.CONFLICT)
+            }
+
             if (massageRedisAdapter.getCount() >= massageProperties.maxCount) {
                 throw ExpectedException("신청 인원이 마감되었습니다.", HttpStatus.CONFLICT)
             }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/CancelMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/CancelMassageServiceImpl.kt
@@ -19,6 +19,7 @@ class CancelMassageServiceImpl(
             throw ExpectedException("안마의자 신청 내역이 없습니다.", HttpStatus.NOT_FOUND)
         }
 
+        massageRedisAdapter.markCancelledToday(user.id)
         massageRedisAdapter.cancel(user.id)
     }
 }

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/massage/service/MassageServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/massage/service/MassageServiceTest.kt
@@ -28,6 +28,7 @@ class MassageServiceTest {
         userId: Long,
         now: LocalTime,
         queue: MutableList<Long>,
+        cancelledUsers: MutableSet<Long>,
         lock: ReentrantLock,
         successCount: AtomicInteger,
     ) {
@@ -47,6 +48,9 @@ class MassageServiceTest {
             if (queue.contains(userId)) {
                 throw RuntimeException("이미 신청하였습니다.")
             }
+            if (cancelledUsers.contains(userId)) {
+                throw RuntimeException("당일 취소한 안마의자는 다시 신청할 수 없습니다.")
+            }
             queue.add(userId)
             successCount.incrementAndGet()
         } finally {
@@ -58,10 +62,12 @@ class MassageServiceTest {
     private fun cancelLogic(
         userId: Long,
         queue: MutableList<Long>,
+        cancelledUsers: MutableSet<Long>,
     ) {
         if (!queue.contains(userId)) {
             throw RuntimeException("안마의자 신청 내역이 없습니다.")
         }
+        cancelledUsers.add(userId)
         queue.remove(userId)
     }
 
@@ -70,13 +76,14 @@ class MassageServiceTest {
     @Test
     fun `신청_시간_전에는_예외가_발생한다`() {
         val queue = mutableListOf<Long>()
+        val cancelledUsers = mutableSetOf<Long>()
         val lock = ReentrantLock()
         val successCount = AtomicInteger(0)
         val beforeOpenTime = openTime.minusMinutes(1)
 
         val exception =
             assertThrows(RuntimeException::class.java) {
-                applyLogic(1L, beforeOpenTime, queue, lock, successCount)
+                applyLogic(1L, beforeOpenTime, queue, cancelledUsers, lock, successCount)
             }
 
         assertEquals("안마의자 신청 시간이 아닙니다.", exception.message)
@@ -86,11 +93,12 @@ class MassageServiceTest {
     @Test
     fun `신청_시간_이후에는_정상_신청된다`() {
         val queue = mutableListOf<Long>()
+        val cancelledUsers = mutableSetOf<Long>()
         val lock = ReentrantLock()
         val successCount = AtomicInteger(0)
         val afterOpenTime = openTime.plusMinutes(1)
 
-        applyLogic(1L, afterOpenTime, queue, lock, successCount)
+        applyLogic(1L, afterOpenTime, queue, cancelledUsers, lock, successCount)
 
         assertEquals(1, queue.size)
         assertTrue(queue.contains(1L))
@@ -100,19 +108,20 @@ class MassageServiceTest {
     @Test
     fun `최대_인원_초과_시_예외가_발생한다`() {
         val queue = mutableListOf<Long>()
+        val cancelledUsers = mutableSetOf<Long>()
         val lock = ReentrantLock()
         val successCount = AtomicInteger(0)
         val now = openTime.plusMinutes(1)
 
         // maxCount만큼 먼저 채움
         (1L..maxCount.toLong()).forEach { id ->
-            applyLogic(id, now, queue, lock, successCount)
+            applyLogic(id, now, queue, cancelledUsers, lock, successCount)
         }
         assertEquals(maxCount, queue.size)
 
         val exception =
             assertThrows(RuntimeException::class.java) {
-                applyLogic(maxCount + 1L, now, queue, lock, successCount)
+                applyLogic(maxCount + 1L, now, queue, cancelledUsers, lock, successCount)
             }
 
         assertEquals("신청 인원이 마감되었습니다.", exception.message)
@@ -122,15 +131,16 @@ class MassageServiceTest {
     @Test
     fun `동일_유저_중복_신청_시_예외가_발생한다`() {
         val queue = mutableListOf<Long>()
+        val cancelledUsers = mutableSetOf<Long>()
         val lock = ReentrantLock()
         val successCount = AtomicInteger(0)
         val now = openTime.plusMinutes(1)
 
-        applyLogic(1L, now, queue, lock, successCount)
+        applyLogic(1L, now, queue, cancelledUsers, lock, successCount)
 
         val exception =
             assertThrows(RuntimeException::class.java) {
-                applyLogic(1L, now, queue, lock, successCount)
+                applyLogic(1L, now, queue, cancelledUsers, lock, successCount)
             }
 
         assertEquals("이미 신청하였습니다.", exception.message)
@@ -142,10 +152,11 @@ class MassageServiceTest {
     @Test
     fun `신청_내역이_없을_때_취소하면_예외가_발생한다`() {
         val queue = mutableListOf<Long>()
+        val cancelledUsers = mutableSetOf<Long>()
 
         val exception =
             assertThrows(RuntimeException::class.java) {
-                cancelLogic(1L, queue)
+                cancelLogic(1L, queue, cancelledUsers)
             }
 
         assertEquals("안마의자 신청 내역이 없습니다.", exception.message)
@@ -154,27 +165,34 @@ class MassageServiceTest {
     @Test
     fun `신청한_유저는_정상_취소된다`() {
         val queue = mutableListOf(1L, 2L, 3L)
+        val cancelledUsers = mutableSetOf<Long>()
 
-        cancelLogic(2L, queue)
+        cancelLogic(2L, queue, cancelledUsers)
 
         assertEquals(2, queue.size)
         assertFalse(queue.contains(2L))
+        assertTrue(cancelledUsers.contains(2L))
     }
 
     @Test
-    fun `취소_후_재신청이_가능하다`() {
+    fun `취소_후_당일_재신청은_불가능하다`() {
         val queue = mutableListOf<Long>()
+        val cancelledUsers = mutableSetOf<Long>()
         val lock = ReentrantLock()
         val successCount = AtomicInteger(0)
         val now = openTime.plusMinutes(1)
 
-        applyLogic(1L, now, queue, lock, successCount)
-        cancelLogic(1L, queue)
-        applyLogic(1L, now, queue, lock, successCount)
+        applyLogic(1L, now, queue, cancelledUsers, lock, successCount)
+        cancelLogic(1L, queue, cancelledUsers)
 
-        assertEquals(1, queue.size)
-        assertTrue(queue.contains(1L))
-        assertEquals(2, successCount.get())
+        val exception =
+            assertThrows(RuntimeException::class.java) {
+                applyLogic(1L, now, queue, cancelledUsers, lock, successCount)
+            }
+
+        assertEquals("당일 취소한 안마의자는 다시 신청할 수 없습니다.", exception.message)
+        assertEquals(0, queue.size)
+        assertEquals(1, successCount.get())
     }
 
     // ── 동시성 테스트 ──────────────────────────────────────────────────────────
@@ -185,6 +203,7 @@ class MassageServiceTest {
 
         repeat(10) { attempt ->
             val queue = CopyOnWriteArrayList<Long>()
+            val cancelledUsers = mutableSetOf<Long>()
             val lock = ReentrantLock()
             val successCount = AtomicInteger(0)
             val now = openTime.plusMinutes(1)
@@ -195,7 +214,7 @@ class MassageServiceTest {
                 executor.submit {
                     latch.await()
                     try {
-                        applyLogic(userId, now, queue, lock, successCount)
+                        applyLogic(userId, now, queue, cancelledUsers, lock, successCount)
                     } catch (_: Exception) {
                     }
                 }
@@ -217,6 +236,7 @@ class MassageServiceTest {
         val concurrentRequests = 30
 
         val queue = CopyOnWriteArrayList<Long>()
+        val cancelledUsers = mutableSetOf<Long>()
         val lock = ReentrantLock()
         val successCount = AtomicInteger(0)
         val now = openTime.plusMinutes(1)
@@ -227,7 +247,7 @@ class MassageServiceTest {
             executor.submit {
                 latch.await()
                 try {
-                    applyLogic(sameUserId, now, queue, lock, successCount)
+                    applyLogic(sameUserId, now, queue, cancelledUsers, lock, successCount)
                 } catch (_: Exception) {
                 }
             }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

**안마의자 당일 취소 후 재신청 차단**
- 취소 시 `massage:cancelled:{userId}` Redis 키를 자정까지 TTL로 설정
- 신청 시 해당 키가 존재하면 `409 CONFLICT` 예외 발생
- 기존 `LocalDate.now()` / `LocalDateTime.now()` 를 `Clock` 기반으로 변경

**동아리 개설 상태 임시 처리**
- `isOpened` 를 `true` 로 하드코딩 (임시)

**테스트**
- `cancelledUsers` 집합 추가, 취소 후 당일 재신청 불가 케이스 반영
- 기존 `취소_후_재신청이_가능하다` → `취소_후_당일_재신청은_불가능하다` 로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음