### PR TITLE
jackson-dataformat-xml 충돌로 인한 POST 빈 응답 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/global/config/WebMvcConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/WebMvcConfig.kt
@@ -1,0 +1,13 @@
+package team.incube.flooding.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.MediaType
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig : WebMvcConfigurer {
+    override fun configureContentNegotiation(configurer: ContentNegotiationConfigurer) {
+        configurer.defaultContentType(MediaType.APPLICATION_JSON)
+    }
+}

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicServiceImplTest.kt
@@ -1,7 +1,7 @@
 package team.incube.flooding.domain.dormitory.music.service
 
-import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

### 문제
`springdoc-openapi-starter-webmvc-ui` 의존성이 `jackson-dataformat-xml`을 transitive 의존성으로 포함합니다.
이로 인해 Spring MVC가 `MappingJackson2XmlHttpMessageConverter`를 등록하게 되고, 프론트엔드에서 `Accept: */*` 헤더로 POST 요청을 보낼 때 XML 컨버터를 선택합니다.
`CommonApiResponse`의 `HttpStatus` 필드가 XML로 직렬화되지 않아 응답 body가 비어버리는 문제가 발생했습니다.

### 수정 내용
- `WebMvcConfig.kt` 추가: `ContentNegotiationConfigurer`를 통해 기본 응답 Content-Type을 `application/json`으로 설정
- `Accept: */*`로 요청 시에도 JSON 응답이 반환되도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음