### PR TITLE
자습 체크인 해제 API 구현

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -20,28 +20,24 @@ class StudyAttendanceSseEmitterRegistry {
 
     @Async
     fun broadcast(event: StudyAttendanceEventResponse) {
-        emitters.forEach { emitter ->
-            try {
-                emitter.send(
-                    SseEmitter
-                        .event()
-                        .name("attendance")
-                        .data(event),
-                )
-            } catch (e: Exception) {
-                emitter.completeWithError(e)
-            }
-        }
+        broadcastEvent("attendance", event)
     }
 
     @Async
     fun broadcastCancel(event: StudyAttendanceEventResponse) {
+        broadcastEvent("cancel-attendance", event)
+    }
+
+    private fun broadcastEvent(
+        name: String,
+        event: StudyAttendanceEventResponse,
+    ) {
         emitters.forEach { emitter ->
             try {
                 emitter.send(
                     SseEmitter
                         .event()
-                        .name("cancel-attendance")
+                        .name(name)
                         .data(event),
                 )
             } catch (e: Exception) {

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -33,4 +33,20 @@ class StudyAttendanceSseEmitterRegistry {
             }
         }
     }
+
+    @Async
+    fun broadcastCancel(event: StudyAttendanceEventResponse) {
+        emitters.forEach { emitter ->
+            try {
+                emitter.send(
+                    SseEmitter
+                        .event()
+                        .name("cancel-attendance")
+                        .data(event),
+                )
+            } catch (e: Exception) {
+                emitter.completeWithError(e)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
@@ -83,6 +83,10 @@ class StudyRedisAdapter(
     fun isAttendanceChecked(userId: Long): Boolean =
         redisTemplate.opsForSet().isMember(ATTENDANCE_KEY, userId.toString()) ?: false
 
+    fun cancelAttendance(userId: Long) {
+        redisTemplate.opsForSet().remove(ATTENDANCE_KEY, userId.toString())
+    }
+
     fun getAttendanceIds(): Set<Long> =
         redisTemplate
             .opsForSet()

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/controller/StudyController.kt
@@ -21,6 +21,7 @@ import team.incube.flooding.domain.dormitory.study.service.GetStudyService
 import team.incube.flooding.domain.dormitory.study.service.StudyApplicationService
 import team.incube.flooding.domain.dormitory.study.service.SubscribeStudyAttendanceService
 import team.incube.flooding.domain.dormitory.study.service.UnbanStudyService
+import team.incube.flooding.domain.dormitory.study.service.UncheckStudyAttendanceService
 import team.themoment.sdk.response.CommonApiResponse
 
 @Tag(name = "자습", description = "자습 신청 관련 API")
@@ -34,6 +35,7 @@ class StudyController(
     private val getStudyService: GetStudyService,
     private val subscribeStudyAttendanceService: SubscribeStudyAttendanceService,
     private val checkStudyAttendanceService: CheckStudyAttendanceService,
+    private val uncheckStudyAttendanceService: UncheckStudyAttendanceService,
 ) {
     @Operation(
         summary = "자습 신청자 목록 조회",
@@ -101,6 +103,22 @@ class StudyController(
         @Parameter(description = "체크인할 학생의 ID") @PathVariable userId: Long,
     ): CommonApiResponse<Nothing> {
         checkStudyAttendanceService.execute(userId)
+        return CommonApiResponse.success("OK")
+    }
+
+    @Operation(
+        summary = "자습 체크인 해제",
+        description = "자습 체크인된 학생의 체크인을 해제합니다. 관리자 또는 기자위 권한이 필요합니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "체크인 해제 성공"),
+        ApiResponse(responseCode = "404", description = "존재하지 않는 학생 또는 체크인 기록 없음"),
+    )
+    @DeleteMapping("/attendance/{userId}")
+    fun uncheckAttendance(
+        @Parameter(description = "체크인 해제할 학생의 ID") @PathVariable userId: Long,
+    ): CommonApiResponse<Nothing> {
+        uncheckStudyAttendanceService.execute(userId)
         return CommonApiResponse.success("OK")
     }
 

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/UncheckStudyAttendanceService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/UncheckStudyAttendanceService.kt
@@ -1,0 +1,5 @@
+package team.incube.flooding.domain.dormitory.study.service
+
+interface UncheckStudyAttendanceService {
+    fun execute(userId: Long)
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UncheckStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UncheckStudyAttendanceServiceImpl.kt
@@ -11,7 +11,7 @@ import team.incube.flooding.domain.user.repository.UserRepository
 import team.themoment.sdk.exception.ExpectedException
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 class UncheckStudyAttendanceServiceImpl(
     private val userRepository: UserRepository,
     private val studyRedisAdapter: StudyRedisAdapter,

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UncheckStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UncheckStudyAttendanceServiceImpl.kt
@@ -1,0 +1,35 @@
+package team.incube.flooding.domain.dormitory.study.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.dormitory.study.adapter.StudyAttendanceSseEmitterRegistry
+import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
+import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
+import team.incube.flooding.domain.dormitory.study.service.UncheckStudyAttendanceService
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+@Transactional(readOnly = true)
+class UncheckStudyAttendanceServiceImpl(
+    private val userRepository: UserRepository,
+    private val studyRedisAdapter: StudyRedisAdapter,
+    private val sseEmitterRegistry: StudyAttendanceSseEmitterRegistry,
+) : UncheckStudyAttendanceService {
+    override fun execute(userId: Long) {
+        val user =
+            userRepository
+                .findById(userId)
+                .orElseThrow { ExpectedException("존재하지 않는 학생입니다.", HttpStatus.NOT_FOUND) }
+
+        if (!studyRedisAdapter.isAttendanceChecked(userId)) {
+            throw ExpectedException("체크인 기록이 없습니다.", HttpStatus.NOT_FOUND)
+        }
+
+        studyRedisAdapter.cancelAttendance(userId)
+        sseEmitterRegistry.broadcastCancel(
+            StudyAttendanceEventResponse(name = user.name, studentNumber = user.studentNumber),
+        )
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -92,6 +92,9 @@ class SecurityConfig(
                 it
                     .requestMatchers(HttpMethod.POST, "/dormitory/studies/attendance/*")
                     .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
+                it
+                    .requestMatchers(HttpMethod.DELETE, "/dormitory/studies/attendance/*")
+                    .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
 
                 // massage
                 it.requestMatchers(HttpMethod.GET, "/dormitory/massages").authenticated()

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/UncheckStudyAttendanceServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/UncheckStudyAttendanceServiceTest.kt
@@ -1,0 +1,100 @@
+package team.incube.flooding.domain.dormitory.study.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpStatus
+import team.incube.flooding.domain.dormitory.study.adapter.StudyAttendanceSseEmitterRegistry
+import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
+import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
+import team.incube.flooding.domain.dormitory.study.service.impl.UncheckStudyAttendanceServiceImpl
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.themoment.sdk.exception.ExpectedException
+import java.util.Optional
+
+class UncheckStudyAttendanceServiceTest :
+    BehaviorSpec({
+        val userRepository = mockk<UserRepository>()
+        val studyRedisAdapter = mockk<StudyRedisAdapter>()
+        val sseEmitterRegistry = mockk<StudyAttendanceSseEmitterRegistry>()
+        val service = UncheckStudyAttendanceServiceImpl(userRepository, studyRedisAdapter, sseEmitterRegistry)
+
+        beforeEach { clearAllMocks() }
+
+        fun user(id: Long) =
+            UserJpaEntity(
+                id = id,
+                name = "학생$id",
+                sex = Sex.MAN,
+                email = "student$id@test.com",
+                studentNumber = 1101,
+                role = Role.GENERAL_STUDENT,
+                dormitoryRoom = 101,
+            )
+
+        given("존재하지 않는 학생 ID로 요청할 때") {
+            `when`("체크인을 해제하면") {
+                then("NOT_FOUND 예외 - 존재하지 않는 학생") {
+                    every { userRepository.findById(1L) } returns Optional.empty()
+
+                    val exception = shouldThrow<ExpectedException> { service.execute(1L) }
+
+                    exception.statusCode shouldBe HttpStatus.NOT_FOUND
+                    exception.message shouldBe "존재하지 않는 학생입니다."
+                }
+            }
+        }
+
+        given("학생은 존재하지만 체크인 기록이 없을 때") {
+            `when`("체크인을 해제하면") {
+                then("NOT_FOUND 예외 - 체크인 기록 없음") {
+                    every { userRepository.findById(1L) } returns Optional.of(user(1L))
+                    every { studyRedisAdapter.isAttendanceChecked(1L) } returns false
+
+                    val exception = shouldThrow<ExpectedException> { service.execute(1L) }
+
+                    exception.statusCode shouldBe HttpStatus.NOT_FOUND
+                    exception.message shouldBe "체크인 기록이 없습니다."
+                }
+            }
+        }
+
+        given("체크인된 학생이 있을 때") {
+            `when`("체크인을 해제하면") {
+                then("Redis에서 체크인을 삭제하고 SSE cancel-attendance 이벤트를 브로드캐스트한다") {
+                    val targetUser = user(1L)
+                    every { userRepository.findById(1L) } returns Optional.of(targetUser)
+                    every { studyRedisAdapter.isAttendanceChecked(1L) } returns true
+                    justRun { studyRedisAdapter.cancelAttendance(1L) }
+                    justRun {
+                        sseEmitterRegistry.broadcastCancel(
+                            StudyAttendanceEventResponse(
+                                name = targetUser.name,
+                                studentNumber = targetUser.studentNumber,
+                            ),
+                        )
+                    }
+
+                    service.execute(1L)
+
+                    verify(exactly = 1) { studyRedisAdapter.cancelAttendance(1L) }
+                    verify(exactly = 1) {
+                        sseEmitterRegistry.broadcastCancel(
+                            StudyAttendanceEventResponse(
+                                name = targetUser.name,
+                                studentNumber = targetUser.studentNumber,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## #️⃣연관된 이슈

> #143

## 📝작업 내용

자습 체크인된 학생의 체크인을 해제하는 API를 추가합니다.

- `DELETE /dormitory/studies/attendance/{userId}` 엔드포인트 추가
- Redis Set에서 해당 학생의 체크인 정보 삭제 (`cancelAttendance`)
- SSE `cancel-attendance` 이벤트 브로드캐스트 (`broadcastCancel`)
- 관리자(`ADMIN`) 및 기자위(`DORMITORY_MANAGER`) 권한으로 접근 제한
- 서비스 단위 테스트 추가 (학생 미존재, 체크인 기록 없음, 정상 해제 시나리오)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음