### PR TITLE
기상음악 신청 시 YouTube API 오류 처리 개선

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.dormitory.music.service.impl
 
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.music.entity.WakeUpMusicJpaEntity
@@ -10,6 +11,7 @@ import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicReposit
 import team.incube.flooding.domain.dormitory.music.service.ApplyWakeUpMusicService
 import team.incube.flooding.global.client.YoutubeClient
 import team.incube.flooding.global.security.util.CurrentUserProvider
+import team.themoment.sdk.exception.ExpectedException
 import java.time.Clock
 import java.time.LocalDateTime
 
@@ -36,19 +38,21 @@ class ApplyWakeUpMusicServiceImpl(
             wakeUpMusicRepository.deleteAllInBatch(toDelete)
         }
 
-        val videoInfo = youtubeClient.getVideoInfo(request.musicUrl)
+        val videoInfo =
+            youtubeClient.getVideoInfo(request.musicUrl)
+                ?: throw ExpectedException("YouTube 영상 정보를 가져오지 못했습니다. URL을 확인해주세요.", HttpStatus.BAD_REQUEST)
 
         val saved =
             wakeUpMusicRepository.save(
                 WakeUpMusicJpaEntity(
                     user = user,
                     musicUrl = request.musicUrl,
-                    title = videoInfo?.title,
-                    artist = videoInfo?.artist,
-                    duration = videoInfo?.duration,
-                    durationText = videoInfo?.durationText,
-                    thumbnailUrl = videoInfo?.thumbnailUrl,
-                    videoUrl = videoInfo?.videoUrl,
+                    title = videoInfo.title,
+                    artist = videoInfo.artist,
+                    duration = videoInfo.duration,
+                    durationText = videoInfo.durationText,
+                    thumbnailUrl = videoInfo.thumbnailUrl,
+                    videoUrl = videoInfo.videoUrl,
                     appliedAt = LocalDateTime.now(clock),
                 ),
             )

--- a/src/main/kotlin/team/incube/flooding/global/client/YoutubeClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/YoutubeClient.kt
@@ -22,26 +22,26 @@ class YoutubeClient(
     fun getVideoInfo(videoUrl: String): VideoInfo? {
         val videoId = extractVideoId(videoUrl) ?: return null
         return runCatching {
-            youtubeApiClient
-                .getVideos(part = "snippet,contentDetails", id = videoId)
-                .items
-                ?.firstOrNull()
-                ?.let { item ->
-                    val snippet = item.snippet ?: return@let null
-                    val isoDuration = item.contentDetails?.duration ?: "PT0S"
-                    VideoInfo(
-                        title = snippet.title,
-                        artist = snippet.channelTitle,
-                        duration = isoDuration,
-                        durationText = formatDuration(isoDuration),
-                        thumbnailUrl =
-                            snippet.thumbnails?.maxres?.url
-                                ?: snippet.thumbnails?.high?.url
-                                ?: snippet.thumbnails?.default?.url
-                                ?: "",
-                        videoUrl = "https://www.youtube.com/watch?v=$videoId",
-                    )
-                }
+            val response = youtubeApiClient.getVideos(part = "snippet,contentDetails", id = videoId)
+            val item = response.items?.firstOrNull()
+            if (item == null) {
+                log.warn("YouTube API 응답에 영상 정보 없음: videoId=$videoId")
+                return@runCatching null
+            }
+            val snippet = item.snippet ?: return@runCatching null
+            val isoDuration = item.contentDetails?.duration ?: "PT0S"
+            VideoInfo(
+                title = snippet.title,
+                artist = snippet.channelTitle,
+                duration = isoDuration,
+                durationText = formatDuration(isoDuration),
+                thumbnailUrl =
+                    snippet.thumbnails?.maxres?.url
+                        ?: snippet.thumbnails?.high?.url
+                        ?: snippet.thumbnails?.default?.url
+                        ?: "",
+                videoUrl = "https://www.youtube.com/watch?v=$videoId",
+            )
         }.onFailure { log.error("YouTube 영상 정보 조회 실패: videoId=$videoId", it) }
             .getOrNull()
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

YouTube API 호출이 실패(네트워크 오류, 비공개 영상, 할당량 초과 등)하면
`getVideoInfo()`가 null을 반환하고, 그 null 값이 DB의 NOT NULL 컬럼(`artist`)에
삽입되어 500 에러가 발생하는 문제를 수정합니다.

- `ApplyWakeUpMusicServiceImpl`: `videoInfo`가 null이면 즉시 400 `ExpectedException`을 던져 DB 저장 시도 전에 명확한 오류 응답 반환
- `videoInfo` non-null 보장 후 `?.` → `.` 연산자로 변경
- `YoutubeClient`: API 응답의 items가 비어있을 때 WARN 로그 추가

> ⚠️ DB 조치 필요: `tb_wake_up_music.artist` 컬럼의 NOT NULL 제약을 제거해야 합니다.
> ```sql
> ALTER TABLE tb_wake_up_music ALTER COLUMN artist DROP NOT NULL;
> ```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> DB의 `artist` 컬럼이 아직 NOT NULL인 경우 위 SQL을 함께 실행해야 완전히 해결됩니다.