### PR TITLE
자습 출석 SSE init 이벤트에 자기 자신이 포함되는 버그 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
@@ -8,6 +8,7 @@ import team.incube.flooding.domain.dormitory.study.adapter.StudyRedisAdapter
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
 import team.incube.flooding.domain.dormitory.study.service.SubscribeStudyAttendanceService
 import team.incube.flooding.domain.user.repository.UserRepository
+import team.incube.flooding.global.security.util.CurrentUserProvider
 import tools.jackson.databind.ObjectMapper
 
 @Service
@@ -17,8 +18,10 @@ class SubscribeStudyAttendanceServiceImpl(
     private val userRepository: UserRepository,
     private val sseEmitterRegistry: StudyAttendanceSseEmitterRegistry,
     private val objectMapper: ObjectMapper,
+    private val currentUserProvider: CurrentUserProvider,
 ) : SubscribeStudyAttendanceService {
     override fun execute(): SseEmitter {
+        val currentUser = currentUserProvider.getCurrentUser()
         val emitter = SseEmitter(1_800_000L)
         return sseEmitterRegistry.registerWithInitialSend(emitter) {
             emitter.send(SseEmitter.event().name("connect").data("connected"))
@@ -30,6 +33,7 @@ class SubscribeStudyAttendanceServiceImpl(
                 } else {
                     userRepository
                         .findAllById(attendanceIds)
+                        .filter { it.id != currentUser.id }
                         .sortedBy { it.studentNumber }
                         .map { StudyAttendanceEventResponse(name = it.name, studentNumber = it.studentNumber) }
                 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

SSE 구독 시 전송되는 `init` 이벤트에 현재 접속한 사용자 본인의 출석 정보가 포함되는 문제를 수정했습니다.

`SubscribeStudyAttendanceServiceImpl`에서 `CurrentUserProvider`로 현재 사용자를 조회한 뒤,
Redis에서 가져온 출석자 목록에서 자기 자신을 필터링하여 제외합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음