### PR TITLE
SSE 스트림 조기 종료 원인 제거 및 초기 전송 비동기 분리

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -46,6 +46,28 @@ class StudyAttendanceSseEmitterRegistry(
         emitter.onError { emitters.remove(emitter) }
     }
 
+    @Async
+    fun sendInitialData(
+        emitter: SseEmitter,
+        initList: List<StudyAttendanceEventResponse>,
+    ) {
+        synchronized(emitter) {
+            try {
+                emitter.send(SseEmitter.event().name("connect").data("connected"))
+                val json = objectMapper.writeValueAsString(initList)
+                emitter.send(
+                    SseEmitter
+                        .event()
+                        .name("init")
+                        .data(json),
+                )
+            } catch (e: Exception) {
+                emitters.remove(emitter)
+                emitter.completeWithError(e)
+            }
+        }
+    }
+
     @Scheduled(fixedDelay = 30_000L)
     fun sendHeartbeat() {
         emitters.forEach { emitter ->

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -51,10 +51,19 @@ class StudyAttendanceSseEmitterRegistry(
         emitter: SseEmitter,
         initList: List<StudyAttendanceEventResponse>,
     ) {
+        val json =
+            try {
+                objectMapper.writeValueAsString(initList)
+            } catch (e: Exception) {
+                log.error("SSE 초기 데이터 직렬화 실패", e)
+                emitters.remove(emitter)
+                emitter.completeWithError(e)
+                return
+            }
+
         synchronized(emitter) {
             try {
                 emitter.send(SseEmitter.event().name("connect").data("connected"))
-                val json = objectMapper.writeValueAsString(initList)
                 emitter.send(
                     SseEmitter
                         .event()
@@ -62,6 +71,7 @@ class StudyAttendanceSseEmitterRegistry(
                         .data(json),
                 )
             } catch (e: Exception) {
+                log.error("SSE 초기 데이터 전송 실패", e)
                 emitters.remove(emitter)
                 emitter.completeWithError(e)
             }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/SubscribeStudyAttendanceServiceImpl.kt
@@ -23,33 +23,27 @@ class SubscribeStudyAttendanceServiceImpl(
     override fun execute(): SseEmitter {
         val currentUser = currentUserProvider.getCurrentUser()
         val emitter = SseEmitter(1_800_000L)
-        return sseEmitterRegistry.registerWithInitialSend(emitter) {
-            emitter.send(SseEmitter.event().name("connect").data("connected"))
 
-            val attendanceIds = studyRedisAdapter.getAttendanceIds()
-            val initList =
-                if (attendanceIds.isEmpty()) {
-                    emptyList()
-                } else {
-                    userRepository
-                        .findAllById(attendanceIds)
-                        .filter { it.id != currentUser.id }
-                        .sortedBy { it.studentNumber }
-                        .map {
-                            StudyAttendanceEventResponse(
-                                userId = it.id,
-                                name = it.name,
-                                studentNumber = it.studentNumber,
-                            )
-                        }
-                }
+        val attendanceIds = studyRedisAdapter.getAttendanceIds()
+        val initList =
+            if (attendanceIds.isEmpty()) {
+                emptyList()
+            } else {
+                userRepository
+                    .findAllById(attendanceIds)
+                    .filter { it.id != currentUser.id }
+                    .sortedBy { it.studentNumber }
+                    .map {
+                        StudyAttendanceEventResponse(
+                            userId = it.id,
+                            name = it.name,
+                            studentNumber = it.studentNumber,
+                        )
+                    }
+            }
 
-            emitter.send(
-                SseEmitter
-                    .event()
-                    .name("init")
-                    .data(objectMapper.writeValueAsString(initList)),
-            )
-        }
+        sseEmitterRegistry.register(emitter)
+        sseEmitterRegistry.sendInitialData(emitter, initList)
+        return emitter
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,7 @@ sdk:
     not-logging-urls:
       - "/v3/api-docs/**"
       - "/swagger-ui/**"
+      - "/dormitory/studies/attendance"
 
   response:
     enabled: true


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

### SSE 초기 이벤트 전송 비동기 분리

기존에는 메인 요청 스레드에서 connect, init 이벤트를 동기적으로 전송하는 도중
Tomcat이 응답 버퍼를 조기 커밋하여 SSE 스트림이 끊기는 현상이 있었습니다.

- SubscribeStudyAttendanceServiceImpl에서 트랜잭션 내 데이터 조회를 먼저 수행
- Emitter 등록 직후 Tomcat에 반환하여 영구 스트리밍 채널(chunked) 확보
- 초기 데이터 전송은 @Async 메서드(sendInitialData)로 분리하여 백그라운드 처리

### LoggingFilter 응답 캐싱 우회 설정 적용

SDK의 LoggingFilter(ContentCachingResponseWrapper)가 SSE 스트림을 버퍼링하면서
Content-Length 헤더를 강제 설정하고 커넥션을 종료하는 치명적인 이슈를 확인하여 application.yml의 sdk.logging.not-logging-urls에 `/dormitory/studies/attendance` 경로를 추가하여 우회 처리를 수행하였습니다.

https://github.com/user-attachments/assets/6ca6b2af-9b42-4f89-97c8-082da9d59971

## 💬리뷰 요구사항(선택)

> SDK 내장 LoggingFilter 우회를 위해 not-logging-urls 설정을 활용했습니다.
> 추가로 우회가 필요한 SSE 또는 스트리밍 엔드포인트가 있는지 함께 검토 부탁드립니다.