### PR TITLE
이미지 업로드 본문 생성 방식 변경

### DIFF
--- a/src/main/kotlin/team/incube/flooding/global/util/FileStorageService.kt
+++ b/src/main/kotlin/team/incube/flooding/global/util/FileStorageService.kt
@@ -12,7 +12,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import team.incube.flooding.global.config.FileStorageProperties
 import team.themoment.sdk.exception.ExpectedException
 import java.io.IOException
-import java.io.PushbackInputStream
 import java.util.UUID
 
 @Component
@@ -31,20 +30,18 @@ class FileStorageService(
         val objectKey = getObjectKey(subDir, fileName)
 
         try {
-            file.inputStream.use { rawInputStream ->
-                val inputStream = PushbackInputStream(rawInputStream, IMAGE_SIGNATURE_READ_SIZE)
-                validateImageSignature(inputStream)
-                s3Client.putObject(
-                    PutObjectRequest
-                        .builder()
-                        .bucket(fileStorageProperties.bucket)
-                        .key(objectKey)
-                        .contentType(image.contentType)
-                        .cacheControl("public, max-age=31536000, immutable")
-                        .build(),
-                    RequestBody.fromInputStream(inputStream, file.size),
-                )
-            }
+            val fileBytes = file.bytes
+            validateImageSignature(fileBytes)
+            s3Client.putObject(
+                PutObjectRequest
+                    .builder()
+                    .bucket(fileStorageProperties.bucket)
+                    .key(objectKey)
+                    .contentType(image.contentType)
+                    .cacheControl("public, max-age=31536000, immutable")
+                    .build(),
+                RequestBody.fromBytes(fileBytes),
+            )
         } catch (exception: ExpectedException) {
             throw exception
         } catch (exception: IOException) {
@@ -121,18 +118,9 @@ class FileStorageService(
         return extension
     }
 
-    private fun validateImageSignature(inputStream: PushbackInputStream) {
-        val header =
-            runCatching {
-                val bytes = ByteArray(IMAGE_SIGNATURE_READ_SIZE)
-                val bytesRead = inputStream.readNBytes(bytes, 0, IMAGE_SIGNATURE_READ_SIZE)
-
-                if (bytesRead > 0) {
-                    inputStream.unread(bytes, 0, bytesRead)
-                }
-
-                bytes.copyOf(bytesRead)
-            }.getOrElse { throw ExpectedException("이미지 파일을 읽을 수 없습니다.", HttpStatus.BAD_REQUEST) }
+    private fun validateImageSignature(bytes: ByteArray) {
+        val readSize = minOf(bytes.size, IMAGE_SIGNATURE_READ_SIZE)
+        val header = bytes.copyOf(readSize)
 
         if (!hasValidImageSignature(header)) {
             throw ExpectedException("지원하지 않는 이미지 형식입니다.", HttpStatus.BAD_REQUEST)

--- a/src/test/kotlin/team/incube/flooding/global/util/FileStorageServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/global/util/FileStorageServiceTest.kt
@@ -11,7 +11,6 @@ import io.mockk.slot
 import io.mockk.verify
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.MockMultipartFile
-import org.springframework.web.multipart.MultipartFile
 import software.amazon.awssdk.core.exception.SdkClientException
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
@@ -21,8 +20,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectResponse
 import team.incube.flooding.global.config.FileStorageProperties
 import team.themoment.sdk.exception.ExpectedException
-import java.io.IOException
-import java.io.InputStream
 
 class FileStorageServiceTest :
     BehaviorSpec({
@@ -116,16 +113,16 @@ class FileStorageServiceTest :
             }
         }
 
-        given("한 번만 열 수 있는 이미지 스트림이 주어졌을 때") {
+        given("정상 이미지 bytes가 주어졌을 때") {
             `when`("저장하면") {
-                then("같은 스트림으로 검증과 저장을 수행한다") {
+                then("검증한 bytes를 R2 업로드 본문으로 사용한다") {
                     every { s3Client.putObject(any<PutObjectRequest>(), any<RequestBody>()) } answers {
                         secondArg<RequestBody>().contentStreamProvider().newStream().use { inputStream ->
                             inputStream.readAllBytes() shouldBe pngBytes()
                         }
                         PutObjectResponse.builder().eTag("etag").build()
                     }
-                    val file = SingleUseMultipartFile()
+                    val file = MockMultipartFile("image", "profile.png", "image/png", pngBytes())
 
                     val imageUrl = service.store(file, "clubs")
 
@@ -219,29 +216,3 @@ private fun pngBytes(): ByteArray =
         0x00,
         0x00,
     )
-
-private class SingleUseMultipartFile : MultipartFile {
-    private var opened = false
-
-    override fun getName(): String = "image"
-
-    override fun getOriginalFilename(): String = "profile.png"
-
-    override fun getContentType(): String = "image/png"
-
-    override fun isEmpty(): Boolean = false
-
-    override fun getSize(): Long = pngBytes().size.toLong()
-
-    override fun getBytes(): ByteArray = pngBytes()
-
-    override fun getInputStream(): InputStream {
-        if (opened) {
-            throw IOException("stream already consumed")
-        }
-        opened = true
-        return pngBytes().inputStream()
-    }
-
-    override fun transferTo(dest: java.io.File) = Unit
-}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

R2 업로드 본문 생성 방식을 `InputStream` 기반에서 byte array 기반으로 변경했습니다.

이미지 파일을 `file.bytes`로 한 번 읽은 뒤, 같은 byte array로 이미지 시그니처 검증과 R2 업로드 본문 생성을 수행하도록 단순화했습니다.

`RequestBody.fromInputStream(...)` 대신 `RequestBody.fromBytes(...)`를 사용해 업로드 본문 생성 방식이 스트림 상태에 의존하지 않도록 수정했습니다.

스트림 재사용 검증 테스트는 byte array 업로드 본문 검증 테스트로 정리했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> R2 업로드 본문 생성 방식이 byte array 기반으로 변경된 점 확인 부탁드립니다.
>
> 테스트: `./gradlew test --tests team.incube.flooding.global.util.FileStorageServiceTest --tests team.incube.flooding.domain.club.service.UploadClubRepresentativeImageServiceImplTest`, `./gradlew ktlintCheck`