### PR TITLE
기상음악 신청 시 DB 제약 위반으로 인한 200 빈 응답 버그 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -1,6 +1,7 @@
 package team.incube.flooding.domain.dormitory.music.service.impl
 
 import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -45,19 +46,24 @@ class ApplyWakeUpMusicServiceImpl(
                 }
 
         val saved =
-            wakeUpMusicRepository.save(
-                WakeUpMusicJpaEntity(
-                    user = user,
-                    musicUrl = videoInfo.videoUrl,
-                    title = videoInfo.title,
-                    artist = videoInfo.artist,
-                    duration = videoInfo.duration,
-                    durationText = videoInfo.durationText,
-                    thumbnailUrl = videoInfo.thumbnailUrl,
-                    videoUrl = videoInfo.videoUrl,
-                    appliedAt = LocalDateTime.now(clock),
-                ),
-            )
+            try {
+                wakeUpMusicRepository.save(
+                    WakeUpMusicJpaEntity(
+                        user = user,
+                        musicUrl = videoInfo.videoUrl,
+                        title = videoInfo.title,
+                        artist = videoInfo.artist,
+                        duration = videoInfo.duration,
+                        durationText = videoInfo.durationText,
+                        thumbnailUrl = videoInfo.thumbnailUrl,
+                        videoUrl = videoInfo.videoUrl,
+                        appliedAt = LocalDateTime.now(clock),
+                    ),
+                )
+            } catch (e: DataIntegrityViolationException) {
+                log.warn("기상음악 신청 DB 제약 위반: userId={}", user.id, e)
+                throw ExpectedException("이미 기상음악을 신청했습니다.", HttpStatus.CONFLICT)
+            }
         log.info("기상음악 신청 완료: userId={}, musicId={}, title={}", user.id, saved.id, saved.title)
 
         return WakeUpMusicResponse(

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -47,7 +47,7 @@ class ApplyWakeUpMusicServiceImpl(
 
         val saved =
             try {
-                wakeUpMusicRepository.save(
+                wakeUpMusicRepository.saveAndFlush(
                     WakeUpMusicJpaEntity(
                         user = user,
                         musicUrl = videoInfo.videoUrl,

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/ApplyWakeUpMusicServiceImplTest.kt
@@ -83,11 +83,11 @@ class ApplyWakeUpMusicServiceImplTest :
                     } returns
                         false
                     stubYoutubeInfo(request.musicUrl)
-                    every { wakeUpMusicRepository.save(capture(slot)) } answers { slot.captured }
+                    every { wakeUpMusicRepository.saveAndFlush(capture(slot)) } answers { slot.captured }
 
                     val result = service.execute(request)
 
-                    verify(exactly = 1) { wakeUpMusicRepository.save(any()) }
+                    verify(exactly = 1) { wakeUpMusicRepository.saveAndFlush(any()) }
                     slot.captured.musicUrl shouldBe "https://www.youtube.com/watch?v=test"
                     slot.captured.title shouldBe "테스트 음악"
                     slot.captured.artist shouldBe "테스트 채널"
@@ -124,7 +124,7 @@ class ApplyWakeUpMusicServiceImplTest :
 
                     exception.statusCode shouldBe HttpStatus.CONFLICT
                     verify(exactly = 0) { youtubeClient.getVideoInfo(any()) }
-                    verify(exactly = 0) { wakeUpMusicRepository.save(any()) }
+                    verify(exactly = 0) { wakeUpMusicRepository.saveAndFlush(any()) }
                 }
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

기상음악 신청(POST /dormitory/music) 시 200 응답에 바디가 비어서 오는 버그의 실제 원인을 수정.

**실제 원인 (서버 로그 분석)**
`tb_wake_up_music` 테이블의 `user_id` 컬럼에 UNIQUE 제약(`ukpgvhuwu85p7nt3upi63sfqt4n`)이 걸려 있어, 이전 날짜에 신청한 이력이 있는 유저가 재신청 시 아래 흐름으로 빈 응답 발생:

1. `existsByUserIdAndAppliedAtBetween(오늘 범위)` → 오늘 기록 없으므로 체크 통과
2. `save()` 호출 → DB UNIQUE 제약 위반 → `DataIntegrityViolationException`
3. `GlobalExceptionHandler`에 해당 예외 핸들러 없음 → `LoggingFilter`까지 전파
4. **이미 커밋된 200 상태코드 + 빈 바디로 응답**

**코드 수정**
`save()` 호출에 `try-catch`를 추가하여 `DataIntegrityViolationException` 발생 시 `ExpectedException(409)`으로 변환. 이로써 빈 응답 대신 명확한 409 응답 반환.

**DB 수정 필요 (별도 실행)**
매일 신청 가능한 정책임에도 `user_id`에 UNIQUE 제약이 걸려 있어 정상 신청도 막히는 상황.
아래 SQL을 production DB에서 직접 실행해야 함:
```sql
ALTER TABLE tb_wake_up_music DROP CONSTRAINT ukpgvhuwu85p7nt3upi63sfqt4n;
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> DB UNIQUE 제약 DROP SQL을 배포 전 반드시 실행해야 매일 신청 정상 동작합니다. 코드 수정만으로는 기존 신청 이력이 있는 유저의 재신청이 여전히 409로 막힙니다.