### PR TITLE
기상음악 중복 신청 시 409 반환 및 접근 거부 로깅 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
@@ -23,9 +23,9 @@ class ApplyMassageServiceImpl(
 
         val now = LocalTime.now()
 
-    if (now.isBefore(massageProperties.openTime)) {
-        throw ExpectedException("안마의자 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
-    }
+        if (now.isBefore(massageProperties.openTime)) {
+            throw ExpectedException("안마의자 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
+        }
 
         val lock = redissonClient.getLock(massageProperties.lockKey)
         val acquired = lock.tryLock(5, 3, TimeUnit.SECONDS)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.dormitory.music.entity.WakeUpMusicJpaEntity
 import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicByUrlRequest
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
-import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRepository
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.domain.dormitory.music.service.ApplyWakeUpMusicService
 import team.incube.flooding.global.client.YoutubeClient
@@ -19,16 +18,11 @@ import java.time.LocalDateTime
 @Service
 class ApplyWakeUpMusicServiceImpl(
     private val wakeUpMusicRepository: WakeUpMusicRepository,
-    private val wakeUpMusicLikeRepository: WakeUpMusicLikeRepository,
     private val currentUserProvider: CurrentUserProvider,
     private val youtubeClient: YoutubeClient,
     private val clock: Clock,
 ) : ApplyWakeUpMusicService {
     private val log = LoggerFactory.getLogger(javaClass)
-
-    companion object {
-        private const val MAX_HISTORY_SIZE = 5
-    }
 
     @Transactional
     override fun execute(request: ApplyWakeUpMusicByUrlRequest): WakeUpMusicResponse {
@@ -36,10 +30,9 @@ class ApplyWakeUpMusicServiceImpl(
         log.info("기상음악 신청 시작: userId={}, role={}, musicUrl={}", user.id, user.role, request.musicUrl)
 
         val histories = wakeUpMusicRepository.findAllByUserIdOrderByAppliedAtAsc(user.id)
-        if (histories.size >= MAX_HISTORY_SIZE) {
-            val toDelete = histories.take(histories.size - MAX_HISTORY_SIZE + 1)
-            wakeUpMusicLikeRepository.deleteAllByMusicIdIn(toDelete.map { it.id })
-            wakeUpMusicRepository.deleteAllInBatch(toDelete)
+        if (histories.isNotEmpty()) {
+            log.warn("기상음악 신청 거절 - 이미 신청됨: userId={}, musicId={}", user.id, histories.first().id)
+            throw ExpectedException("이미 기상음악을 신청했습니다.", HttpStatus.CONFLICT)
         }
 
         val videoInfo =

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
@@ -43,8 +43,15 @@ class StudyApplicationServiceImpl(
             }
 
         if (outOfRange) {
-            log.warn("자습 신청 가능 시간 아님: userId={}, now={}, openTime={}, closeTime={}", user.id, now, studyProperties.openTime, studyProperties.closeTime)
-            throw ExpectedException("자습 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST) }
+            log.warn(
+                "자습 신청 가능 시간 아님: userId={}, now={}, openTime={}, closeTime={}",
+                user.id,
+                now,
+                studyProperties.openTime,
+                studyProperties.closeTime,
+            )
+            throw ExpectedException("자습 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
+        }
 
         if (studyRedisAdapter.getApplicationStatus(user.id) == StudyApplicationStatus.BANNED ||
             studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now(clock))

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicServiceImplTest.kt
@@ -1,15 +1,16 @@
 package team.incube.flooding.domain.dormitory.music.service
 
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.springframework.http.HttpStatus
 import team.incube.flooding.domain.dormitory.music.entity.WakeUpMusicJpaEntity
 import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicByUrlRequest
-import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRepository
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.domain.dormitory.music.service.impl.ApplyWakeUpMusicServiceImpl
 import team.incube.flooding.domain.user.entity.Role
@@ -17,6 +18,7 @@ import team.incube.flooding.domain.user.entity.Sex
 import team.incube.flooding.domain.user.entity.UserJpaEntity
 import team.incube.flooding.global.client.YoutubeClient
 import team.incube.flooding.global.security.util.CurrentUserProvider
+import team.themoment.sdk.exception.ExpectedException
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
@@ -25,7 +27,6 @@ import java.time.ZoneId
 class ApplyWakeUpMusicServiceImplTest :
     BehaviorSpec({
         val wakeUpMusicRepository = mockk<WakeUpMusicRepository>()
-        val wakeUpMusicLikeRepository = mockk<WakeUpMusicLikeRepository>()
         val currentUserProvider = mockk<CurrentUserProvider>()
         val youtubeClient = mockk<YoutubeClient>()
         val clock = Clock.fixed(Instant.parse("2026-05-14T01:00:00Z"), ZoneId.of("Asia/Seoul"))
@@ -33,7 +34,6 @@ class ApplyWakeUpMusicServiceImplTest :
         val service =
             ApplyWakeUpMusicServiceImpl(
                 wakeUpMusicRepository = wakeUpMusicRepository,
-                wakeUpMusicLikeRepository = wakeUpMusicLikeRepository,
                 currentUserProvider = currentUserProvider,
                 youtubeClient = youtubeClient,
                 clock = clock,
@@ -93,62 +93,28 @@ class ApplyWakeUpMusicServiceImplTest :
             }
         }
 
-        given("신청 이력이 정확히 5개일 때") {
+        given("이미 신청 이력이 있을 때") {
             `when`("execute를 호출하면") {
-                then("가장 오래된 이력 1개가 삭제된 후 저장된다") {
+                then("CONFLICT 예외가 발생한다") {
                     val request = ApplyWakeUpMusicByUrlRequest("https://youtube.com/watch?v=new")
                     val histories =
-                        (1L..5L).map { id ->
+                        listOf(
                             WakeUpMusicJpaEntity(
-                                id = id,
+                                id = 1L,
                                 user = user,
-                                musicUrl = "https://youtube.com/watch?v=$id",
-                                appliedAt = LocalDateTime.now(clock).minusDays(6 - id),
-                            )
-                        }
-                    val slot = slot<WakeUpMusicJpaEntity>()
+                                musicUrl = "https://youtube.com/watch?v=existing",
+                                appliedAt = LocalDateTime.now(clock).minusDays(1),
+                            ),
+                        )
 
                     every { currentUserProvider.getCurrentUser() } returns user
                     every { wakeUpMusicRepository.findAllByUserIdOrderByAppliedAtAsc(user.id) } returns histories
-                    every { wakeUpMusicLikeRepository.deleteAllByMusicIdIn(listOf(1L)) } returns Unit
-                    every { wakeUpMusicRepository.deleteAllInBatch(listOf(histories[0])) } returns Unit
-                    stubYoutubeInfo(request.musicUrl)
-                    every { wakeUpMusicRepository.save(capture(slot)) } answers { slot.captured }
 
-                    service.execute(request)
+                    val exception = shouldThrow<ExpectedException> { service.execute(request) }
 
-                    verify(exactly = 1) { wakeUpMusicLikeRepository.deleteAllByMusicIdIn(listOf(1L)) }
-                    verify(exactly = 1) { wakeUpMusicRepository.deleteAllInBatch(listOf(histories[0])) }
-                    verify(exactly = 1) { wakeUpMusicRepository.save(any()) }
-                }
-            }
-        }
-
-        given("신청 이력이 4개일 때") {
-            `when`("execute를 호출하면") {
-                then("삭제 없이 바로 저장된다") {
-                    val request = ApplyWakeUpMusicByUrlRequest("https://youtube.com/watch?v=new")
-                    val histories =
-                        (1L..4L).map { id ->
-                            WakeUpMusicJpaEntity(
-                                id = id,
-                                user = user,
-                                musicUrl = "https://youtube.com/watch?v=$id",
-                                appliedAt = LocalDateTime.now(clock).minusDays(5 - id),
-                            )
-                        }
-                    val slot = slot<WakeUpMusicJpaEntity>()
-
-                    every { currentUserProvider.getCurrentUser() } returns user
-                    every { wakeUpMusicRepository.findAllByUserIdOrderByAppliedAtAsc(user.id) } returns histories
-                    stubYoutubeInfo(request.musicUrl)
-                    every { wakeUpMusicRepository.save(capture(slot)) } answers { slot.captured }
-
-                    service.execute(request)
-
-                    verify(exactly = 0) { wakeUpMusicLikeRepository.deleteAllByMusicIdIn(any()) }
-                    verify(exactly = 0) { wakeUpMusicRepository.deleteAllInBatch(any()) }
-                    verify(exactly = 1) { wakeUpMusicRepository.save(any()) }
+                    exception.statusCode shouldBe HttpStatus.CONFLICT
+                    verify(exactly = 0) { youtubeClient.getVideoInfo(any()) }
+                    verify(exactly = 0) { wakeUpMusicRepository.save(any()) }
                 }
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- 기상음악 중복 신청 로직을 이력 슬라이딩(최대 5개 유지)에서 이미 신청 이력이 있으면 409 CONFLICT 반환으로 변경
- 403 Forbidden 발생 시 요청 정보(method, uri, user id, authorities)를 로그로 기록하는 CustomAccessDeniedHandler 추가
- CustomAccessDeniedHandler에서 principal을 id로만 출력하도록 수정 (개인정보 보호)
- 안마의자 및 자습 신청 서비스 들여쓰기 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 기상음악 중복 신청 정책이 "최대 5개 이력 유지"에서 "1인 1신청"으로 변경된 부분이 의도된 스펙 변경인지 확인 부탁드립니다.