### PR TITLE
SSE broadcast async 스레드 Jackson 직렬화 오류 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -1,15 +1,17 @@
 package team.incube.flooding.domain.dormitory.study.adapter
 
-import org.springframework.http.MediaType
 import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
+import tools.jackson.databind.ObjectMapper
 import java.util.concurrent.CopyOnWriteArrayList
 
 @Component
-class StudyAttendanceSseEmitterRegistry {
+class StudyAttendanceSseEmitterRegistry(
+    private val objectMapper: ObjectMapper,
+) {
     private val emitters = CopyOnWriteArrayList<SseEmitter>()
 
     fun register(emitter: SseEmitter): SseEmitter {
@@ -56,17 +58,17 @@ class StudyAttendanceSseEmitterRegistry {
 
     @Async
     fun broadcast(event: StudyAttendanceEventResponse) {
-        broadcastEvent("attendance", event)
+        broadcastEvent("attendance", objectMapper.writeValueAsString(event))
     }
 
     @Async
     fun broadcastCancel(event: StudyAttendanceEventResponse) {
-        broadcastEvent("cancel-attendance", event)
+        broadcastEvent("cancel-attendance", objectMapper.writeValueAsString(event))
     }
 
     private fun broadcastEvent(
         name: String,
-        event: StudyAttendanceEventResponse,
+        json: String,
     ) {
         emitters.forEach { emitter ->
             synchronized(emitter) {
@@ -75,7 +77,7 @@ class StudyAttendanceSseEmitterRegistry {
                         SseEmitter
                             .event()
                             .name(name)
-                            .data(event, MediaType.APPLICATION_JSON),
+                            .data(json),
                     )
                 } catch (e: Exception) {
                     emitter.completeWithError(e)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.dormitory.study.adapter
 
+import org.springframework.http.MediaType
 import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -74,7 +75,7 @@ class StudyAttendanceSseEmitterRegistry {
                         SseEmitter
                             .event()
                             .name(name)
-                            .data(event),
+                            .data(event, MediaType.APPLICATION_JSON),
                     )
                 } catch (e: Exception) {
                     emitter.completeWithError(e)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -58,12 +58,24 @@ class StudyAttendanceSseEmitterRegistry(
 
     @Async
     fun broadcast(event: StudyAttendanceEventResponse) {
-        broadcastEvent("attendance", objectMapper.writeValueAsString(event))
+        val json =
+            try {
+                objectMapper.writeValueAsString(event)
+            } catch (e: Exception) {
+                return
+            }
+        broadcastEvent("attendance", json)
     }
 
     @Async
     fun broadcastCancel(event: StudyAttendanceEventResponse) {
-        broadcastEvent("cancel-attendance", objectMapper.writeValueAsString(event))
+        val json =
+            try {
+                objectMapper.writeValueAsString(event)
+            } catch (e: Exception) {
+                return
+            }
+        broadcastEvent("cancel-attendance", json)
     }
 
     private fun broadcastEvent(

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.dormitory.study.service.impl
 
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
@@ -36,7 +37,7 @@ class SubscribeStudyAttendanceServiceImpl(
                 SseEmitter
                     .event()
                     .name("init")
-                    .data(initList),
+                    .data(initList, MediaType.APPLICATION_JSON),
             )
         }
     }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
@@ -1,6 +1,5 @@
 package team.incube.flooding.domain.dormitory.study.service.impl
 
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
@@ -9,6 +8,7 @@ import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
 import team.incube.flooding.domain.dormitory.study.service.SubscribeStudyAttendanceService
 import team.incube.flooding.domain.user.repository.UserRepository
+import tools.jackson.databind.ObjectMapper
 
 @Service
 @Transactional(readOnly = true)
@@ -16,6 +16,7 @@ class SubscribeStudyAttendanceServiceImpl(
     private val studyRedisAdapter: StudyRedisAdapter,
     private val userRepository: UserRepository,
     private val sseEmitterRegistry: StudyAttendanceSseEmitterRegistry,
+    private val objectMapper: ObjectMapper,
 ) : SubscribeStudyAttendanceService {
     override fun execute(): SseEmitter {
         val emitter = SseEmitter(1_800_000L)
@@ -37,7 +38,7 @@ class SubscribeStudyAttendanceServiceImpl(
                 SseEmitter
                     .event()
                     .name("init")
-                    .data(initList, MediaType.APPLICATION_JSON),
+                    .data(objectMapper.writeValueAsString(initList)),
             )
         }
     }

--- a/src/main/kotlin/team/incube/flooding/global/config/DotenvEnvironmentPostProcessor.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/DotenvEnvironmentPostProcessor.kt
@@ -1,0 +1,28 @@
+package team.incube.flooding.global.config
+
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.env.EnvironmentPostProcessor
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.MapPropertySource
+import java.io.File
+
+class DotenvEnvironmentPostProcessor : EnvironmentPostProcessor {
+    override fun postProcessEnvironment(
+        environment: ConfigurableEnvironment,
+        application: SpringApplication,
+    ) {
+        val envFile = File(".env")
+        if (!envFile.exists()) return
+
+        val properties =
+            envFile
+                .readLines()
+                .filter { it.isNotBlank() && !it.startsWith("#") && "=" in it }
+                .associate { line ->
+                    val (key, value) = line.split("=", limit = 2)
+                    key.trim() to value.trim()
+                }
+
+        environment.propertySources.addLast(MapPropertySource("dotenv", properties))
+    }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor
@@ -1,0 +1,1 @@
+team.incube.flooding.global.config.DotenvEnvironmentPostProcessor


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

`@Async` 스레드에서 `SseEmitter.send()`에 Kotlin 데이터 클래스를 직접 전달하면
해당 스레드의 `HttpMessageConverter`에 `KotlinModule`이 등록되지 않아
직렬화에 실패하는 문제가 있었습니다.

- `StudyAttendanceSseEmitterRegistry`: `ObjectMapper`를 주입받아
  `broadcast` / `broadcastCancel` 호출 시 `writeValueAsString()`으로
  미리 직렬화한 JSON 문자열을 `emitter.send()`에 전달하도록 변경
- `SubscribeStudyAttendanceServiceImpl`: 초기 `init` 이벤트의 목록 데이터도
  동일한 방식으로 사전 직렬화하도록 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음