### PR TITLE
기상음악 목록 조회 시 현재 유저 좋아요 여부 반환

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/response/WakeUpMusicResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/response/WakeUpMusicResponse.kt
@@ -7,4 +7,8 @@ data class WakeUpMusicResponse(
     val musicUrl: String,
     val appliedAt: LocalDateTime,
     val likeCount: Long,
-)
+    val isLiked: Boolean,
+) {
+    constructor(id: Long, musicUrl: String, appliedAt: LocalDateTime, likeCount: Long) :
+        this(id, musicUrl, appliedAt, likeCount, false)
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicLikeRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicLikeRepository.kt
@@ -1,6 +1,7 @@
 package team.incube.flooding.domain.dormitory.music.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import team.incube.flooding.domain.dormitory.music.entity.WakeUpMusicLikeJpaEntity
 
 interface WakeUpMusicLikeRepository : JpaRepository<WakeUpMusicLikeJpaEntity, Long> {
@@ -17,4 +18,10 @@ interface WakeUpMusicLikeRepository : JpaRepository<WakeUpMusicLikeJpaEntity, Lo
     fun countByMusicId(musicId: Long): Long
 
     fun deleteAllByMusicIdIn(musicIds: List<Long>)
+
+    @Query("SELECT l.music.id FROM WakeUpMusicLikeJpaEntity l WHERE l.user.id = :userId AND l.music.id IN :musicIds")
+    fun findLikedMusicIdsByUserIdAndMusicIdIn(
+        userId: Long,
+        musicIds: List<Long>,
+    ): List<Long>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -48,6 +48,7 @@ class ApplyWakeUpMusicServiceImpl(
             musicUrl = saved.musicUrl,
             appliedAt = saved.appliedAt,
             likeCount = 0,
+            isLiked = false,
         )
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/GetWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/GetWakeUpMusicServiceImpl.kt
@@ -21,8 +21,7 @@ class GetWakeUpMusicServiceImpl(
         val endOfDay = date.plusDays(1).atStartOfDay()
         val musicList = wakeUpMusicRepository.findAllWithLikeCountByDate(startOfDay, endOfDay)
         if (musicList.isEmpty()) return emptyList()
-        val currentUser = runCatching { currentUserProvider.getCurrentUser() }.getOrNull()
-        if (currentUser == null) return musicList
+        val currentUser = currentUserProvider.getCurrentUser()
         val likedIds =
             wakeUpMusicLikeRepository
                 .findLikedMusicIdsByUserIdAndMusicIdIn(currentUser.id, musicList.map { it.id })

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/GetWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/GetWakeUpMusicServiceImpl.kt
@@ -3,18 +3,29 @@ package team.incube.flooding.domain.dormitory.music.service.impl
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
+import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRepository
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.domain.dormitory.music.service.GetWakeUpMusicService
+import team.incube.flooding.global.security.util.CurrentUserProvider
 import java.time.LocalDate
 
 @Service
 class GetWakeUpMusicServiceImpl(
     private val wakeUpMusicRepository: WakeUpMusicRepository,
+    private val wakeUpMusicLikeRepository: WakeUpMusicLikeRepository,
+    private val currentUserProvider: CurrentUserProvider,
 ) : GetWakeUpMusicService {
     @Transactional(readOnly = true)
     override fun execute(date: LocalDate): List<WakeUpMusicResponse> {
         val startOfDay = date.atStartOfDay()
         val endOfDay = date.plusDays(1).atStartOfDay()
-        return wakeUpMusicRepository.findAllWithLikeCountByDate(startOfDay, endOfDay)
+        val musicList = wakeUpMusicRepository.findAllWithLikeCountByDate(startOfDay, endOfDay)
+        if (musicList.isEmpty()) return emptyList()
+        val user = currentUserProvider.getCurrentUser()
+        val likedIds =
+            wakeUpMusicLikeRepository
+                .findLikedMusicIdsByUserIdAndMusicIdIn(user.id, musicList.map { it.id })
+                .toSet()
+        return musicList.map { it.copy(isLiked = it.id in likedIds) }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/GetWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/GetWakeUpMusicServiceImpl.kt
@@ -21,10 +21,11 @@ class GetWakeUpMusicServiceImpl(
         val endOfDay = date.plusDays(1).atStartOfDay()
         val musicList = wakeUpMusicRepository.findAllWithLikeCountByDate(startOfDay, endOfDay)
         if (musicList.isEmpty()) return emptyList()
-        val user = currentUserProvider.getCurrentUser()
+        val currentUser = runCatching { currentUserProvider.getCurrentUser() }.getOrNull()
+        if (currentUser == null) return musicList
         val likedIds =
             wakeUpMusicLikeRepository
-                .findLikedMusicIdsByUserIdAndMusicIdIn(user.id, musicList.map { it.id })
+                .findLikedMusicIdsByUserIdAndMusicIdIn(currentUser.id, musicList.map { it.id })
                 .toSet()
         return musicList.map { it.copy(isLiked = it.id in likedIds) }
     }

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -49,7 +49,6 @@ class SecurityConfig(
                 it.requestMatchers("/auth/signin", "/auth/reissue").permitAll()
                 it.requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
                 it.requestMatchers(*IMAGE_RESOURCE_PATTERNS).permitAll()
-                it.requestMatchers(HttpMethod.GET, "/dormitory/music").permitAll()
                 // ai
                 it.requestMatchers(HttpMethod.POST, "/ai/chat").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/ai/song").authenticated()

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -49,6 +49,7 @@ class SecurityConfig(
                 it.requestMatchers("/auth/signin", "/auth/reissue").permitAll()
                 it.requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
                 it.requestMatchers(*IMAGE_RESOURCE_PATTERNS).permitAll()
+                it.requestMatchers(HttpMethod.GET, "/dormitory/music").permitAll()
                 // ai
                 it.requestMatchers(HttpMethod.POST, "/ai/chat").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/ai/song").authenticated()

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicServiceImplTest.kt
@@ -7,17 +7,28 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
+import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRepository
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.domain.dormitory.music.service.impl.GetWakeUpMusicServiceImpl
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.global.security.util.CurrentUserProvider
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 class GetWakeUpMusicServiceImplTest :
     BehaviorSpec({
         val wakeUpMusicRepository = mockk<WakeUpMusicRepository>()
-        val service = GetWakeUpMusicServiceImpl(wakeUpMusicRepository)
+        val wakeUpMusicLikeRepository = mockk<WakeUpMusicLikeRepository>()
+        val currentUserProvider = mockk<CurrentUserProvider>()
+        val service = GetWakeUpMusicServiceImpl(wakeUpMusicRepository, wakeUpMusicLikeRepository, currentUserProvider)
 
-        beforeEach { clearAllMocks() }
+        val mockUser = mockk<UserJpaEntity>(relaxed = true)
+
+        beforeEach {
+            clearAllMocks()
+            every { mockUser.id } returns 1L
+            every { currentUserProvider.getCurrentUser() } returns mockUser
+        }
 
         given("날짜가 2026-05-14일 때") {
             `when`("execute를 호출하면") {
@@ -32,11 +43,14 @@ class GetWakeUpMusicServiceImplTest :
                                 musicUrl = "https://youtube.com/watch?v=abc",
                                 appliedAt = LocalDateTime.of(2026, 5, 14, 10, 0),
                                 likeCount = 3,
+                                isLiked = false,
                             ),
                         )
 
                     every { wakeUpMusicRepository.findAllWithLikeCountByDate(expectedStart, expectedEnd) } returns
                         mockResponse
+                    every { wakeUpMusicLikeRepository.findLikedMusicIdsByUserIdAndMusicIdIn(1L, listOf(1L)) } returns
+                        emptyList()
 
                     val result = service.execute(date)
 
@@ -61,6 +75,44 @@ class GetWakeUpMusicServiceImplTest :
                     val result = service.execute(date)
 
                     result shouldBe emptyList()
+                }
+            }
+        }
+
+        given("현재 유저가 좋아요를 누른 기상음악이 있을 때") {
+            `when`("execute를 호출하면") {
+                then("isLiked가 true인 항목이 포함된다") {
+                    val date = LocalDate.of(2026, 5, 14)
+                    val expectedStart = LocalDateTime.of(2026, 5, 14, 0, 0)
+                    val expectedEnd = LocalDateTime.of(2026, 5, 15, 0, 0)
+                    val mockResponse =
+                        listOf(
+                            WakeUpMusicResponse(
+                                id = 1L,
+                                musicUrl = "https://youtube.com/watch?v=abc",
+                                appliedAt = LocalDateTime.of(2026, 5, 14, 10, 0),
+                                likeCount = 3,
+                                isLiked = false,
+                            ),
+                            WakeUpMusicResponse(
+                                id = 2L,
+                                musicUrl = "https://youtube.com/watch?v=def",
+                                appliedAt = LocalDateTime.of(2026, 5, 14, 11, 0),
+                                likeCount = 1,
+                                isLiked = false,
+                            ),
+                        )
+
+                    every { wakeUpMusicRepository.findAllWithLikeCountByDate(expectedStart, expectedEnd) } returns
+                        mockResponse
+                    every {
+                        wakeUpMusicLikeRepository.findLikedMusicIdsByUserIdAndMusicIdIn(1L, listOf(1L, 2L))
+                    } returns listOf(2L)
+
+                    val result = service.execute(date)
+
+                    result[0].isLiked shouldBe false
+                    result[1].isLiked shouldBe true
                 }
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

기상음악 목록 조회 API(`GET /dormitory/music`) 응답에 현재 로그인한 유저의 좋아요 여부(`isLiked`) 필드가 누락된 문제를 수정합니다.

- `WakeUpMusicResponse`에 `isLiked: Boolean` 필드 추가
- `WakeUpMusicLikeRepository`에 유저별 좋아요 음악 ID 조회 쿼리 추가
- `GetWakeUpMusicServiceImpl`에서 현재 유저 기준으로 `isLiked` 매핑
  - 미인증 사용자는 `isLiked = false`로 반환
- `GET /dormitory/music` 엔드포인트를 비로그인 접근 허용으로 변경
- `ApplyWakeUpMusicServiceImpl` 신청 응답에도 `isLiked = false` 명시
- 관련 서비스 테스트 업데이트

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음