### PR TITLE
기상음악 응답에 YouTube 메타데이터 필드 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/response/WakeUpMusicResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/response/WakeUpMusicResponse.kt
@@ -5,10 +5,13 @@ import java.time.LocalDateTime
 data class WakeUpMusicResponse(
     val id: Long,
     val musicUrl: String,
+    val title: String?,
+    val artist: String?,
+    val duration: String?,
+    val durationText: String?,
+    val thumbnailUrl: String?,
+    val videoUrl: String?,
     val appliedAt: LocalDateTime,
     val likeCount: Long,
-    val isLiked: Boolean,
-) {
-    constructor(id: Long, musicUrl: String, appliedAt: LocalDateTime, likeCount: Long) :
-        this(id, musicUrl, appliedAt, likeCount, false)
-}
+    val isLiked: Boolean = false,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
@@ -14,10 +14,10 @@ interface WakeUpMusicRepository : JpaRepository<WakeUpMusicJpaEntity, Long> {
     @Query(
         """
         SELECT new team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse(
-            m.id, m.musicUrl, m.appliedAt, COUNT(l.id))
+            m.id, m.musicUrl, m.title, m.artist, m.duration, m.durationText, m.thumbnailUrl, m.videoUrl, m.appliedAt, COUNT(l.id))
         FROM WakeUpMusicJpaEntity m LEFT JOIN WakeUpMusicLikeJpaEntity l ON l.music = m
         WHERE m.appliedAt >= :startOfDay AND m.appliedAt < :endOfDay
-        GROUP BY m.id, m.musicUrl, m.appliedAt
+        GROUP BY m.id, m.musicUrl, m.title, m.artist, m.duration, m.durationText, m.thumbnailUrl, m.videoUrl, m.appliedAt
         ORDER BY m.appliedAt DESC
     """,
     )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -56,6 +56,12 @@ class ApplyWakeUpMusicServiceImpl(
         return WakeUpMusicResponse(
             id = saved.id,
             musicUrl = saved.musicUrl,
+            title = saved.title,
+            artist = saved.artist,
+            duration = saved.duration,
+            durationText = saved.durationText,
+            thumbnailUrl = saved.thumbnailUrl,
+            videoUrl = saved.videoUrl,
             appliedAt = saved.appliedAt,
             likeCount = 0,
             isLiked = false,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

기상음악 신청 및 목록 조회 응답(WakeUpMusicResponse)에 YouTube 메타데이터 필드를 추가하였습니다.

- WakeUpMusicResponse에 title, artist, duration, durationText, thumbnailUrl, videoUrl 필드 추가
- JPQL 쿼리에 새 필드 반영 및 GROUP BY 절 업데이트
- 기상음악 신청 응답에도 저장된 메타데이터 포함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음