### PR TITLE
자습 신청 처리 단계별 로그 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
@@ -1,6 +1,7 @@
 package team.incube.flooding.domain.dormitory.study.service.impl
 
 import org.redisson.api.RedissonClient
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -26,6 +27,8 @@ class StudyApplicationServiceImpl(
     private val redissonClient: RedissonClient,
     private val clock: Clock,
 ) : StudyApplicationService {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     override fun execute() {
         val user = currentUserProvider.getCurrentUser()
 
@@ -40,12 +43,14 @@ class StudyApplicationServiceImpl(
             }
 
 //        if (outOfRange) {
+//            log.warn("자습 신청 가능 시간 아님: userId={}, now={}, openTime={}, closeTime={}", user.id, now, studyProperties.openTime, studyProperties.closeTime)
 //            throw ExpectedException("자습 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
 //        }
 
         if (studyRedisAdapter.getApplicationStatus(user.id) == StudyApplicationStatus.BANNED ||
             studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now(clock))
         ) {
+            log.warn("자습 신청 거절 - 금지 상태: userId={}", user.id)
             throw ExpectedException("자습 금지 상태입니다.", HttpStatus.FORBIDDEN)
         }
 
@@ -53,26 +58,42 @@ class StudyApplicationServiceImpl(
         val acquired = lock.tryLock(5, 3, TimeUnit.SECONDS)
 
         if (!acquired) {
+            log.warn("자습 신청 거절 - 락 획득 실패: userId={}", user.id)
             throw ExpectedException("잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS)
         }
 
         try {
             val status = studyRedisAdapter.getApplicationStatus(user.id)
             if (status == StudyApplicationStatus.APPROVED) {
+                log.warn("자습 신청 거절 - 이미 신청됨: userId={}, status={}", user.id, status)
                 throw ExpectedException("이미 자습을 신청했습니다.", HttpStatus.CONFLICT)
             }
             if (status == StudyApplicationStatus.CANCELLED) {
+                log.warn("자습 신청 거절 - 당일 취소 이력: userId={}, status={}", user.id, status)
                 throw ExpectedException("자습을 취소하여 신청하지 못합니다.", HttpStatus.CONFLICT)
             }
 
             val newCount = studyRedisAdapter.incrementCount()
             if (newCount > studyProperties.maxCount) {
                 studyRedisAdapter.decrementCount()
+                log.warn(
+                    "자습 신청 거절 - 정원 초과: userId={}, currentCount={}, maxCount={}",
+                    user.id,
+                    newCount,
+                    studyProperties.maxCount,
+                )
                 throw ExpectedException("자습 신청 인원이 마감되었습니다.", HttpStatus.CONFLICT)
             }
 
             studyRedisAdapter.saveApplication(user.id, StudyApplicationStatus.APPROVED)
             studyRedisAdapter.addApplicant(user.id)
+            log.info(
+                "자습 신청 완료: userId={}, count={}, maxCount={}, appliedAt={}",
+                user.id,
+                newCount,
+                studyProperties.maxCount,
+                LocalDateTime.now(clock),
+            )
         } finally {
             lock.unlock()
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- 자습 신청 서비스(`StudyApplicationServiceImpl`)에 단계별 로그 추가
- 신청 거절 사유(금지 상태, 락 획득 실패, 중복 신청, 당일 취소 이력, 정원 초과)마다 `warn` 로그 출력
- 신청 성공 시 userId, 현재 인원, 최대 인원, 신청 시각을 `info` 로그로 출력

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음