### PR TITLE
AccessDeniedHandler 및 기상음악 서비스 로그 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.dormitory.music.service.impl
 
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -23,6 +24,8 @@ class ApplyWakeUpMusicServiceImpl(
     private val youtubeClient: YoutubeClient,
     private val clock: Clock,
 ) : ApplyWakeUpMusicService {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     companion object {
         private const val MAX_HISTORY_SIZE = 5
     }
@@ -30,6 +33,7 @@ class ApplyWakeUpMusicServiceImpl(
     @Transactional
     override fun execute(request: ApplyWakeUpMusicByUrlRequest): WakeUpMusicResponse {
         val user = currentUserProvider.getCurrentUser()
+        log.info("기상음악 신청 시작: userId={}, role={}, musicUrl={}", user.id, user.role, request.musicUrl)
 
         val histories = wakeUpMusicRepository.findAllByUserIdOrderByAppliedAtAsc(user.id)
         if (histories.size >= MAX_HISTORY_SIZE) {
@@ -40,7 +44,10 @@ class ApplyWakeUpMusicServiceImpl(
 
         val videoInfo =
             youtubeClient.getVideoInfo(request.musicUrl)
-                ?: throw ExpectedException("YouTube 영상 정보를 가져오지 못했습니다. URL을 확인해주세요.", HttpStatus.BAD_REQUEST)
+                ?: run {
+                    log.warn("YouTube 영상 정보 조회 실패: userId={}, musicUrl={}", user.id, request.musicUrl)
+                    throw ExpectedException("YouTube 영상 정보를 가져오지 못했습니다. URL을 확인해주세요.", HttpStatus.BAD_REQUEST)
+                }
 
         val saved =
             wakeUpMusicRepository.save(
@@ -56,6 +63,7 @@ class ApplyWakeUpMusicServiceImpl(
                     appliedAt = LocalDateTime.now(clock),
                 ),
             )
+        log.info("기상음악 신청 완료: userId={}, musicId={}, title={}", user.id, saved.id, saved.title)
 
         return WakeUpMusicResponse(
             id = saved.id,

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -14,11 +14,13 @@ import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 import team.incube.flooding.domain.user.entity.Role
 import team.incube.flooding.global.security.filter.JwtAuthenticationFilter
+import team.incube.flooding.global.security.handler.CustomAccessDeniedHandler
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val customAccessDeniedHandler: CustomAccessDeniedHandler,
 ) {
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
@@ -123,6 +125,7 @@ class SecurityConfig(
                 it.authenticationEntryPoint { _, response, _ ->
                     response.sendError(HttpServletResponse.SC_UNAUTHORIZED)
                 }
+                it.accessDeniedHandler(customAccessDeniedHandler)
             }.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
 }

--- a/src/main/kotlin/team/incube/flooding/global/security/handler/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/handler/CustomAccessDeniedHandler.kt
@@ -7,6 +7,7 @@ import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.stereotype.Component
+import team.incube.flooding.domain.user.entity.UserJpaEntity
 
 @Component
 class CustomAccessDeniedHandler : AccessDeniedHandler {
@@ -18,11 +19,16 @@ class CustomAccessDeniedHandler : AccessDeniedHandler {
         ex: AccessDeniedException,
     ) {
         val authentication = SecurityContextHolder.getContext().authentication
+        val userIdentifier =
+            when (val principal = authentication?.principal) {
+                is UserJpaEntity -> "User(id=${principal.id})"
+                else -> authentication?.name ?: "anonymous"
+            }
         log.warn(
             "403 Forbidden: method={}, uri={}, user={}, authorities={}, message={}",
             request.method,
             request.requestURI,
-            authentication?.name ?: "anonymous",
+            userIdentifier,
             authentication?.authorities ?: "none",
             ex.message,
         )

--- a/src/main/kotlin/team/incube/flooding/global/security/handler/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/handler/CustomAccessDeniedHandler.kt
@@ -1,0 +1,31 @@
+package team.incube.flooding.global.security.handler
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+
+@Component
+class CustomAccessDeniedHandler : AccessDeniedHandler {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        ex: AccessDeniedException,
+    ) {
+        val authentication = SecurityContextHolder.getContext().authentication
+        log.warn(
+            "403 Forbidden: method={}, uri={}, user={}, authorities={}, message={}",
+            request.method,
+            request.requestURI,
+            authentication?.name ?: "anonymous",
+            authentication?.authorities ?: "none",
+            ex.message,
+        )
+        response.sendError(HttpServletResponse.SC_FORBIDDEN)
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- CustomAccessDeniedHandler 추가: 403 Forbidden 발생 시 요청 메서드, URI, 유저, 권한, 메시지를 warn 로그로 출력
- SecurityConfig에 CustomAccessDeniedHandler 연결
- ApplyWakeUpMusicServiceImpl에 로그 추가
  - 신청 시작: userId, role, musicUrl
  - YouTube 영상 조회 실패 시: userId, musicUrl (warn)
  - 신청 완료: userId, musicId, title

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음