### PR TITLE
동아리 신청목록 조회의 값이 비어있을 시 200에러와 빈 값을 반환하도록 변경

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/QueryClubApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/QueryClubApplicationServiceImpl.kt
@@ -25,7 +25,7 @@ class QueryClubApplicationServiceImpl(
             throw ExpectedException("동아리 개설 신청 목록을 조회할 권한이 없습니다.", HttpStatus.FORBIDDEN)
         }
 
-        val clubs = clubJpaRepository.findAllByStatus(ClubStatus.NEW) ?: emptyList()
+        val clubs = clubJpaRepository.findAllByStatus(ClubStatus.NEW)
 
         return ClubApplicationListResponse(
             clubs =
@@ -36,7 +36,7 @@ class QueryClubApplicationServiceImpl(
                         leader = club.leader?.name ?: "정보 없음",
                         type = club.type,
                         description = club.description ?: "",
-                        imageUrl = club.imageUrl ?: "",
+                        imageUrl = club.imageUrl,
                         maxMember = club.maxMember,
                     )
                 },

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/QueryClubApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/QueryClubApplicationServiceImpl.kt
@@ -25,7 +25,7 @@ class QueryClubApplicationServiceImpl(
             throw ExpectedException("동아리 개설 신청 목록을 조회할 권한이 없습니다.", HttpStatus.FORBIDDEN)
         }
 
-        val clubs = clubJpaRepository.findAllByStatus(ClubStatus.NEW)
+        val clubs = clubJpaRepository.findAllByStatus(ClubStatus.NEW) ?: emptyList()
 
         return ClubApplicationListResponse(
             clubs =
@@ -33,12 +33,10 @@ class QueryClubApplicationServiceImpl(
                     ClubApplicationResponse(
                         id = club.id,
                         name = club.name,
-                        leader =
-                            club.leader?.name
-                                ?: throw ExpectedException("동아리장 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+                        leader = club.leader?.name ?: "정보 없음",
                         type = club.type,
                         description = club.description ?: "",
-                        imageUrl = club.imageUrl,
+                        imageUrl = club.imageUrl ?: "",
                         maxMember = club.maxMember,
                     )
                 },


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호


## 📝작업 내용

동아리 신청목록 조회의 값이 비어있을 시 200에러와 빈 값을 반환하도록 변경했습니다


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
