### PR TITLE
기상음악 응답 musicUrl에 list 파라미터 포함되는 문제 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -46,7 +46,7 @@ class ApplyWakeUpMusicServiceImpl(
             wakeUpMusicRepository.save(
                 WakeUpMusicJpaEntity(
                     user = user,
-                    musicUrl = request.musicUrl,
+                    musicUrl = videoInfo.videoUrl,
                     title = videoInfo.title,
                     artist = videoInfo.artist,
                     duration = videoInfo.duration,

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicServiceImplTest.kt
@@ -79,14 +79,14 @@ class ApplyWakeUpMusicServiceImplTest :
                     val result = service.execute(request)
 
                     verify(exactly = 1) { wakeUpMusicRepository.save(any()) }
-                    slot.captured.musicUrl shouldBe request.musicUrl
+                    slot.captured.musicUrl shouldBe "https://www.youtube.com/watch?v=test"
                     slot.captured.title shouldBe "테스트 음악"
                     slot.captured.artist shouldBe "테스트 채널"
                     slot.captured.durationText shouldBe "3:21"
                     slot.captured.thumbnailUrl shouldBe "https://img.youtube.com/vi/test/maxresdefault.jpg"
                     slot.captured.videoUrl shouldBe "https://www.youtube.com/watch?v=test"
                     slot.captured.appliedAt shouldBe fixedNow
-                    result.musicUrl shouldBe request.musicUrl
+                    result.musicUrl shouldBe "https://www.youtube.com/watch?v=test"
                     result.title shouldBe "테스트 음악"
                     result.likeCount shouldBe 0
                 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

YouTube 재생목록에서 공유한 링크에는 `&list=...` 파라미터가 포함되어 있는데,
기상음악 신청 시 클라이언트 입력값(`request.musicUrl`)을 그대로 저장하여 응답에도 불필요한 파라미터가 노출되는 문제가 있었습니다.

`YoutubeClient`에서 이미 비디오 ID만 추출해 정규화된 URL(`videoInfo.videoUrl`)을 생성하고 있으므로,
`musicUrl` 저장 시 해당 값을 사용하도록 변경하여 항상 `https://www.youtube.com/watch?v={id}` 형식으로 저장되도록 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음