### PR TITLE
자습 일일 초기화 스케줄러 추가 및 기상음악 조회 날짜 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
@@ -49,7 +49,7 @@ class WakeUpMusicController(
         @RequestParam(required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate?,
     ): CommonApiResponse<List<WakeUpMusicResponse>> =
-        CommonApiResponse.success("OK", getWakeUpMusicService.execute(date ?: LocalDate.now(clock)))
+        CommonApiResponse.success("OK", getWakeUpMusicService.execute(date ?: LocalDate.now(clock).plusDays(1)))
 
     @Operation(
         summary = "기상음악 신청",

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
@@ -87,4 +87,12 @@ class StudyRedisAdapter(
             .members(ATTENDANCE_KEY)
             ?.map { it.toLong() }
             ?.toSet() ?: emptySet()
+
+    fun resetAll() {
+        val applicationKeys = redisTemplate.keys("$APPLICATION_KEY:*") ?: emptySet()
+        if (applicationKeys.isNotEmpty()) redisTemplate.delete(applicationKeys)
+        redisTemplate.delete(COUNT_KEY)
+        redisTemplate.delete(APPLICANTS_KEY)
+        redisTemplate.delete(ATTENDANCE_KEY)
+    }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
@@ -1,6 +1,7 @@
 package team.incube.flooding.domain.dormitory.study.adapter
 
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ScanOptions
 import org.springframework.stereotype.Component
 import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
 import java.time.Clock
@@ -21,9 +22,15 @@ class StudyRedisAdapter(
         private const val ATTENDANCE_KEY = "study:attendance"
     }
 
-    private fun ttlUntilMidnight(): Duration {
-        val midnight = LocalDateTime.of(LocalDate.now(clock).plusDays(1), LocalTime.MIDNIGHT)
-        return Duration.between(LocalDateTime.now(clock), midnight)
+    private fun ttlUntil6AM(): Duration {
+        val now = LocalDateTime.now(clock)
+        val next6AM =
+            if (now.hour < 6) {
+                LocalDateTime.of(now.toLocalDate(), LocalTime.of(6, 0))
+            } else {
+                LocalDateTime.of(now.toLocalDate().plusDays(1), LocalTime.of(6, 0))
+            }
+        return Duration.between(now, next6AM)
     }
 
     fun saveApplication(
@@ -33,7 +40,7 @@ class StudyRedisAdapter(
         redisTemplate.opsForValue().set(
             "$APPLICATION_KEY:$userId",
             status.name,
-            ttlUntilMidnight(),
+            ttlUntil6AM(),
         )
     }
 
@@ -46,9 +53,7 @@ class StudyRedisAdapter(
 
     fun incrementCount(): Long {
         val count = redisTemplate.opsForValue().increment(COUNT_KEY) ?: 0
-        if (count == 1L) {
-            redisTemplate.expire(COUNT_KEY, ttlUntilMidnight())
-        }
+        redisTemplate.expire(COUNT_KEY, ttlUntil6AM())
         return count
     }
 
@@ -56,10 +61,7 @@ class StudyRedisAdapter(
 
     fun addApplicant(userId: Long) {
         redisTemplate.opsForSet().add(APPLICANTS_KEY, userId.toString())
-        val size = redisTemplate.opsForSet().size(APPLICANTS_KEY) ?: 0L
-        if (size == 1L) {
-            redisTemplate.expire(APPLICANTS_KEY, ttlUntilMidnight())
-        }
+        redisTemplate.expire(APPLICANTS_KEY, ttlUntil6AM())
     }
 
     fun removeApplicant(userId: Long) {
@@ -75,7 +77,7 @@ class StudyRedisAdapter(
 
     fun checkAttendance(userId: Long) {
         redisTemplate.opsForSet().add(ATTENDANCE_KEY, userId.toString())
-        redisTemplate.expire(ATTENDANCE_KEY, ttlUntilMidnight())
+        redisTemplate.expire(ATTENDANCE_KEY, ttlUntil6AM())
     }
 
     fun isAttendanceChecked(userId: Long): Boolean =
@@ -89,7 +91,19 @@ class StudyRedisAdapter(
             ?.toSet() ?: emptySet()
 
     fun resetAll() {
-        val applicationKeys = redisTemplate.keys("$APPLICATION_KEY:*") ?: emptySet()
+        val scanOptions =
+            ScanOptions
+                .scanOptions()
+                .match("$APPLICATION_KEY:*")
+                .count(100)
+                .build()
+        val applicationKeys = mutableListOf<String>()
+        redisTemplate.execute { connection ->
+            connection.scan(scanOptions).use { cursor ->
+                cursor.forEach { applicationKeys.add(String(it)) }
+            }
+            null
+        }
         if (applicationKeys.isNotEmpty()) redisTemplate.delete(applicationKeys)
         redisTemplate.delete(COUNT_KEY)
         redisTemplate.delete(APPLICANTS_KEY)

--- a/src/main/kotlin/team/incube/flooding/global/scheduler/StudyResetScheduler.kt
+++ b/src/main/kotlin/team/incube/flooding/global/scheduler/StudyResetScheduler.kt
@@ -1,0 +1,20 @@
+package team.incube.flooding.global.scheduler
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
+
+@Component
+class StudyResetScheduler(
+    private val studyRedisAdapter: StudyRedisAdapter,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = "0 0 6 * * *")
+    fun resetStudyApplications() {
+        log.info("자습 신청 상태 초기화 시작")
+        studyRedisAdapter.resetAll()
+        log.info("자습 신청 상태 초기화 완료")
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

### 기상음악 기본 조회 날짜 버그 수정
- 기상음악 신청은 내일 날짜(wakeUpDate = now + 1)로 저장되는데, date 파라미터 없이 조회 시 오늘 날짜로 조회하여 빈 목록이 반환되는 버그 수정
- 기본 조회 날짜를 `LocalDate.now()` → `LocalDate.now().plusDays(1)`로 변경

### 자습 신청 상태 일일 초기화 스케줄러 추가
- 하루가 지나도 자습 신청 상태가 초기화되지 않아 신청 불가 상태가 유지되는 문제 수정
- 매일 새벽 6시에 Redis의 자습 관련 키(신청 상태, 신청 카운트, 신청자 목록, 출석 목록)를 전체 초기화하는 스케줄러 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음