### PR TITLE
기상음악 API 권한 설정 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -95,7 +95,11 @@ class SecurityConfig(
                     .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
 
                 // music
-                it.requestMatchers("/dormitory/music/**").authenticated()
+                it.requestMatchers(HttpMethod.GET, "/dormitory/music").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/dormitory/music").authenticated()
+                it.requestMatchers(HttpMethod.DELETE, "/dormitory/music/*").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/dormitory/music/*/like").authenticated()
+                it.requestMatchers(HttpMethod.DELETE, "/dormitory/music/*/like").authenticated()
 
                 // massage
                 it.requestMatchers(HttpMethod.GET, "/dormitory/massages").authenticated()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- 기존 `/dormitory/music/**` 와일드카드 단일 설정을 HTTP 메서드별로 명시적으로 세분화
  - GET /dormitory/music — 목록 조회
  - POST /dormitory/music — 신청
  - DELETE /dormitory/music/* — 취소
  - POST /dormitory/music/*/like — 좋아요
  - DELETE /dormitory/music/*/like — 좋아요 취소

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음