### PR TITLE
동아리 신청과 삭제 흐름 보완

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubApplicationController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/presentation/controller/ClubApplicationController.kt
@@ -64,7 +64,7 @@ class ClubApplicationController(
         ApiResponse(responseCode = "200", description = "조회 성공"),
         ApiResponse(responseCode = "400", description = "정규 동아리가 아님"),
         ApiResponse(responseCode = "403", description = "권한 없음"),
-        ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 또는 생성된 폼 없음"),
+        ApiResponse(responseCode = "404", description = "존재하지 않는 동아리"),
     )
     @GetMapping("/{clubId}/applications")
     fun getClubApplicationList(

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormAnswerRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormAnswerRepository.kt
@@ -11,11 +11,11 @@ interface ClubFormAnswerRepository : JpaRepository<ClubFormAnswerJpaEntity, Long
     )
     fun findAllBySubmissionIdIn(submissionIds: List<Long>): List<ClubFormAnswerJpaEntity>
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query("DELETE FROM ClubFormAnswerJpaEntity a WHERE a.submission.id = :submissionId")
     fun deleteAllBySubmissionId(submissionId: Long)
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query(
         """
         DELETE FROM ClubFormAnswerJpaEntity a

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormAnswerRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormAnswerRepository.kt
@@ -1,6 +1,7 @@
 package team.incube.flooding.domain.club.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import team.incube.flooding.domain.club.entity.ClubFormAnswerJpaEntity
 
@@ -9,4 +10,20 @@ interface ClubFormAnswerRepository : JpaRepository<ClubFormAnswerJpaEntity, Long
         "SELECT a FROM ClubFormAnswerJpaEntity a JOIN FETCH a.field WHERE a.submission.id IN :submissionIds ORDER BY a.field.fieldOrder ASC",
     )
     fun findAllBySubmissionIdIn(submissionIds: List<Long>): List<ClubFormAnswerJpaEntity>
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM ClubFormAnswerJpaEntity a WHERE a.submission.id = :submissionId")
+    fun deleteAllBySubmissionId(submissionId: Long)
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+        DELETE FROM ClubFormAnswerJpaEntity a
+        WHERE a.submission.id IN (
+            SELECT s.id FROM ClubFormSubmissionJpaEntity s
+            WHERE s.form.club.id = :clubId
+        )
+        """,
+    )
+    fun deleteAllByClubId(clubId: Long)
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormFieldOptionRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormFieldOptionRepository.kt
@@ -12,7 +12,7 @@ interface ClubFormFieldOptionRepository : JpaRepository<ClubFormFieldOptionJpaEn
     @Query("DELETE FROM ClubFormFieldOptionJpaEntity o WHERE o.field.form.id = :formId")
     fun deleteAllByFormId(formId: Long)
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query(
         """
         DELETE FROM ClubFormFieldOptionJpaEntity o

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormFieldOptionRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormFieldOptionRepository.kt
@@ -11,4 +11,16 @@ interface ClubFormFieldOptionRepository : JpaRepository<ClubFormFieldOptionJpaEn
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM ClubFormFieldOptionJpaEntity o WHERE o.field.form.id = :formId")
     fun deleteAllByFormId(formId: Long)
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+        DELETE FROM ClubFormFieldOptionJpaEntity o
+        WHERE o.field.id IN (
+            SELECT f.id FROM ClubFormFieldJpaEntity f
+            WHERE f.form.club.id = :clubId
+        )
+        """,
+    )
+    fun deleteAllByClubId(clubId: Long)
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormFieldRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormFieldRepository.kt
@@ -11,4 +11,16 @@ interface ClubFormFieldRepository : JpaRepository<ClubFormFieldJpaEntity, Long> 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM ClubFormFieldJpaEntity f WHERE f.form.id = :formId")
     fun deleteAllByFormId(formId: Long)
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+        DELETE FROM ClubFormFieldJpaEntity f
+        WHERE f.form.id IN (
+            SELECT form.id FROM ClubFormJpaEntity form
+            WHERE form.club.id = :clubId
+        )
+        """,
+    )
+    fun deleteAllByClubId(clubId: Long)
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormFieldRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormFieldRepository.kt
@@ -12,7 +12,7 @@ interface ClubFormFieldRepository : JpaRepository<ClubFormFieldJpaEntity, Long> 
     @Query("DELETE FROM ClubFormFieldJpaEntity f WHERE f.form.id = :formId")
     fun deleteAllByFormId(formId: Long)
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query(
         """
         DELETE FROM ClubFormFieldJpaEntity f

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormRepository.kt
@@ -1,10 +1,16 @@
 package team.incube.flooding.domain.club.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import team.incube.flooding.domain.club.entity.ClubFormJpaEntity
 
 interface ClubFormRepository : JpaRepository<ClubFormJpaEntity, Long> {
     fun findByClubIdAndIsActiveTrue(clubId: Long): ClubFormJpaEntity?
 
     fun findAllByClubIdAndIsActiveTrue(clubId: Long): List<ClubFormJpaEntity>
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM ClubFormJpaEntity f WHERE f.club.id = :clubId")
+    fun deleteAllByClubId(clubId: Long)
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormRepository.kt
@@ -10,7 +10,7 @@ interface ClubFormRepository : JpaRepository<ClubFormJpaEntity, Long> {
 
     fun findAllByClubIdAndIsActiveTrue(clubId: Long): List<ClubFormJpaEntity>
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query("DELETE FROM ClubFormJpaEntity f WHERE f.club.id = :clubId")
     fun deleteAllByClubId(clubId: Long)
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormSubmissionRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormSubmissionRepository.kt
@@ -1,6 +1,7 @@
 package team.incube.flooding.domain.club.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import team.incube.flooding.domain.club.entity.ClubFormSubmissionJpaEntity
 
@@ -15,7 +16,34 @@ interface ClubFormSubmissionRepository : JpaRepository<ClubFormSubmissionJpaEnti
     ): Boolean
 
     @Query(
-        "SELECT s FROM ClubFormSubmissionJpaEntity s JOIN FETCH s.user WHERE s.form.id = :formId ORDER BY s.submittedAt DESC",
+        """
+        SELECT s FROM ClubFormSubmissionJpaEntity s
+        JOIN FETCH s.user
+        WHERE s.form.id = :formId
+        AND NOT EXISTS (
+            SELECT p FROM ClubParticipantJpaEntity p
+            WHERE p.club.id = s.form.club.id
+            AND p.user.id = s.user.id
+        )
+        ORDER BY s.submittedAt DESC
+        """,
     )
     fun findAllByFormIdWithUser(formId: Long): List<ClubFormSubmissionJpaEntity>
+
+    fun findByFormIdAndUserId(
+        formId: Long,
+        userId: Long,
+    ): ClubFormSubmissionJpaEntity?
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+        DELETE FROM ClubFormSubmissionJpaEntity s
+        WHERE s.form.id IN (
+            SELECT form.id FROM ClubFormJpaEntity form
+            WHERE form.club.id = :clubId
+        )
+        """,
+    )
+    fun deleteAllByClubId(clubId: Long)
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormSubmissionRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubFormSubmissionRepository.kt
@@ -35,7 +35,11 @@ interface ClubFormSubmissionRepository : JpaRepository<ClubFormSubmissionJpaEnti
         userId: Long,
     ): ClubFormSubmissionJpaEntity?
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
+    @Query("DELETE FROM ClubFormSubmissionJpaEntity s WHERE s.id = :submissionId")
+    fun deleteBySubmissionId(submissionId: Long)
+
+    @Modifying
     @Query(
         """
         DELETE FROM ClubFormSubmissionJpaEntity s

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantRepository.kt
@@ -1,6 +1,7 @@
 package team.incube.flooding.domain.club.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import team.incube.flooding.domain.club.entity.ClubParticipantId
 import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
@@ -18,4 +19,8 @@ interface ClubParticipantRepository : JpaRepository<ClubParticipantJpaEntity, Cl
 
     @Query("SELECT p FROM ClubParticipantJpaEntity p JOIN FETCH p.user WHERE p.club.id = :clubId")
     fun findAllByClubId(clubId: Long): List<ClubParticipantJpaEntity>
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM ClubParticipantJpaEntity p WHERE p.club.id = :clubId")
+    fun deleteAllByClubId(clubId: Long)
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubParticipantRepository.kt
@@ -20,7 +20,7 @@ interface ClubParticipantRepository : JpaRepository<ClubParticipantJpaEntity, Cl
     @Query("SELECT p FROM ClubParticipantJpaEntity p JOIN FETCH p.user WHERE p.club.id = :clubId")
     fun findAllByClubId(clubId: Long): List<ClubParticipantJpaEntity>
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query("DELETE FROM ClubParticipantJpaEntity p WHERE p.club.id = :clubId")
     fun deleteAllByClubId(clubId: Long)
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/ClubApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/ClubApplicationServiceImpl.kt
@@ -8,8 +8,8 @@ import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
 import team.incube.flooding.domain.club.repository.ClubFormAnswerRepository
 import team.incube.flooding.domain.club.repository.ClubFormRepository
 import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
-import team.incube.flooding.domain.club.repository.ClubJpaRepository
-import team.incube.flooding.domain.club.repository.ClubParticipantJpaRepository
+import team.incube.flooding.domain.club.repository.ClubParticipantRepository
+import team.incube.flooding.domain.club.repository.ClubRepository
 import team.incube.flooding.domain.club.service.ClubApplicationService
 import team.incube.flooding.domain.user.repository.UserRepository
 import team.incube.flooding.global.security.util.CurrentUserProvider
@@ -17,12 +17,12 @@ import team.themoment.sdk.exception.ExpectedException
 
 @Service
 class ClubApplicationServiceImpl(
-    private val clubJpaRepository: ClubJpaRepository,
+    private val clubRepository: ClubRepository,
     private val userRepository: UserRepository,
     private val clubFormRepository: ClubFormRepository,
     private val clubFormSubmissionRepository: ClubFormSubmissionRepository,
     private val clubFormAnswerRepository: ClubFormAnswerRepository,
-    private val clubParticipantJpaRepository: ClubParticipantJpaRepository,
+    private val clubParticipantRepository: ClubParticipantRepository,
     private val currentUserProvider: CurrentUserProvider,
 ) : ClubApplicationService {
     @Transactional
@@ -31,7 +31,7 @@ class ClubApplicationServiceImpl(
         userId: Long,
     ) {
         val club =
-            clubJpaRepository
+            clubRepository
                 .findById(clubId)
                 .orElseThrow { ExpectedException("존재하지 않는 동아리입니다", HttpStatus.NOT_FOUND) }
 
@@ -41,7 +41,7 @@ class ClubApplicationServiceImpl(
             throw ExpectedException("동아리 리더만 승인할 수 있습니다", HttpStatus.FORBIDDEN)
         }
 
-        if (clubParticipantJpaRepository.existsById(ClubParticipantId(club = clubId, user = userId))) {
+        if (clubParticipantRepository.existsById(ClubParticipantId(club = clubId, user = userId))) {
             throw ExpectedException("이미 가입된 유저입니다", HttpStatus.CONFLICT)
         }
 
@@ -55,14 +55,14 @@ class ClubApplicationServiceImpl(
                 club = club,
                 user = user,
             )
-        clubParticipantJpaRepository.save(participant)
+        clubParticipantRepository.save(participant)
 
         clubFormRepository
             .findByClubIdAndIsActiveTrue(clubId)
             ?.let { form -> clubFormSubmissionRepository.findByFormIdAndUserId(form.id, userId) }
             ?.let { submission ->
                 clubFormAnswerRepository.deleteAllBySubmissionId(submission.id)
-                clubFormSubmissionRepository.delete(submission)
+                clubFormSubmissionRepository.deleteBySubmissionId(submission.id)
             }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/ClubApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/ClubApplicationServiceImpl.kt
@@ -5,6 +5,9 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.club.entity.ClubParticipantId
 import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
+import team.incube.flooding.domain.club.repository.ClubFormAnswerRepository
+import team.incube.flooding.domain.club.repository.ClubFormRepository
+import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
 import team.incube.flooding.domain.club.repository.ClubJpaRepository
 import team.incube.flooding.domain.club.repository.ClubParticipantJpaRepository
 import team.incube.flooding.domain.club.service.ClubApplicationService
@@ -16,6 +19,9 @@ import team.themoment.sdk.exception.ExpectedException
 class ClubApplicationServiceImpl(
     private val clubJpaRepository: ClubJpaRepository,
     private val userRepository: UserRepository,
+    private val clubFormRepository: ClubFormRepository,
+    private val clubFormSubmissionRepository: ClubFormSubmissionRepository,
+    private val clubFormAnswerRepository: ClubFormAnswerRepository,
     private val clubParticipantJpaRepository: ClubParticipantJpaRepository,
     private val currentUserProvider: CurrentUserProvider,
 ) : ClubApplicationService {
@@ -50,5 +56,13 @@ class ClubApplicationServiceImpl(
                 user = user,
             )
         clubParticipantJpaRepository.save(participant)
+
+        clubFormRepository
+            .findByClubIdAndIsActiveTrue(clubId)
+            ?.let { form -> clubFormSubmissionRepository.findByFormIdAndUserId(form.id, userId) }
+            ?.let { submission ->
+                clubFormAnswerRepository.deleteAllBySubmissionId(submission.id)
+                clubFormSubmissionRepository.delete(submission)
+            }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/DeleteClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/DeleteClubServiceImpl.kt
@@ -3,6 +3,12 @@ package team.incube.flooding.domain.club.service.impl
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.club.repository.ClubFormAnswerRepository
+import team.incube.flooding.domain.club.repository.ClubFormFieldOptionRepository
+import team.incube.flooding.domain.club.repository.ClubFormFieldRepository
+import team.incube.flooding.domain.club.repository.ClubFormRepository
+import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
+import team.incube.flooding.domain.club.repository.ClubParticipantRepository
 import team.incube.flooding.domain.club.repository.ClubRepository
 import team.incube.flooding.domain.club.service.DeleteClubService
 import team.incube.flooding.global.security.util.CurrentUserProvider
@@ -11,6 +17,12 @@ import team.themoment.sdk.exception.ExpectedException
 @Service
 class DeleteClubServiceImpl(
     private val clubRepository: ClubRepository,
+    private val clubParticipantRepository: ClubParticipantRepository,
+    private val clubFormRepository: ClubFormRepository,
+    private val clubFormFieldRepository: ClubFormFieldRepository,
+    private val clubFormFieldOptionRepository: ClubFormFieldOptionRepository,
+    private val clubFormSubmissionRepository: ClubFormSubmissionRepository,
+    private val clubFormAnswerRepository: ClubFormAnswerRepository,
     private val currentUserProvider: CurrentUserProvider,
 ) : DeleteClubService {
     @Transactional
@@ -26,6 +38,12 @@ class DeleteClubServiceImpl(
             throw ExpectedException("동아리를 삭제할 권한이 없습니다.", HttpStatus.FORBIDDEN)
         }
 
+        clubFormAnswerRepository.deleteAllByClubId(clubId)
+        clubFormSubmissionRepository.deleteAllByClubId(clubId)
+        clubFormFieldOptionRepository.deleteAllByClubId(clubId)
+        clubFormFieldRepository.deleteAllByClubId(clubId)
+        clubFormRepository.deleteAllByClubId(clubId)
+        clubParticipantRepository.deleteAllByClubId(clubId)
         clubRepository.delete(club)
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubApplicationListServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubApplicationListServiceImpl.kt
@@ -41,7 +41,7 @@ class GetClubApplicationListServiceImpl(
 
         val form =
             clubFormRepository.findByClubIdAndIsActiveTrue(clubId)
-                ?: throw ExpectedException("생성된 폼이 없습니다.", HttpStatus.NOT_FOUND)
+                ?: return GetClubApplicationListResponse(emptyList())
 
         val submissions = submissionRepository.findAllByFormIdWithUser(form.id)
         if (submissions.isEmpty()) return GetClubApplicationListResponse(emptyList())

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubServiceImpl.kt
@@ -22,16 +22,22 @@ class GetClubServiceImpl(
         val club =
             clubRepository.findByIdWithLeader(clubId)
                 ?: throw ExpectedException("존재하지 않는 동아리입니다.", HttpStatus.NOT_FOUND)
+        val participantMembers =
+            clubParticipantRepository
+                .findAllByClubId(clubId)
+                .map { p -> p.user }
         val members =
-            clubParticipantRepository.findAllByClubId(clubId).map { p ->
-                GetClubResponse.MemberSummary(
-                    id = p.user.id,
-                    name = p.user.name,
-                    studentNumber = p.user.studentNumber,
-                    sex = p.user.sex.name,
-                    specialty = p.user.specialty,
-                )
-            }
+            (listOfNotNull(club.leader) + participantMembers)
+                .distinctBy { it.id }
+                .map { user ->
+                    GetClubResponse.MemberSummary(
+                        id = user.id,
+                        name = user.name,
+                        studentNumber = user.studentNumber,
+                        sex = user.sex.name,
+                        specialty = user.specialty,
+                    )
+                }
         val projects =
             club.dataGsmClubId?.let { dgId ->
                 runCatching { dataGsmProjectClient.getProjectsByClubId(dgId) }.getOrElse { emptyList() }

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/ClubApplicationServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/ClubApplicationServiceTest.kt
@@ -1,0 +1,100 @@
+package team.incube.flooding.domain.club.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import team.incube.flooding.domain.club.entity.ClubFormJpaEntity
+import team.incube.flooding.domain.club.entity.ClubFormSubmissionJpaEntity
+import team.incube.flooding.domain.club.entity.ClubJpaEntity
+import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
+import team.incube.flooding.domain.club.entity.ClubStatus
+import team.incube.flooding.domain.club.entity.ClubType
+import team.incube.flooding.domain.club.repository.ClubFormAnswerRepository
+import team.incube.flooding.domain.club.repository.ClubFormRepository
+import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
+import team.incube.flooding.domain.club.repository.ClubJpaRepository
+import team.incube.flooding.domain.club.repository.ClubParticipantJpaRepository
+import team.incube.flooding.domain.club.service.impl.ClubApplicationServiceImpl
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.incube.flooding.global.security.util.CurrentUserProvider
+import java.util.Optional
+
+class ClubApplicationServiceTest :
+    BehaviorSpec({
+        val clubJpaRepository = mockk<ClubJpaRepository>()
+        val userRepository = mockk<UserRepository>()
+        val clubFormRepository = mockk<ClubFormRepository>()
+        val clubFormSubmissionRepository = mockk<ClubFormSubmissionRepository>()
+        val clubFormAnswerRepository = mockk<ClubFormAnswerRepository>()
+        val clubParticipantJpaRepository = mockk<ClubParticipantJpaRepository>()
+        val currentUserProvider = mockk<CurrentUserProvider>()
+        val service =
+            ClubApplicationServiceImpl(
+                clubJpaRepository,
+                userRepository,
+                clubFormRepository,
+                clubFormSubmissionRepository,
+                clubFormAnswerRepository,
+                clubParticipantJpaRepository,
+                currentUserProvider,
+            )
+
+        beforeEach { clearAllMocks() }
+
+        fun user(id: Long) =
+            UserJpaEntity(
+                id = id,
+                name = "테스트$id",
+                sex = Sex.MAN,
+                email = "test$id@test.com",
+                studentNumber = 10100 + id.toInt(),
+                role = Role.GENERAL_STUDENT,
+                dormitoryRoom = 101,
+            )
+
+        fun club(leader: UserJpaEntity) =
+            ClubJpaEntity(
+                id = 1L,
+                name = "테스트 동아리",
+                type = ClubType.MAJOR_CLUB,
+                leader = leader,
+                imageUrl = null,
+                status = ClubStatus.MAINTAIN,
+                description = null,
+                maxMember = null,
+            )
+
+        given("동아리 리더가 신청자를 승인할 때") {
+            `when`("신청 제출 데이터가 존재하면") {
+                then("동아리원으로 추가하고 신청 목록에서 제거한다") {
+                    val leader = user(1L)
+                    val applicant = user(2L)
+                    val club = club(leader)
+                    val form = ClubFormJpaEntity(id = 10L, club = club, title = "신청 폼", description = null)
+                    val submission = ClubFormSubmissionJpaEntity(id = 100L, form = form, user = applicant)
+
+                    every { clubJpaRepository.findById(1L) } returns Optional.of(club)
+                    every { currentUserProvider.getCurrentUser() } returns leader
+                    every { clubParticipantJpaRepository.existsById(any()) } returns false
+                    every { userRepository.findById(2L) } returns Optional.of(applicant)
+                    every { clubParticipantJpaRepository.save(any()) } answers { firstArg<ClubParticipantJpaEntity>() }
+                    every { clubFormRepository.findByClubIdAndIsActiveTrue(1L) } returns form
+                    every { clubFormSubmissionRepository.findByFormIdAndUserId(10L, 2L) } returns submission
+                    justRun { clubFormAnswerRepository.deleteAllBySubmissionId(100L) }
+                    justRun { clubFormSubmissionRepository.delete(submission) }
+
+                    service.execute(1L, 2L)
+
+                    verify(exactly = 1) { clubParticipantJpaRepository.save(any()) }
+                    verify(exactly = 1) { clubFormAnswerRepository.deleteAllBySubmissionId(100L) }
+                    verify(exactly = 1) { clubFormSubmissionRepository.delete(submission) }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/ClubApplicationServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/ClubApplicationServiceTest.kt
@@ -15,8 +15,8 @@ import team.incube.flooding.domain.club.entity.ClubType
 import team.incube.flooding.domain.club.repository.ClubFormAnswerRepository
 import team.incube.flooding.domain.club.repository.ClubFormRepository
 import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
-import team.incube.flooding.domain.club.repository.ClubJpaRepository
-import team.incube.flooding.domain.club.repository.ClubParticipantJpaRepository
+import team.incube.flooding.domain.club.repository.ClubParticipantRepository
+import team.incube.flooding.domain.club.repository.ClubRepository
 import team.incube.flooding.domain.club.service.impl.ClubApplicationServiceImpl
 import team.incube.flooding.domain.user.entity.Role
 import team.incube.flooding.domain.user.entity.Sex
@@ -27,21 +27,21 @@ import java.util.Optional
 
 class ClubApplicationServiceTest :
     BehaviorSpec({
-        val clubJpaRepository = mockk<ClubJpaRepository>()
+        val clubRepository = mockk<ClubRepository>()
         val userRepository = mockk<UserRepository>()
         val clubFormRepository = mockk<ClubFormRepository>()
         val clubFormSubmissionRepository = mockk<ClubFormSubmissionRepository>()
         val clubFormAnswerRepository = mockk<ClubFormAnswerRepository>()
-        val clubParticipantJpaRepository = mockk<ClubParticipantJpaRepository>()
+        val clubParticipantRepository = mockk<ClubParticipantRepository>()
         val currentUserProvider = mockk<CurrentUserProvider>()
         val service =
             ClubApplicationServiceImpl(
-                clubJpaRepository,
+                clubRepository,
                 userRepository,
                 clubFormRepository,
                 clubFormSubmissionRepository,
                 clubFormAnswerRepository,
-                clubParticipantJpaRepository,
+                clubParticipantRepository,
                 currentUserProvider,
             )
 
@@ -79,21 +79,21 @@ class ClubApplicationServiceTest :
                     val form = ClubFormJpaEntity(id = 10L, club = club, title = "신청 폼", description = null)
                     val submission = ClubFormSubmissionJpaEntity(id = 100L, form = form, user = applicant)
 
-                    every { clubJpaRepository.findById(1L) } returns Optional.of(club)
+                    every { clubRepository.findById(1L) } returns Optional.of(club)
                     every { currentUserProvider.getCurrentUser() } returns leader
-                    every { clubParticipantJpaRepository.existsById(any()) } returns false
+                    every { clubParticipantRepository.existsById(any()) } returns false
                     every { userRepository.findById(2L) } returns Optional.of(applicant)
-                    every { clubParticipantJpaRepository.save(any()) } answers { firstArg<ClubParticipantJpaEntity>() }
+                    every { clubParticipantRepository.save(any()) } answers { firstArg<ClubParticipantJpaEntity>() }
                     every { clubFormRepository.findByClubIdAndIsActiveTrue(1L) } returns form
                     every { clubFormSubmissionRepository.findByFormIdAndUserId(10L, 2L) } returns submission
                     justRun { clubFormAnswerRepository.deleteAllBySubmissionId(100L) }
-                    justRun { clubFormSubmissionRepository.delete(submission) }
+                    justRun { clubFormSubmissionRepository.deleteBySubmissionId(100L) }
 
                     service.execute(1L, 2L)
 
-                    verify(exactly = 1) { clubParticipantJpaRepository.save(any()) }
+                    verify(exactly = 1) { clubParticipantRepository.save(any()) }
                     verify(exactly = 1) { clubFormAnswerRepository.deleteAllBySubmissionId(100L) }
-                    verify(exactly = 1) { clubFormSubmissionRepository.delete(submission) }
+                    verify(exactly = 1) { clubFormSubmissionRepository.deleteBySubmissionId(100L) }
                 }
             }
         }

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/DeleteClubServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/DeleteClubServiceTest.kt
@@ -12,6 +12,12 @@ import org.springframework.http.HttpStatus
 import team.incube.flooding.domain.club.entity.ClubJpaEntity
 import team.incube.flooding.domain.club.entity.ClubStatus
 import team.incube.flooding.domain.club.entity.ClubType
+import team.incube.flooding.domain.club.repository.ClubFormAnswerRepository
+import team.incube.flooding.domain.club.repository.ClubFormFieldOptionRepository
+import team.incube.flooding.domain.club.repository.ClubFormFieldRepository
+import team.incube.flooding.domain.club.repository.ClubFormRepository
+import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
+import team.incube.flooding.domain.club.repository.ClubParticipantRepository
 import team.incube.flooding.domain.club.repository.ClubRepository
 import team.incube.flooding.domain.club.service.impl.DeleteClubServiceImpl
 import team.incube.flooding.domain.user.entity.Role
@@ -24,8 +30,24 @@ import java.util.Optional
 class DeleteClubServiceTest :
     BehaviorSpec({
         val clubRepository = mockk<ClubRepository>()
+        val clubParticipantRepository = mockk<ClubParticipantRepository>()
+        val clubFormRepository = mockk<ClubFormRepository>()
+        val clubFormFieldRepository = mockk<ClubFormFieldRepository>()
+        val clubFormFieldOptionRepository = mockk<ClubFormFieldOptionRepository>()
+        val clubFormSubmissionRepository = mockk<ClubFormSubmissionRepository>()
+        val clubFormAnswerRepository = mockk<ClubFormAnswerRepository>()
         val currentUserProvider = mockk<CurrentUserProvider>()
-        val service = DeleteClubServiceImpl(clubRepository, currentUserProvider)
+        val service =
+            DeleteClubServiceImpl(
+                clubRepository,
+                clubParticipantRepository,
+                clubFormRepository,
+                clubFormFieldRepository,
+                clubFormFieldOptionRepository,
+                clubFormSubmissionRepository,
+                clubFormAnswerRepository,
+                currentUserProvider,
+            )
 
         beforeEach { clearAllMocks() }
 
@@ -53,6 +75,15 @@ class DeleteClubServiceTest :
                 description = null,
                 maxMember = null,
             )
+
+        fun mockDeleteDependencies() {
+            justRun { clubFormAnswerRepository.deleteAllByClubId(1L) }
+            justRun { clubFormSubmissionRepository.deleteAllByClubId(1L) }
+            justRun { clubFormFieldOptionRepository.deleteAllByClubId(1L) }
+            justRun { clubFormFieldRepository.deleteAllByClubId(1L) }
+            justRun { clubFormRepository.deleteAllByClubId(1L) }
+            justRun { clubParticipantRepository.deleteAllByClubId(1L) }
+        }
 
         given("존재하지 않는 clubId로 요청할 때") {
             `when`("삭제하면") {
@@ -86,10 +117,17 @@ class DeleteClubServiceTest :
                     val leader = user(1L, Role.GENERAL_STUDENT)
                     every { clubRepository.findById(1L) } returns Optional.of(club(leader))
                     every { currentUserProvider.getCurrentUser() } returns leader
+                    mockDeleteDependencies()
                     justRun { clubRepository.delete(any()) }
 
                     service.execute(1L)
 
+                    verify(exactly = 1) { clubFormAnswerRepository.deleteAllByClubId(1L) }
+                    verify(exactly = 1) { clubFormSubmissionRepository.deleteAllByClubId(1L) }
+                    verify(exactly = 1) { clubFormFieldOptionRepository.deleteAllByClubId(1L) }
+                    verify(exactly = 1) { clubFormFieldRepository.deleteAllByClubId(1L) }
+                    verify(exactly = 1) { clubFormRepository.deleteAllByClubId(1L) }
+                    verify(exactly = 1) { clubParticipantRepository.deleteAllByClubId(1L) }
                     verify(exactly = 1) { clubRepository.delete(any()) }
                 }
             }
@@ -101,6 +139,7 @@ class DeleteClubServiceTest :
                     val admin = user(1L, Role.ADMIN)
                     every { clubRepository.findById(1L) } returns Optional.of(club(null))
                     every { currentUserProvider.getCurrentUser() } returns admin
+                    mockDeleteDependencies()
                     justRun { clubRepository.delete(any()) }
 
                     service.execute(1L)
@@ -116,6 +155,7 @@ class DeleteClubServiceTest :
                     val council = user(1L, Role.STUDENT_COUNCIL)
                     every { clubRepository.findById(1L) } returns Optional.of(club(null))
                     every { currentUserProvider.getCurrentUser() } returns council
+                    mockDeleteDependencies()
                     justRun { clubRepository.delete(any()) }
 
                     service.execute(1L)

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/GetClubApplicationListServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/GetClubApplicationListServiceTest.kt
@@ -1,0 +1,98 @@
+package team.incube.flooding.domain.club.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import team.incube.flooding.domain.club.entity.ClubFormJpaEntity
+import team.incube.flooding.domain.club.entity.ClubJpaEntity
+import team.incube.flooding.domain.club.entity.ClubStatus
+import team.incube.flooding.domain.club.entity.ClubType
+import team.incube.flooding.domain.club.repository.ClubFormAnswerRepository
+import team.incube.flooding.domain.club.repository.ClubFormRepository
+import team.incube.flooding.domain.club.repository.ClubFormSubmissionRepository
+import team.incube.flooding.domain.club.repository.ClubRepository
+import team.incube.flooding.domain.club.service.impl.GetClubApplicationListServiceImpl
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.global.security.util.CurrentUserProvider
+
+class GetClubApplicationListServiceTest :
+    BehaviorSpec({
+        val clubRepository = mockk<ClubRepository>()
+        val clubFormRepository = mockk<ClubFormRepository>()
+        val submissionRepository = mockk<ClubFormSubmissionRepository>()
+        val answerRepository = mockk<ClubFormAnswerRepository>()
+        val currentUserProvider = mockk<CurrentUserProvider>()
+        val service =
+            GetClubApplicationListServiceImpl(
+                clubRepository,
+                clubFormRepository,
+                submissionRepository,
+                answerRepository,
+                currentUserProvider,
+            )
+
+        beforeEach { clearAllMocks() }
+
+        fun user(id: Long) =
+            UserJpaEntity(
+                id = id,
+                name = "테스트$id",
+                sex = Sex.MAN,
+                email = "test$id@test.com",
+                studentNumber = 10100 + id.toInt(),
+                role = Role.GENERAL_STUDENT,
+                dormitoryRoom = 101,
+            )
+
+        fun club(leader: UserJpaEntity) =
+            ClubJpaEntity(
+                id = 1L,
+                name = "테스트 동아리",
+                type = ClubType.MAJOR_CLUB,
+                leader = leader,
+                imageUrl = null,
+                status = ClubStatus.MAINTAIN,
+                description = null,
+                maxMember = null,
+            )
+
+        given("동아리 신청 목록을 조회할 때") {
+            `when`("활성 폼이 없으면") {
+                then("null 대신 빈 리스트를 반환한다") {
+                    val leader = user(1L)
+                    every { currentUserProvider.getCurrentUser() } returns leader
+                    every { clubRepository.findByIdWithLeader(1L) } returns club(leader)
+                    every { clubFormRepository.findByClubIdAndIsActiveTrue(1L) } returns null
+
+                    val response = service.execute(1L)
+
+                    response.applications.shouldBeEmpty()
+                }
+            }
+
+            `when`("신청자가 없으면") {
+                then("빈 리스트를 반환한다") {
+                    val leader = user(1L)
+                    every { currentUserProvider.getCurrentUser() } returns leader
+                    every { clubRepository.findByIdWithLeader(1L) } returns club(leader)
+                    every { clubFormRepository.findByClubIdAndIsActiveTrue(1L) } returns
+                        ClubFormJpaEntity(
+                            id = 10L,
+                            club = club(leader),
+                            title = "신청 폼",
+                            description = null,
+                        )
+                    every { submissionRepository.findAllByFormIdWithUser(10L) } returns emptyList()
+
+                    val response = service.execute(1L)
+
+                    response.applications shouldBe emptyList()
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/GetClubServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/GetClubServiceTest.kt
@@ -1,0 +1,86 @@
+package team.incube.flooding.domain.club.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContain
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import team.incube.flooding.domain.club.entity.ClubJpaEntity
+import team.incube.flooding.domain.club.entity.ClubParticipantJpaEntity
+import team.incube.flooding.domain.club.entity.ClubStatus
+import team.incube.flooding.domain.club.entity.ClubType
+import team.incube.flooding.domain.club.presentation.data.response.GetClubResponse
+import team.incube.flooding.domain.club.repository.ClubParticipantRepository
+import team.incube.flooding.domain.club.repository.ClubRepository
+import team.incube.flooding.domain.club.service.impl.GetClubServiceImpl
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.global.client.DataGsmProjectClient
+import team.incube.flooding.global.security.util.CurrentUserProvider
+
+class GetClubServiceTest :
+    BehaviorSpec({
+        val clubRepository = mockk<ClubRepository>()
+        val clubParticipantRepository = mockk<ClubParticipantRepository>()
+        val dataGsmProjectClient = mockk<DataGsmProjectClient>()
+        val currentUserProvider = mockk<CurrentUserProvider>()
+        val service =
+            GetClubServiceImpl(
+                clubRepository,
+                clubParticipantRepository,
+                dataGsmProjectClient,
+                currentUserProvider,
+            )
+
+        beforeEach { clearAllMocks() }
+
+        fun user(
+            id: Long,
+            name: String,
+        ) = UserJpaEntity(
+            id = id,
+            name = name,
+            sex = Sex.MAN,
+            email = "test$id@test.com",
+            studentNumber = 10100 + id.toInt(),
+            role = Role.GENERAL_STUDENT,
+            dormitoryRoom = 101,
+        )
+
+        given("동아리 상세를 조회할 때") {
+            `when`("부장이 참가자 목록에 따로 저장되어 있지 않으면") {
+                then("members에 부장을 포함한다") {
+                    val leader = user(1L, "부장")
+                    val member = user(2L, "멤버")
+                    val club =
+                        ClubJpaEntity(
+                            id = 1L,
+                            name = "테스트 동아리",
+                            type = ClubType.MAJOR_CLUB,
+                            leader = leader,
+                            imageUrl = null,
+                            status = ClubStatus.MAINTAIN,
+                            description = null,
+                            maxMember = null,
+                        )
+
+                    every { currentUserProvider.getCurrentUser() } returns leader
+                    every { clubRepository.findByIdWithLeader(1L) } returns club
+                    every { clubParticipantRepository.findAllByClubId(1L) } returns
+                        listOf(ClubParticipantJpaEntity(club = club, user = member))
+
+                    val response = service.execute(1L)
+
+                    response.members shouldContain
+                        GetClubResponse.MemberSummary(
+                            id = leader.id,
+                            name = leader.name,
+                            studentNumber = leader.studentNumber,
+                            sex = leader.sex.name,
+                            specialty = leader.specialty,
+                        )
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

동아리 신청 승인 이후 승인된 신청자가 신청자 목록에 계속 노출되는 문제를 수정했습니다.

동아리 신청 폼이 없거나 신청자가 없는 경우 신청자 목록 API가 빈 배열을 반환하도록 보완했습니다.

동아리 삭제 시 신청 폼, 필드, 옵션, 제출, 답변, 참여자 데이터를 먼저 정리한 뒤 동아리를 삭제하도록 수정했습니다.

동아리 상세 조회에서 동아리장이 members 목록에 포함되도록 수정했습니다.

관련 서비스 테스트를 추가하고 삭제 서비스 테스트를 갱신했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 동아리 신청 승인 후 데이터 정리 순서와 동아리 삭제 시 연관 데이터 삭제 범위를 중점적으로 확인 부탁드립니다.