### PR TITLE
SSE 엔드포인트 응답 래퍼 우회 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,7 @@ sdk:
       - "/v3/api-docs/**"
       - "/v3/api-docs"
       - "/swagger-ui/**"
+/      - "/dormitory/studies/attendance"
 
   swagger:
     enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,7 +48,7 @@ sdk:
       - "/v3/api-docs/**"
       - "/v3/api-docs"
       - "/swagger-ui/**"
-/      - "/dormitory/studies/attendance"
+      - "/dormitory/studies/attendance"
 
   swagger:
     enabled: true


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

SSE 스트림 엔드포인트(`/dormitory/studies/attendance`)가 SDK 응답 래퍼에 의해 일반 REST 응답처럼 버퍼링되는 문제를 수정했습니다.

래퍼는 connect + init 이후 추가 데이터가 없으면 응답이 완결된 것으로 판단해 SSE 연결을 강제로 닫았습니다.
`not-wrapping-urls`에 해당 경로를 추가하여 래퍼를 우회하도록 설정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음