### PR TITLE
fix: SSE emitter 등록 순서 수정으로 초기 데이터 유실 방지

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -23,10 +23,11 @@ class StudyAttendanceSseEmitterRegistry {
     ): SseEmitter {
         registerCallbacks(emitter)
         synchronized(emitter) {
+            emitters.add(emitter)
             try {
                 initialSend()
-                emitters.add(emitter)
             } catch (e: Exception) {
+                emitters.remove(emitter)
                 emitter.completeWithError(e)
             }
         }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -22,12 +22,11 @@ class StudyAttendanceSseEmitterRegistry {
         initialSend: () -> Unit,
     ): SseEmitter {
         registerCallbacks(emitter)
-        emitters.add(emitter)
         synchronized(emitter) {
             try {
                 initialSend()
+                emitters.add(emitter)
             } catch (e: Exception) {
-                emitters.remove(emitter)
                 emitter.completeWithError(e)
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #147

## 📝작업 내용

`registerWithInitialSend`에서 `emitters.add(emitter)`가 `synchronized` 블록 밖에서 먼저 실행되어 초기 데이터(`connect`, `init`) 전송 전에 broadcast 스레드가 해당 emitter를 발견하고 이벤트를 전송하는 race condition이 존재했습니다.

`emitters.add(emitter)`를 `initialSend()` 완료 이후 `synchronized` 블록 내부로 이동하여 초기 데이터 전송이 완전히 끝난 뒤에만 broadcast 대상에 포함되도록 수정했습니다.

수정 전 이벤트 수신 순서 (잘못됨):
`attendance` → `connect` → `init`

수정 후 이벤트 수신 순서 (정상):
`connect` → `init` → `attendance`

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> `synchronized(emitter)`와 `CopyOnWriteArrayList`의 상호작용이 올바른지 확인 부탁드립니다.