### PR TITLE
기상음악 신청 응답을 ApiResponseWrapper 정상 래핑 경로로 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
@@ -62,8 +62,7 @@ class WakeUpMusicController(
     @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
     fun applyWakeUpMusic(
         @Valid @RequestBody request: ApplyWakeUpMusicByUrlRequest,
-    ): CommonApiResponse<WakeUpMusicResponse> =
-        CommonApiResponse.success("OK", applyWakeUpMusicService.execute(request))
+    ): WakeUpMusicResponse = applyWakeUpMusicService.execute(request)
 
     @Operation(
         summary = "기상음악 취소",


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

기상음악 신청 API(POST /dormitory/music)에서 200 응답에 바디가 비어서 오는 버그 수정.

**원인 분석**
SDK의 `ApiResponseWrapper`(ResponseBodyAdvice)는 두 가지 경로로 응답을 처리한다:
- `CommonApiResponse<*>` 반환 시 → `byPassResponse()` 경로: 그대로 통과만 하며, Spring Framework 7.x 환경에서 Content-Type 협상 타이밍 문제로 응답 바디가 비어 내려올 수 있음
- 일반 객체 반환 시 → else 경로: `ApiResponseWrapper`가 직접 `CommonApiResponse`로 래핑하여 안전하게 직렬화

기존 코드는 컨트롤러에서 `CommonApiResponse<WakeUpMusicResponse>`를 직접 반환하여 `byPassResponse()` 경로를 탔고, `AuthController.signIn()` 등 다른 API는 도메인 객체를 직접 반환하여 else 경로를 타기 때문에 정상 동작했음.

**수정 내용**
`applyWakeUpMusic()`의 반환 타입을 `WakeUpMusicResponse`로 변경하여 `ApiResponseWrapper`의 안전한 래핑 경로를 타도록 수정.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> `ApiResponseWrapper`의 `byPassResponse()`는 `CommonApiResponse<*>`를 직접 반환할 때 호출되므로, 동일하게 `CommonApiResponse<T>`를 반환하는 다른 POST API들도 잠재적 위험이 있을 수 있습니다.