### PR TITLE
기상음악 목록 조회 JPQL 조건 정리

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
@@ -15,10 +15,16 @@ interface WakeUpMusicRepository : JpaRepository<WakeUpMusicJpaEntity, Long> {
     @Query(
         """
         SELECT new team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse(
-            m.id, m.musicUrl, m.appliedAt, COUNT(l.id))
-        FROM WakeUpMusicJpaEntity m LEFT JOIN WakeUpMusicLikeJpaEntity l ON m.id = l.music.id
+            m.id, m.musicUrl, m.appliedAt, COUNT(l.id)
+        )
+        FROM WakeUpMusicJpaEntity m
+        LEFT JOIN WakeUpMusicLikeJpaEntity l ON l.music = m
         WHERE m.wakeUpDate = :date
-            OR (m.wakeUpDate IS NULL AND m.appliedAt >= :legacyStart AND m.appliedAt < :legacyEnd)
+            OR (
+                m.wakeUpDate IS NULL
+                AND m.appliedAt >= :legacyStart
+                AND m.appliedAt < :legacyEnd
+            )
         GROUP BY m.id, m.musicUrl, m.appliedAt
         ORDER BY m.appliedAt DESC
     """,


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

- 기상음악 목록 조회 JPQL의 LEFT JOIN 조건을 엔티티 연관관계 기준으로 수정
- 레거시 데이터 fallback 조건을 괄호로 명확하게 정리
- 조회 테스트 통과 확인

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음