### PR TITLE
기상음악 목록 조회가 좋아요를 포함하는 목록을 조회하여 빈 목록을 반환하는 문제 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
@@ -15,7 +15,7 @@ interface WakeUpMusicRepository : JpaRepository<WakeUpMusicJpaEntity, Long> {
         """
         SELECT new team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse(
             m.id, m.musicUrl, m.appliedAt, COUNT(l.id))
-        FROM WakeUpMusicJpaEntity m LEFT JOIN WakeUpMusicLikeJpaEntity l ON m.id = l.music.id
+        FROM WakeUpMusicJpaEntity m LEFT JOIN WakeUpMusicLikeJpaEntity l ON l.music = m
         WHERE m.appliedAt >= :startOfDay AND m.appliedAt < :endOfDay
         GROUP BY m.id, m.musicUrl, m.appliedAt
         ORDER BY m.appliedAt DESC


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

기상음악 목록 조회 API(`GET /dormitory/music`)가 항상 빈 배열을 반환하던 문제를 수정했습니다.

**원인**
기상음악 조회 JPQL 쿼리의 LEFT JOIN 조건이 `ON m.id = l.music.id`로 작성되어 있었습니다.
`l.music.id`는 연관 엔티티를 경로 탐색하는 표현으로, Hibernate 6가 이를 해석하는 과정에서
`WakeUpMusicLikeJpaEntity.music`에 대한 암묵적 INNER JOIN을 추가로 생성합니다.
LEFT JOIN 뒤에 INNER JOIN이 붙으면 좋아요가 없는 음악(`l.* = NULL`)은 INNER JOIN 조건을 통과하지 못해 결과에서 제외됩니다.
신청 직후의 음악은 좋아요가 0개이므로 날짜와 무관하게 항상 빈 목록이 반환되었습니다.

**수정**
JOIN 조건을 `ON l.music = m`(엔티티 직접 비교)으로 변경했습니다.
Hibernate가 이를 `l.music_id = m.id`로 변환하며 추가 JOIN 없이 정확한 LEFT JOIN SQL을 생성합니다.

### 스크린샷 (선택)

<img width="1540" height="869" alt="image" src="https://github.com/user-attachments/assets/1d6741ec-2ed6-4b77-84ad-90e2b0b69d6a" />

## 💬리뷰 요구사항(선택)

> 없음