### PR TITLE
YoutubeSnippet 필드 nullable 전환으로 Jackson null 우회 방어

### DIFF
--- a/src/main/kotlin/team/incube/flooding/global/client/YoutubeClient.kt
+++ b/src/main/kotlin/team/incube/flooding/global/client/YoutubeClient.kt
@@ -48,10 +48,20 @@ class YoutubeClient internal constructor(
                 return@runCatching null
             }
             val snippet = item.snippet ?: return@runCatching null
+            val title =
+                snippet.title ?: run {
+                    log.warn("YouTube API snippet에 title 없음: videoId=$videoId")
+                    return@runCatching null
+                }
+            val channelTitle =
+                snippet.channelTitle ?: run {
+                    log.warn("YouTube API snippet에 channelTitle 없음: videoId=$videoId")
+                    return@runCatching null
+                }
             val isoDuration = item.contentDetails?.duration ?: "PT0S"
             VideoInfo(
-                title = snippet.title,
-                artist = snippet.channelTitle,
+                title = title,
+                artist = channelTitle,
                 duration = isoDuration,
                 durationText = formatDuration(isoDuration),
                 thumbnailUrl =
@@ -123,8 +133,8 @@ class YoutubeClient internal constructor(
     )
 
     private data class YoutubeSnippet(
-        val title: String,
-        val channelTitle: String,
+        val title: String?,
+        val channelTitle: String?,
         val thumbnails: YoutubeThumbnails?,
     )
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

`YoutubeSnippet.title`, `channelTitle`이 non-nullable `String`으로 선언되어 있어 Jackson이 해당 필드를 런타임에 null로 주입할 경우 `VideoInfo` 객체가 non-null로 생성됩니다. 이 경우 `?: throw` 체크를 통과하여 null 메타데이터가 DB에 저장될 수 있는 잠재적 버그를 방어 처리했습니다.

실제 관찰된 null 저장 문제의 직접적 원인은 YouTube API 키 미설정 및 당시 null 체크가 없던 구 코드였으나(이전 PR에서 수정), 해당 케이스에 대한 방어 코드를 추가합니다.

- `YoutubeSnippet.title`, `channelTitle` 타입을 `String?`으로 변경
- `getVideoInfo()`에 title/channelTitle null 시 경고 로그 후 null 반환 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음