### PR TITLE
기상음악 POST 신청 시 빈 응답 반환 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -58,7 +59,7 @@ class WakeUpMusicController(
         ApiResponse(responseCode = "200", description = "기상음악 신청 성공"),
         ApiResponse(responseCode = "409", description = "이미 기상음악을 신청함"),
     )
-    @PostMapping
+    @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
     fun applyWakeUpMusic(
         @Valid @RequestBody request: ApplyWakeUpMusicByUrlRequest,
     ): CommonApiResponse<WakeUpMusicResponse> =


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

기상음악 신청(POST /dormitory/music) 시 200 응답은 오지만 응답 바디가 비어 있는 문제 수정.

`jackson-dataformat-xml` 의존성은 이미 제거된 상태이나, `Accept` 헤더가 없거나 `*/*`일 때 Spring Boot 4.x의 콘텐츠 협상 과정에서 응답 바디가 비는 경우가 있음.

- `@PostMapping`에 `produces = [MediaType.APPLICATION_JSON_VALUE]` 명시하여 JSON 응답 강제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음