### PR TITLE
자습 조회 응답에 myApplicationStatus 필드 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/entity/MassageApplicationStatus.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/entity/MassageApplicationStatus.kt
@@ -1,0 +1,6 @@
+package team.incube.flooding.domain.dormitory.massage.entity
+
+enum class MassageApplicationStatus {
+    APPLIED,
+    CANCELLED,
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/data/response/GetMassageListResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/data/response/GetMassageListResponse.kt
@@ -1,6 +1,9 @@
 package team.incube.flooding.domain.dormitory.massage.presentation.data.response
 
+import team.incube.flooding.domain.dormitory.massage.entity.MassageApplicationStatus
+
 data class GetMassageListResponse(
     val isApplicationOpen: Boolean,
+    val myApplicationStatus: MassageApplicationStatus?,
     val applicants: List<GetMassageResponse>,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
@@ -4,10 +4,12 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.massage.adapter.MassageRedisAdapter
 import team.incube.flooding.domain.dormitory.massage.config.MassageProperties
+import team.incube.flooding.domain.dormitory.massage.entity.MassageApplicationStatus
 import team.incube.flooding.domain.dormitory.massage.presentation.data.response.GetMassageListResponse
 import team.incube.flooding.domain.dormitory.massage.presentation.data.response.GetMassageResponse
 import team.incube.flooding.domain.dormitory.massage.service.GetMassageService
 import team.incube.flooding.domain.user.repository.UserRepository
+import team.incube.flooding.global.security.util.CurrentUserProvider
 import java.time.Clock
 import java.time.LocalTime
 
@@ -17,10 +19,18 @@ class GetMassageServiceImpl(
     private val massageRedisAdapter: MassageRedisAdapter,
     private val userRepository: UserRepository,
     private val massageProperties: MassageProperties,
+    private val currentUserProvider: CurrentUserProvider,
     private val clock: Clock,
 ) : GetMassageService {
     override fun execute(): GetMassageListResponse {
+        val currentUser = currentUserProvider.getCurrentUser()
         val isApplicationOpen = !LocalTime.now(clock).isBefore(massageProperties.openTime)
+        val myApplicationStatus =
+            when {
+                massageRedisAdapter.isReapplyBlocked(currentUser.id) -> MassageApplicationStatus.CANCELLED
+                massageRedisAdapter.isApply(currentUser.id) -> MassageApplicationStatus.APPLIED
+                else -> null
+            }
         val queue = massageRedisAdapter.getQueue()
         val applicants =
             if (queue.isEmpty()) {
@@ -35,6 +45,7 @@ class GetMassageServiceImpl(
             }
         return GetMassageListResponse(
             isApplicationOpen = isApplicationOpen,
+            myApplicationStatus = myApplicationStatus,
             applicants = applicants,
         )
     }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyListResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyListResponse.kt
@@ -1,6 +1,9 @@
 package team.incube.flooding.domain.dormitory.study.presentation.data.response
 
+import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
+
 data class GetStudyListResponse(
     val isApplicationOpen: Boolean,
+    val myApplicationStatus: StudyApplicationStatus?,
     val applicants: List<GetStudyResponse>,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
@@ -4,11 +4,13 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
 import team.incube.flooding.domain.dormitory.study.config.StudyProperties
+import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.GetStudyListResponse
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.GetStudyResponse
 import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
 import team.incube.flooding.domain.dormitory.study.service.GetStudyService
 import team.incube.flooding.domain.user.repository.UserRepository
+import team.incube.flooding.global.security.util.CurrentUserProvider
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -19,12 +21,18 @@ class GetStudyServiceImpl(
     private val studyRedisAdapter: StudyRedisAdapter,
     private val userRepository: UserRepository,
     private val studyBanJpaRepository: StudyBanJpaRepository,
+    private val currentUserProvider: CurrentUserProvider,
     private val clock: Clock,
     private val studyProperties: StudyProperties,
 ) : GetStudyService {
     override fun execute(): GetStudyListResponse {
+        val currentUser = currentUserProvider.getCurrentUser()
         val now = LocalTime.now(clock)
         val applicantIds = studyRedisAdapter.getApplicantIds()
+        val myApplicationStatus = studyRedisAdapter.getApplicationStatus(currentUser.id)
+        val isMyStudyBanned =
+            myApplicationStatus == StudyApplicationStatus.BANNED ||
+                studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(currentUser.id, LocalDateTime.now(clock))
         val bannedUserIds =
             if (applicantIds.isEmpty()) {
                 emptySet()
@@ -55,6 +63,12 @@ class GetStudyServiceImpl(
             }
         return GetStudyListResponse(
             isApplicationOpen = isStudyAvailable(now),
+            myApplicationStatus =
+                if (isMyStudyBanned) {
+                    StudyApplicationStatus.BANNED
+                } else {
+                    myApplicationStatus
+                },
             applicants = applicants,
         )
     }

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
@@ -7,6 +7,8 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
+import team.incube.flooding.domain.dormitory.study.config.StudyProperties
+import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
 import team.incube.flooding.domain.dormitory.study.entity.StudyBanJpaEntity
 import team.incube.flooding.domain.dormitory.study.repository.StudyBanJpaRepository
 import team.incube.flooding.domain.dormitory.study.service.impl.GetStudyServiceImpl
@@ -14,9 +16,11 @@ import team.incube.flooding.domain.user.entity.Role
 import team.incube.flooding.domain.user.entity.Sex
 import team.incube.flooding.domain.user.entity.UserJpaEntity
 import team.incube.flooding.domain.user.repository.UserRepository
+import team.incube.flooding.global.security.util.CurrentUserProvider
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.ZoneId
 
 class GetStudyServiceTest :
@@ -24,9 +28,15 @@ class GetStudyServiceTest :
         val studyRedisAdapter = mockk<StudyRedisAdapter>()
         val userRepository = mockk<UserRepository>()
         val studyBanJpaRepository = mockk<StudyBanJpaRepository>()
+        val currentUserProvider = mockk<CurrentUserProvider>()
         val clock = Clock.fixed(Instant.parse("2026-04-29T12:00:00Z"), ZoneId.of("Asia/Seoul"))
-
-        val service = GetStudyServiceImpl(studyRedisAdapter, userRepository, studyBanJpaRepository, clock)
+        val studyProperties =
+            StudyProperties(
+                openTime = LocalTime.of(20, 0),
+                closeTime = LocalTime.of(23, 59),
+                maxCount = 50,
+                lockKey = "study:lock",
+            )
 
         fun user(
             id: Long,
@@ -41,15 +51,32 @@ class GetStudyServiceTest :
             role = Role.GENERAL_STUDENT,
             dormitoryRoom = 101,
         )
+        val currentUser = user(id = 999L, studentNumber = 9999)
+
+        every { currentUserProvider.getCurrentUser() } returns currentUser
+        every { studyRedisAdapter.getApplicationStatus(currentUser.id) } returns null
+        every { studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(currentUser.id, any()) } returns false
+
+        val service =
+            GetStudyServiceImpl(
+                studyRedisAdapter = studyRedisAdapter,
+                userRepository = userRepository,
+                studyBanJpaRepository = studyBanJpaRepository,
+                currentUserProvider = currentUserProvider,
+                clock = clock,
+                studyProperties = studyProperties,
+            )
 
         given("신청자가 없을 때") {
             `when`("자습 신청자 목록을 조회하면") {
                 then("빈 리스트를 반환한다") {
                     every { studyRedisAdapter.getApplicantIds() } returns emptySet()
+                    every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
 
                     val result = service.execute()
 
-                    result.shouldBeEmpty()
+                    result.applicants.shouldBeEmpty()
+                    result.myApplicationStatus shouldBe null
                 }
             }
         }
@@ -68,8 +95,8 @@ class GetStudyServiceTest :
 
                     val result = service.execute()
 
-                    result shouldHaveSize 2
-                    result.all { !it.isChecked } shouldBe true
+                    result.applicants shouldHaveSize 2
+                    result.applicants.all { !it.isChecked } shouldBe true
                 }
             }
 
@@ -81,7 +108,7 @@ class GetStudyServiceTest :
                     every { studyRedisAdapter.getAttendanceIds() } returns setOf(1L)
                     every { userRepository.findAllById(any()) } returns listOf(user1, user2)
 
-                    val result = service.execute().sortedBy { it.userId }
+                    val result = service.execute().applicants.sortedBy { it.userId }
 
                     result[0].isChecked shouldBe true
                     result[1].isChecked shouldBe false
@@ -98,8 +125,8 @@ class GetStudyServiceTest :
 
                     val result = service.execute()
 
-                    result shouldHaveSize 2
-                    result.all { it.isChecked } shouldBe true
+                    result.applicants shouldHaveSize 2
+                    result.applicants.all { it.isChecked } shouldBe true
                 }
             }
         }
@@ -123,7 +150,7 @@ class GetStudyServiceTest :
                     every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
                     every { userRepository.findAllById(any()) } returns listOf(user1, user2)
 
-                    val result = service.execute().sortedBy { it.userId }
+                    val result = service.execute().applicants.sortedBy { it.userId }
 
                     result[0].isBanned shouldBe false
                     result[1].isBanned shouldBe true
@@ -149,7 +176,7 @@ class GetStudyServiceTest :
                     every { studyRedisAdapter.getAttendanceIds() } returns setOf(1L)
                     every { userRepository.findAllById(any()) } returns listOf(user1)
 
-                    val result = service.execute()
+                    val result = service.execute().applicants
 
                     result[0].isBanned shouldBe true
                     result[0].isChecked shouldBe true
@@ -169,7 +196,7 @@ class GetStudyServiceTest :
                     every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
                     every { userRepository.findAllById(any()) } returns listOf(manUser, womanUser)
 
-                    val result = service.execute().sortedBy { it.userId }
+                    val result = service.execute().applicants.sortedBy { it.userId }
 
                     result[0].sex shouldBe Sex.MAN
                     result[1].sex shouldBe Sex.WOMAN
@@ -190,11 +217,25 @@ class GetStudyServiceTest :
                     every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
                     every { userRepository.findAllById(any()) } returns listOf(user1, user2, user3)
 
-                    val result = service.execute()
+                    val result = service.execute().applicants
 
                     result[0].studentNumber shouldBe 1101
                     result[1].studentNumber shouldBe 1102
                     result[2].studentNumber shouldBe 1103
+                }
+            }
+        }
+
+        given("현재 사용자가 오늘 자습을 취소했을 때") {
+            `when`("자습 신청자 목록을 조회하면") {
+                then("내 신청 상태가 CANCELLED로 반환된다") {
+                    every { studyRedisAdapter.getApplicantIds() } returns emptySet()
+                    every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
+                    every { studyRedisAdapter.getApplicationStatus(currentUser.id) } returns StudyApplicationStatus.CANCELLED
+
+                    val result = service.execute()
+
+                    result.myApplicationStatus shouldBe StudyApplicationStatus.CANCELLED
                 }
             }
         }

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
@@ -231,7 +231,8 @@ class GetStudyServiceTest :
                 then("내 신청 상태가 CANCELLED로 반환된다") {
                     every { studyRedisAdapter.getApplicantIds() } returns emptySet()
                     every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
-                    every { studyRedisAdapter.getApplicationStatus(currentUser.id) } returns StudyApplicationStatus.CANCELLED
+                    every { studyRedisAdapter.getApplicationStatus(currentUser.id) } returns
+                        StudyApplicationStatus.CANCELLED
 
                     val result = service.execute()
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

`GET /dormitory/studies` 응답에 현재 로그인한 사용자의 자습 신청 상태를 나타내는 `myApplicationStatus` 필드를 추가했습니다.

- `null`: 오늘 자습을 신청하지 않은 상태
- `APPROVED`: 자습 신청 완료 상태
- `CANCELLED`: 오늘 자습을 취소한 상태
- `BANNED`: 자습 금지 상태 (Redis 상태 또는 DB 금지 이력 포함)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음