### PR TITLE
자습 체크인 SSE 이벤트 미수신 버그 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,19 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+tasks.named<org.springframework.boot.gradle.tasks.run.BootRun>("bootRun") {
+    val envFile = rootProject.file(".env")
+    if (envFile.exists()) {
+        envFile
+            .readLines()
+            .filter { line -> line.isNotBlank() && !line.startsWith("#") && "=" in line }
+            .forEach { line ->
+                val (key, value) = line.split("=", limit = 2)
+                environment(key.trim(), value.trim())
+            }
+    }
+}
+
 ktlint {
     version.set("1.8.0")
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.dormitory.study.adapter
 
+import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -9,10 +10,12 @@ import java.util.concurrent.CopyOnWriteArrayList
 
 @Component
 class StudyAttendanceSseEmitterRegistry {
+    private val log = LoggerFactory.getLogger(javaClass)
     private val emitters = CopyOnWriteArrayList<SseEmitter>()
 
     fun register(emitter: SseEmitter): SseEmitter {
         emitters.add(emitter)
+        log.info("SSE emitter 등록: emitters.size={}", emitters.size)
         emitter.onCompletion { emitters.remove(emitter) }
         emitter.onTimeout { emitters.remove(emitter) }
         emitter.onError { emitters.remove(emitter) }
@@ -34,11 +37,13 @@ class StudyAttendanceSseEmitterRegistry {
 
     @Async
     fun broadcast(event: StudyAttendanceEventResponse) {
+        log.info("broadcast 진입: emitters.size={}, event={}", emitters.size, event)
         broadcastEvent("attendance", event)
     }
 
     @Async
     fun broadcastCancel(event: StudyAttendanceEventResponse) {
+        log.info("broadcastCancel 진입: emitters.size={}, event={}", emitters.size, event)
         broadcastEvent("cancel-attendance", event)
     }
 
@@ -46,6 +51,7 @@ class StudyAttendanceSseEmitterRegistry {
         name: String,
         event: StudyAttendanceEventResponse,
     ) {
+        log.info("broadcastEvent: name={}, emitters.size={}", name, emitters.size)
         emitters.forEach { emitter ->
             synchronized(emitter) {
                 try {
@@ -55,7 +61,9 @@ class StudyAttendanceSseEmitterRegistry {
                             .name(name)
                             .data(event),
                     )
+                    log.info("send 성공: name={}", name)
                 } catch (e: Exception) {
+                    log.error("send 실패: name={}, event={}", name, event, e)
                     emitter.completeWithError(e)
                 }
             }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -34,7 +34,15 @@ class StudyAttendanceSseEmitterRegistry {
 
     @Async
     fun broadcast(event: StudyAttendanceEventResponse) {
-        broadcastEvent("attendance", event)
+        emitters.forEach { emitter ->
+            synchronized(emitter) {
+                try {
+                    emitter.send(SseEmitter.event().data(event))
+                } catch (e: Exception) {
+                    emitter.completeWithError(e)
+                }
+            }
+        }
     }
 
     @Async

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -34,15 +34,7 @@ class StudyAttendanceSseEmitterRegistry {
 
     @Async
     fun broadcast(event: StudyAttendanceEventResponse) {
-        emitters.forEach { emitter ->
-            synchronized(emitter) {
-                try {
-                    emitter.send(SseEmitter.event().data(event))
-                } catch (e: Exception) {
-                    emitter.completeWithError(e)
-                }
-            }
-        }
+        broadcastEvent("attendance", event)
     }
 
     @Async

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/StudyAttendanceEventResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/StudyAttendanceEventResponse.kt
@@ -1,6 +1,7 @@
 package team.incube.flooding.domain.dormitory.study.presentation.data.response
 
 data class StudyAttendanceEventResponse(
+    val userId: Long,
     val name: String,
     val studentNumber: Int,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/CheckStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/CheckStudyAttendanceServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.dormitory.study.service.impl
 
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -18,6 +19,8 @@ class CheckStudyAttendanceServiceImpl(
     private val userRepository: UserRepository,
     private val sseEmitterRegistry: StudyAttendanceSseEmitterRegistry,
 ) : CheckStudyAttendanceService {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     override fun execute(userId: Long) {
         val user =
             userRepository
@@ -33,8 +36,10 @@ class CheckStudyAttendanceServiceImpl(
         }
 
         studyRedisAdapter.checkAttendance(userId)
+        log.info("checkAttendance Redis 반영 완료, broadcast 호출 직전: userId={}", userId)
         sseEmitterRegistry.broadcast(
             StudyAttendanceEventResponse(userId = user.id, name = user.name, studentNumber = user.studentNumber),
         )
+        log.info("broadcast 호출 직후 (비동기 위임 완료): userId={}", userId)
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/CheckStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/CheckStudyAttendanceServiceImpl.kt
@@ -34,7 +34,7 @@ class CheckStudyAttendanceServiceImpl(
 
         studyRedisAdapter.checkAttendance(userId)
         sseEmitterRegistry.broadcast(
-            StudyAttendanceEventResponse(name = user.name, studentNumber = user.studentNumber),
+            StudyAttendanceEventResponse(userId = user.id, name = user.name, studentNumber = user.studentNumber),
         )
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
@@ -29,7 +29,13 @@ class SubscribeStudyAttendanceServiceImpl(
                 userRepository
                     .findAllById(attendanceIds)
                     .sortedBy { it.studentNumber }
-                    .map { StudyAttendanceEventResponse(name = it.name, studentNumber = it.studentNumber) }
+                    .map {
+                        StudyAttendanceEventResponse(
+                            userId = it.id,
+                            name = it.name,
+                            studentNumber = it.studentNumber,
+                        )
+                    }
             }
 
         emitter.send(

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UncheckStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UncheckStudyAttendanceServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.dormitory.study.service.impl
 
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,6 +18,8 @@ class UncheckStudyAttendanceServiceImpl(
     private val studyRedisAdapter: StudyRedisAdapter,
     private val sseEmitterRegistry: StudyAttendanceSseEmitterRegistry,
 ) : UncheckStudyAttendanceService {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     override fun execute(userId: Long) {
         val user =
             userRepository
@@ -28,8 +31,10 @@ class UncheckStudyAttendanceServiceImpl(
         }
 
         studyRedisAdapter.cancelAttendance(userId)
+        log.info("cancelAttendance Redis 반영 완료, broadcastCancel 호출 직전: userId={}", userId)
         sseEmitterRegistry.broadcastCancel(
             StudyAttendanceEventResponse(userId = user.id, name = user.name, studentNumber = user.studentNumber),
         )
+        log.info("broadcastCancel 호출 직후 (비동기 위임 완료): userId={}", userId)
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UncheckStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/UncheckStudyAttendanceServiceImpl.kt
@@ -29,7 +29,7 @@ class UncheckStudyAttendanceServiceImpl(
 
         studyRedisAdapter.cancelAttendance(userId)
         sseEmitterRegistry.broadcastCancel(
-            StudyAttendanceEventResponse(name = user.name, studentNumber = user.studentNumber),
+            StudyAttendanceEventResponse(userId = user.id, name = user.name, studentNumber = user.studentNumber),
         )
     }
 }

--- a/src/main/kotlin/team/incube/flooding/global/config/AsyncConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/AsyncConfig.kt
@@ -1,16 +1,21 @@
 package team.incube.flooding.global.config
 
+import org.slf4j.LoggerFactory
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.AsyncConfigurer
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
 
 @Configuration
 @EnableAsync
-class AsyncConfig {
+class AsyncConfig : AsyncConfigurer {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     @Bean(name = ["taskExecutor"])
-    fun taskExecutor(): Executor {
+    override fun getAsyncExecutor(): Executor {
         val executor = ThreadPoolTaskExecutor()
         executor.corePoolSize = 2
         executor.maxPoolSize = 10
@@ -19,4 +24,15 @@ class AsyncConfig {
         executor.initialize()
         return executor
     }
+
+    override fun getAsyncUncaughtExceptionHandler(): AsyncUncaughtExceptionHandler =
+        AsyncUncaughtExceptionHandler { ex, method, params ->
+            log.error(
+                "@Async 미처리 예외: method={}, params={}, message={}",
+                method.name,
+                params.joinToString(),
+                ex.message,
+                ex,
+            )
+        }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -98,7 +98,7 @@ ai:
     base-url: ${AI_SONG_URL:http://localhost:8082}
 
 jwt:
-  secret: ${JWT_SECRET}
+  secret: ${JWT_SECRET:local-dev-secret-key-must-be-at-least-256bits-long}
   access-token-expiration: ${JWT_ACCESS_EXPIRATION:3600000}
   refresh-token-expiration: ${JWT_REFRESH_EXPIRATION:604800000}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -98,7 +98,7 @@ ai:
     base-url: ${AI_SONG_URL:http://localhost:8082}
 
 jwt:
-  secret: ${JWT_SECRET:local-dev-secret-key-must-be-at-least-256bits-long}
+  secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_EXPIRATION:3600000}
   refresh-token-expiration: ${JWT_REFRESH_EXPIRATION:604800000}
 

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/UncheckStudyAttendanceServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/UncheckStudyAttendanceServiceTest.kt
@@ -77,6 +77,7 @@ class UncheckStudyAttendanceServiceTest :
                     justRun {
                         sseEmitterRegistry.broadcastCancel(
                             StudyAttendanceEventResponse(
+                                userId = targetUser.id,
                                 name = targetUser.name,
                                 studentNumber = targetUser.studentNumber,
                             ),
@@ -89,6 +90,7 @@ class UncheckStudyAttendanceServiceTest :
                     verify(exactly = 1) {
                         sseEmitterRegistry.broadcastCancel(
                             StudyAttendanceEventResponse(
+                                userId = targetUser.id,
                                 name = targetUser.name,
                                 studentNumber = targetUser.studentNumber,
                             ),


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

자습 체크인 시 SSE 이벤트가 클라이언트에 전달되지 않는 버그를 수정합니다.

**원인 — 데이터 구조 불일치**
클라이언트의 `collectCheckedUserIds()`는 `userId` / `id` / `studentId` 중 하나를 찾아야 체크 상태를 업데이트합니다.
기존 서버는 `{ name, studentNumber }` 만 전송하여 userId 추출이 불가했습니다.
`StudyAttendanceEventResponse`에 `userId: Long` 필드를 추가하고, Check / Uncheck / Subscribe 서비스 모두 전달하도록 수정합니다.

추가로 개발 편의를 위해 `bootRun` 태스크에 `.env` 파일 환경변수 자동 로드를 추가합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음