### PR TITLE
SecurityConfig에 기상음악 API 권한 설정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -94,6 +94,9 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.DELETE, "/dormitory/studies/attendance/*")
                     .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
 
+                // music
+                it.requestMatchers("/dormitory/music/**").authenticated()
+
                 // massage
                 it.requestMatchers(HttpMethod.GET, "/dormitory/massages").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/dormitory/massages").authenticated()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

SecurityConfig에 기상음악(`/dormitory/music/**`) API 권한이 누락되어 있어 인증된 모든 사용자가 접근 가능하도록 추가하였습니다.

- `GET /dormitory/music` — 기상음악 목록 조회
- `POST /dormitory/music` — 기상음악 신청
- `DELETE /dormitory/music/{musicId}` — 기상음악 취소
- `POST /dormitory/music/{musicId}/like` — 좋아요
- `DELETE /dormitory/music/{musicId}/like` — 좋아요 취소

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음