### PR TITLE
기상음악 JPQL 쿼리 LEFT JOIN 조건 개선

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
@@ -15,10 +15,16 @@ interface WakeUpMusicRepository : JpaRepository<WakeUpMusicJpaEntity, Long> {
     @Query(
         """
         SELECT new team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse(
-            m.id, m.musicUrl, m.appliedAt, COUNT(l.id))
-        FROM WakeUpMusicJpaEntity m LEFT JOIN WakeUpMusicLikeJpaEntity l ON m.id = l.music.id
+            m.id, m.musicUrl, m.appliedAt, COUNT(l.id)
+        )
+        FROM WakeUpMusicJpaEntity m
+        LEFT JOIN WakeUpMusicLikeJpaEntity l ON l.music = m
         WHERE m.wakeUpDate = :date
-            OR (m.wakeUpDate IS NULL AND m.appliedAt >= :legacyStart AND m.appliedAt < :legacyEnd)
+            OR (
+                m.wakeUpDate IS NULL
+                AND m.appliedAt >= :legacyStart
+                AND m.appliedAt < :legacyEnd
+            )
         GROUP BY m.id, m.musicUrl, m.appliedAt
         ORDER BY m.appliedAt DESC
     """,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- 기상음악 목록 조회 JPQL에서 LEFT JOIN 조건이 `m.id = l.music.id`로 작성되어 있던 것을 `l.music = m`으로 수정
- JPQL은 엔티티 기반으로 조인해야 하므로 컬럼 비교 방식은 올바르지 않음

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음