### PR TITLE
기상음악 신청 시 YouTube API로 메타데이터 자동 저장

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,10 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
+    // OpenFeign
+    implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2025.0.0"))
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
     // External SDK
     implementation("com.github.themoment-team:datagsm-oauth-sdk-java:1.4.1")
     implementation("com.github.themoment-team:the-sdk:1.4")

--- a/src/main/kotlin/team/incube/flooding/FloodingServerV2Application.kt
+++ b/src/main/kotlin/team/incube/flooding/FloodingServerV2Application.kt
@@ -3,11 +3,13 @@ package team.incube.flooding
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableScheduling
+@EnableFeignClients
 class FloodingServerV2Application
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
@@ -23,9 +23,9 @@ class WakeUpMusicJpaEntity(
     val user: UserJpaEntity,
     @field:Column(name = "music_url", nullable = false)
     val musicUrl: String,
-    @field:Column(name = "title")
+    @field:Column(name = "title", nullable = true)
     val title: String? = null,
-    @field:Column(name = "artist")
+    @field:Column(name = "artist", nullable = true)
     val artist: String? = null,
     @field:Column(name = "applied_at", nullable = false)
     val appliedAt: LocalDateTime,

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
@@ -33,6 +33,8 @@ class WakeUpMusicJpaEntity(
     val durationText: String? = null,
     @field:Column(name = "thumbnail_url", nullable = true)
     val thumbnailUrl: String? = null,
+    @field:Column(name = "video_url", nullable = true)
+    val videoUrl: String? = null,
     @field:Column(name = "applied_at", nullable = false)
     val appliedAt: LocalDateTime,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/entity/WakeUpMusicJpaEntity.kt
@@ -27,6 +27,12 @@ class WakeUpMusicJpaEntity(
     val title: String? = null,
     @field:Column(name = "artist", nullable = true)
     val artist: String? = null,
+    @field:Column(name = "duration", nullable = true)
+    val duration: String? = null,
+    @field:Column(name = "duration_text", nullable = true)
+    val durationText: String? = null,
+    @field:Column(name = "thumbnail_url", nullable = true)
+    val thumbnailUrl: String? = null,
     @field:Column(name = "applied_at", nullable = false)
     val appliedAt: LocalDateTime,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -8,6 +8,7 @@ import team.incube.flooding.domain.dormitory.music.presentation.data.response.Wa
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRepository
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.domain.dormitory.music.service.ApplyWakeUpMusicService
+import team.incube.flooding.global.client.YoutubeClient
 import team.incube.flooding.global.security.util.CurrentUserProvider
 import java.time.Clock
 import java.time.LocalDateTime
@@ -17,6 +18,7 @@ class ApplyWakeUpMusicServiceImpl(
     private val wakeUpMusicRepository: WakeUpMusicRepository,
     private val wakeUpMusicLikeRepository: WakeUpMusicLikeRepository,
     private val currentUserProvider: CurrentUserProvider,
+    private val youtubeClient: YoutubeClient,
     private val clock: Clock,
 ) : ApplyWakeUpMusicService {
     companion object {
@@ -34,11 +36,18 @@ class ApplyWakeUpMusicServiceImpl(
             wakeUpMusicRepository.deleteAllInBatch(toDelete)
         }
 
+        val videoInfo = youtubeClient.getVideoInfo(request.musicUrl)
+
         val saved =
             wakeUpMusicRepository.save(
                 WakeUpMusicJpaEntity(
                     user = user,
                     musicUrl = request.musicUrl,
+                    title = videoInfo?.title,
+                    artist = videoInfo?.artist,
+                    duration = videoInfo?.duration,
+                    durationText = videoInfo?.durationText,
+                    thumbnailUrl = videoInfo?.thumbnailUrl,
                     appliedAt = LocalDateTime.now(clock),
                 ),
             )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -48,6 +48,7 @@ class ApplyWakeUpMusicServiceImpl(
                     duration = videoInfo?.duration,
                     durationText = videoInfo?.durationText,
                     thumbnailUrl = videoInfo?.thumbnailUrl,
+                    videoUrl = videoInfo?.videoUrl,
                     appliedAt = LocalDateTime.now(clock),
                 ),
             )

--- a/src/main/kotlin/team/incube/flooding/global/client/YoutubeApiClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/YoutubeApiClient.kt
@@ -1,0 +1,47 @@
+package team.incube.flooding.global.client
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(
+    name = "youtube",
+    url = "https://www.googleapis.com/youtube/v3",
+    configuration = [YoutubeApiClientConfig::class],
+)
+interface YoutubeApiClient {
+    @GetMapping("/videos")
+    fun getVideos(
+        @RequestParam("part") part: String,
+        @RequestParam("id") id: String,
+    ): YoutubeVideoListResponse
+}
+
+data class YoutubeVideoListResponse(
+    val items: List<YoutubeVideoItem>?,
+)
+
+data class YoutubeVideoItem(
+    val snippet: YoutubeSnippet?,
+    val contentDetails: YoutubeContentDetails?,
+)
+
+data class YoutubeSnippet(
+    val title: String,
+    val channelTitle: String,
+    val thumbnails: YoutubeThumbnails?,
+)
+
+data class YoutubeContentDetails(
+    val duration: String?,
+)
+
+data class YoutubeThumbnails(
+    val default: YoutubeThumbnail?,
+    val high: YoutubeThumbnail?,
+    val maxres: YoutubeThumbnail?,
+)
+
+data class YoutubeThumbnail(
+    val url: String?,
+)

--- a/src/main/kotlin/team/incube/flooding/global/client/YoutubeApiClientConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/YoutubeApiClientConfig.kt
@@ -1,0 +1,12 @@
+package team.incube.flooding.global.client
+
+import feign.RequestInterceptor
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+
+class YoutubeApiClientConfig {
+    @Bean
+    fun youtubeApiKeyInterceptor(
+        @Value("\${youtube.api-key}") apiKey: String,
+    ): RequestInterceptor = RequestInterceptor { template -> template.query("key", apiKey) }
+}

--- a/src/main/kotlin/team/incube/flooding/global/client/YoutubeClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/YoutubeClient.kt
@@ -1,23 +1,14 @@
 package team.incube.flooding.global.client
 
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import org.springframework.web.client.RestClient
 import java.net.URI
 
 @Component
 class YoutubeClient(
-    @Value("\${youtube.api-key}") private val apiKey: String,
+    private val youtubeApiClient: YoutubeApiClient,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-
-    private val restClient: RestClient by lazy {
-        RestClient
-            .builder()
-            .baseUrl("https://www.googleapis.com/youtube/v3")
-            .build()
-    }
 
     data class VideoInfo(
         val title: String,
@@ -30,18 +21,9 @@ class YoutubeClient(
     fun getVideoInfo(videoUrl: String): VideoInfo? {
         val videoId = extractVideoId(videoUrl) ?: return null
         return runCatching {
-            restClient
-                .get()
-                .uri {
-                    it
-                        .path("/videos")
-                        .queryParam("part", "snippet,contentDetails")
-                        .queryParam("id", videoId)
-                        .queryParam("key", apiKey)
-                        .build()
-                }.retrieve()
-                .body(YoutubeResponse::class.java)
-                ?.items
+            youtubeApiClient
+                .getVideos(part = "snippet,contentDetails", id = videoId)
+                .items
                 ?.firstOrNull()
                 ?.let { item ->
                     val snippet = item.snippet ?: return@let null
@@ -81,11 +63,7 @@ class YoutubeClient(
                 ?.groupValues
                 ?.get(1)
                 ?.toLongOrNull() ?: 0L
-        return if (hours > 0) {
-            "%d:%02d:%02d".format(hours, minutes, seconds)
-        } else {
-            "%d:%02d".format(minutes, seconds)
-        }
+        return if (hours > 0) "%d:%02d:%02d".format(hours, minutes, seconds) else "%d:%02d".format(minutes, seconds)
     }
 
     private fun extractVideoId(url: String): String? =
@@ -113,33 +91,4 @@ class YoutubeClient(
                 }
             }
         }.getOrNull()
-
-    private data class YoutubeResponse(
-        val items: List<YoutubeItem>?,
-    )
-
-    private data class YoutubeItem(
-        val snippet: YoutubeSnippet?,
-        val contentDetails: YoutubeContentDetails?,
-    )
-
-    private data class YoutubeSnippet(
-        val title: String,
-        val channelTitle: String,
-        val thumbnails: YoutubeThumbnails?,
-    )
-
-    private data class YoutubeContentDetails(
-        val duration: String?,
-    )
-
-    private data class YoutubeThumbnails(
-        val default: YoutubeThumbnail?,
-        val high: YoutubeThumbnail?,
-        val maxres: YoutubeThumbnail?,
-    )
-
-    private data class YoutubeThumbnail(
-        val url: String?,
-    )
 }

--- a/src/main/kotlin/team/incube/flooding/global/client/YoutubeClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/YoutubeClient.kt
@@ -1,0 +1,145 @@
+package team.incube.flooding.global.client
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import java.net.URI
+
+@Component
+class YoutubeClient(
+    @Value("\${youtube.api-key}") private val apiKey: String,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val restClient: RestClient by lazy {
+        RestClient
+            .builder()
+            .baseUrl("https://www.googleapis.com/youtube/v3")
+            .build()
+    }
+
+    data class VideoInfo(
+        val title: String,
+        val artist: String,
+        val duration: String,
+        val durationText: String,
+        val thumbnailUrl: String,
+    )
+
+    fun getVideoInfo(videoUrl: String): VideoInfo? {
+        val videoId = extractVideoId(videoUrl) ?: return null
+        return runCatching {
+            restClient
+                .get()
+                .uri {
+                    it
+                        .path("/videos")
+                        .queryParam("part", "snippet,contentDetails")
+                        .queryParam("id", videoId)
+                        .queryParam("key", apiKey)
+                        .build()
+                }.retrieve()
+                .body(YoutubeResponse::class.java)
+                ?.items
+                ?.firstOrNull()
+                ?.let { item ->
+                    val snippet = item.snippet ?: return@let null
+                    val isoDuration = item.contentDetails?.duration ?: "PT0S"
+                    VideoInfo(
+                        title = snippet.title,
+                        artist = snippet.channelTitle,
+                        duration = isoDuration,
+                        durationText = formatDuration(isoDuration),
+                        thumbnailUrl =
+                            snippet.thumbnails?.maxres?.url
+                                ?: snippet.thumbnails?.high?.url
+                                ?: snippet.thumbnails?.default?.url
+                                ?: "",
+                    )
+                }
+        }.onFailure { log.error("YouTube 영상 정보 조회 실패: videoId=$videoId", it) }
+            .getOrNull()
+    }
+
+    private fun formatDuration(isoDuration: String): String {
+        val hours =
+            Regex("(\\d+)H")
+                .find(isoDuration)
+                ?.groupValues
+                ?.get(1)
+                ?.toLongOrNull() ?: 0L
+        val minutes =
+            Regex("(\\d+)M")
+                .find(isoDuration)
+                ?.groupValues
+                ?.get(1)
+                ?.toLongOrNull() ?: 0L
+        val seconds =
+            Regex("(\\d+)S")
+                .find(isoDuration)
+                ?.groupValues
+                ?.get(1)
+                ?.toLongOrNull() ?: 0L
+        return if (hours > 0) {
+            "%d:%02d:%02d".format(hours, minutes, seconds)
+        } else {
+            "%d:%02d".format(minutes, seconds)
+        }
+    }
+
+    private fun extractVideoId(url: String): String? =
+        runCatching {
+            val uri = URI(url)
+            when {
+                uri.host?.contains("youtu.be") == true -> {
+                    uri.path.trimStart('/')
+                }
+
+                uri.host?.contains("youtube.com") == true -> {
+                    val path = uri.path ?: ""
+                    if (path.startsWith("/embed/") || path.startsWith("/v/")) {
+                        path.split("/").lastOrNull()
+                    } else {
+                        uri.query
+                            ?.split("&")
+                            ?.firstOrNull { it.startsWith("v=") }
+                            ?.removePrefix("v=")
+                    }
+                }
+
+                else -> {
+                    null
+                }
+            }
+        }.getOrNull()
+
+    private data class YoutubeResponse(
+        val items: List<YoutubeItem>?,
+    )
+
+    private data class YoutubeItem(
+        val snippet: YoutubeSnippet?,
+        val contentDetails: YoutubeContentDetails?,
+    )
+
+    private data class YoutubeSnippet(
+        val title: String,
+        val channelTitle: String,
+        val thumbnails: YoutubeThumbnails?,
+    )
+
+    private data class YoutubeContentDetails(
+        val duration: String?,
+    )
+
+    private data class YoutubeThumbnails(
+        val default: YoutubeThumbnail?,
+        val high: YoutubeThumbnail?,
+        val maxres: YoutubeThumbnail?,
+    )
+
+    private data class YoutubeThumbnail(
+        val url: String?,
+    )
+}

--- a/src/main/kotlin/team/incube/flooding/global/client/YoutubeClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/YoutubeClient.kt
@@ -16,6 +16,7 @@ class YoutubeClient(
         val duration: String,
         val durationText: String,
         val thumbnailUrl: String,
+        val videoUrl: String,
     )
 
     fun getVideoInfo(videoUrl: String): VideoInfo? {
@@ -38,6 +39,7 @@ class YoutubeClient(
                                 ?: snippet.thumbnails?.high?.url
                                 ?: snippet.thumbnails?.default?.url
                                 ?: "",
+                        videoUrl = "https://www.youtube.com/watch?v=$videoId",
                     )
                 }
         }.onFailure { log.error("YouTube 영상 정보 조회 실패: videoId=$videoId", it) }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -99,6 +99,9 @@ ai:
   song:
     base-url: ${AI_SONG_URL:http://localhost:8082}
 
+youtube:
+  api-key: ${YOUTUBE_API_KEY}
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_EXPIRATION:3600000}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

기상음악 URL 신청 시 서버에서 YouTube Data API v3를 호출하여 영상 메타데이터를 자동으로 저장합니다.

- `WakeUpMusicJpaEntity`에 `title`, `artist`, `duration`, `durationText`, `thumbnailUrl`, `videoUrl` 필드 추가
- `YoutubeApiClient` (OpenFeign 인터페이스) 및 API 키 인터셉터 구현
- `YoutubeClient` 어댑터에서 video ID 추출, ISO 8601 duration 파싱(`3:45` 형식 변환), 정규화된 YouTube URL 구성 처리
- `ApplyWakeUpMusicServiceImpl`에서 YouTube API 호출 후 메타데이터 함께 저장
- YouTube API 호출 실패 시에도 음악 신청은 정상 처리 (메타데이터는 null 저장)
- `YOUTUBE_API_KEY` 환경변수 추가 필요

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음