### PR TITLE
기상음악 신청 시 오늘 날짜 기준 중복 체크 적용

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
@@ -11,6 +11,12 @@ interface WakeUpMusicRepository : JpaRepository<WakeUpMusicJpaEntity, Long> {
 
     fun findAllByUserIdOrderByAppliedAtAsc(userId: Long): List<WakeUpMusicJpaEntity>
 
+    fun existsByUserIdAndAppliedAtBetween(
+        userId: Long,
+        start: LocalDateTime,
+        end: LocalDateTime,
+    ): Boolean
+
     @Query(
         """
         SELECT new team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse(

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -29,9 +29,11 @@ class ApplyWakeUpMusicServiceImpl(
         val user = currentUserProvider.getCurrentUser()
         log.info("기상음악 신청 시작: userId={}, role={}, musicUrl={}", user.id, user.role, request.musicUrl)
 
-        val histories = wakeUpMusicRepository.findAllByUserIdOrderByAppliedAtAsc(user.id)
-        if (histories.isNotEmpty()) {
-            log.warn("기상음악 신청 거절 - 이미 신청됨: userId={}, musicId={}", user.id, histories.first().id)
+        val now = LocalDateTime.now(clock)
+        val startOfDay = now.toLocalDate().atStartOfDay()
+        val endOfDay = startOfDay.plusDays(1)
+        if (wakeUpMusicRepository.existsByUserIdAndAppliedAtBetween(user.id, startOfDay, endOfDay)) {
+            log.warn("기상음악 신청 거절 - 오늘 이미 신청됨: userId={}", user.id)
             throw ExpectedException("이미 기상음악을 신청했습니다.", HttpStatus.CONFLICT)
         }
 

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicServiceImplTest.kt
@@ -64,15 +64,24 @@ class ApplyWakeUpMusicServiceImplTest :
                 )
         }
 
-        given("신청 이력이 없을 때") {
+        given("오늘 신청 이력이 없을 때") {
             `when`("execute를 호출하면") {
                 then("기상음악이 저장되고 응답이 반환된다") {
                     val request = ApplyWakeUpMusicByUrlRequest("https://youtube.com/watch?v=abc")
                     val fixedNow = LocalDateTime.now(clock)
+                    val startOfDay = fixedNow.toLocalDate().atStartOfDay()
+                    val endOfDay = startOfDay.plusDays(1)
                     val slot = slot<WakeUpMusicJpaEntity>()
 
                     every { currentUserProvider.getCurrentUser() } returns user
-                    every { wakeUpMusicRepository.findAllByUserIdOrderByAppliedAtAsc(user.id) } returns emptyList()
+                    every {
+                        wakeUpMusicRepository.existsByUserIdAndAppliedAtBetween(
+                            user.id,
+                            startOfDay,
+                            endOfDay,
+                        )
+                    } returns
+                        false
                     stubYoutubeInfo(request.musicUrl)
                     every { wakeUpMusicRepository.save(capture(slot)) } answers { slot.captured }
 
@@ -93,22 +102,23 @@ class ApplyWakeUpMusicServiceImplTest :
             }
         }
 
-        given("이미 신청 이력이 있을 때") {
+        given("오늘 이미 신청 이력이 있을 때") {
             `when`("execute를 호출하면") {
                 then("CONFLICT 예외가 발생한다") {
                     val request = ApplyWakeUpMusicByUrlRequest("https://youtube.com/watch?v=new")
-                    val histories =
-                        listOf(
-                            WakeUpMusicJpaEntity(
-                                id = 1L,
-                                user = user,
-                                musicUrl = "https://youtube.com/watch?v=existing",
-                                appliedAt = LocalDateTime.now(clock).minusDays(1),
-                            ),
-                        )
+                    val fixedNow = LocalDateTime.now(clock)
+                    val startOfDay = fixedNow.toLocalDate().atStartOfDay()
+                    val endOfDay = startOfDay.plusDays(1)
 
                     every { currentUserProvider.getCurrentUser() } returns user
-                    every { wakeUpMusicRepository.findAllByUserIdOrderByAppliedAtAsc(user.id) } returns histories
+                    every {
+                        wakeUpMusicRepository.existsByUserIdAndAppliedAtBetween(
+                            user.id,
+                            startOfDay,
+                            endOfDay,
+                        )
+                    } returns
+                        true
 
                     val exception = shouldThrow<ExpectedException> { service.execute(request) }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

기존 코드에서 `findAllByUserIdOrderByAppliedAtAsc`로 전체 이력을 조회해 비어 있지 않으면 409를 반환했습니다.
날짜 필터가 없어 이전 날 신청한 이력이 있어도 오늘 신청이 막히는 버그가 있었습니다.

- `WakeUpMusicRepository`에 `existsByUserIdAndAppliedAtBetween` 메서드 추가 (오늘 00:00 ~ 익일 00:00 범위)
- `ApplyWakeUpMusicServiceImpl`에서 오늘 날짜 기준으로 중복 여부만 체크하도록 수정
- 테스트를 새 메서드 기준으로 업데이트

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음