### PR TITLE
SSE 연결 관리 개선 - open-in-view 비활성화 및 하트비트 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -1,6 +1,7 @@
 package team.incube.flooding.domain.dormitory.study.adapter
 
 import org.springframework.scheduling.annotation.Async
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
@@ -16,6 +17,17 @@ class StudyAttendanceSseEmitterRegistry {
         emitter.onTimeout { emitters.remove(emitter) }
         emitter.onError { emitters.remove(emitter) }
         return emitter
+    }
+
+    @Scheduled(fixedDelay = 30_000L)
+    fun sendHeartbeat() {
+        emitters.forEach { emitter ->
+            try {
+                emitter.send(SseEmitter.event().comment("heartbeat"))
+            } catch (e: Exception) {
+                emitter.completeWithError(e)
+            }
+        }
     }
 
     @Async

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -22,10 +22,12 @@ class StudyAttendanceSseEmitterRegistry {
     @Scheduled(fixedDelay = 30_000L)
     fun sendHeartbeat() {
         emitters.forEach { emitter ->
-            try {
-                emitter.send(SseEmitter.event().comment("heartbeat"))
-            } catch (e: Exception) {
-                emitter.completeWithError(e)
+            synchronized(emitter) {
+                try {
+                    emitter.send(SseEmitter.event().comment("heartbeat"))
+                } catch (e: Exception) {
+                    emitter.completeWithError(e)
+                }
             }
         }
     }
@@ -45,15 +47,17 @@ class StudyAttendanceSseEmitterRegistry {
         event: StudyAttendanceEventResponse,
     ) {
         emitters.forEach { emitter ->
-            try {
-                emitter.send(
-                    SseEmitter
-                        .event()
-                        .name(name)
-                        .data(event),
-                )
-            } catch (e: Exception) {
-                emitter.completeWithError(e)
+            synchronized(emitter) {
+                try {
+                    emitter.send(
+                        SseEmitter
+                            .event()
+                            .name(name)
+                            .data(event),
+                    )
+                } catch (e: Exception) {
+                    emitter.completeWithError(e)
+                }
             }
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,7 @@ spring:
     driver-class-name: ${DB_DRIVER:org.postgresql.Driver}
 
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: ${JPA_DDL_AUTO:update}
     properties:


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

SSE 연결 시 Hikari Connection Pool이 고갈되는 문제와 클라이언트 연결 해지 감지 누락 문제를 수정합니다.

**Hikari Pool 고갈 원인 및 수정**
- `spring.jpa.open-in-view`가 기본값(`true`)으로 동작하고 있었습니다.
- 이 설정은 HTTP 요청 전체 생명주기 동안 JPA EntityManager(Hikari 커넥션)를 유지하는데,
  SSE는 HTTP 요청이 최대 30분간 유지되므로 연결당 커넥션 1개를 계속 점유합니다.
- `open-in-view: false`로 비활성화하여 수정했습니다.

**클라이언트 연결 해지 감지**
- 기존 `onError` / `onCompletion` 콜백만으로는 클라이언트가 조용히 끊었을 때(브라우저 탭 닫기 등) 즉시 감지하지 못합니다.
- `@Scheduled(fixedDelay = 30_000L)` 하트비트를 추가하여 30초마다 comment 이벤트를 전송합니다.
- 클라이언트가 이미 끊겼다면 `send()` 예외 발생 → `completeWithError()` → `onError` 콜백 → emitter 제거로 이어집니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음