### PR TITLE
기상음악 신청 컨트롤러에 @Valid 누락 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -59,7 +60,7 @@ class WakeUpMusicController(
     )
     @PostMapping
     fun applyWakeUpMusic(
-        @RequestBody request: ApplyWakeUpMusicByUrlRequest,
+        @Valid @RequestBody request: ApplyWakeUpMusicByUrlRequest,
     ): CommonApiResponse<WakeUpMusicResponse> =
         CommonApiResponse.success("OK", applyWakeUpMusicService.execute(request))
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

기상음악 신청 API(`POST /dormitory/music`)에서 요청 DTO인 `ApplyWakeUpMusicByUrlRequest`에
`@field:NotBlank`가 선언되어 있었지만, 컨트롤러 파라미터에 `@Valid`가 누락되어
빈 값이나 공백으로도 신청이 가능한 버그를 수정했습니다.

- `WakeUpMusicController.applyWakeUpMusic()` 파라미터에 `@Valid` 추가
- `jakarta.validation.Valid` import 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음