### PR TITLE
기상음악 빈 응답, 취소 실패, 중복 체크 버그 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicLikeRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicLikeRepository.kt
@@ -17,6 +17,8 @@ interface WakeUpMusicLikeRepository : JpaRepository<WakeUpMusicLikeJpaEntity, Lo
 
     fun countByMusicId(musicId: Long): Long
 
+    fun deleteAllByMusicId(musicId: Long)
+
     fun deleteAllByMusicIdIn(musicIds: List<Long>)
 
     @Query("SELECT l.music.id FROM WakeUpMusicLikeJpaEntity l WHERE l.user.id = :userId AND l.music.id IN :musicIds")

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/CancelWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/CancelWakeUpMusicServiceImpl.kt
@@ -3,6 +3,7 @@ package team.incube.flooding.domain.dormitory.music.service.impl
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRepository
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.domain.dormitory.music.service.CancelWakeUpMusicService
 import team.incube.flooding.domain.user.entity.Role
@@ -12,6 +13,7 @@ import team.themoment.sdk.exception.ExpectedException
 @Service
 class CancelWakeUpMusicServiceImpl(
     private val wakeUpMusicRepository: WakeUpMusicRepository,
+    private val wakeUpMusicLikeRepository: WakeUpMusicLikeRepository,
     private val currentUserProvider: CurrentUserProvider,
 ) : CancelWakeUpMusicService {
     @Transactional
@@ -27,6 +29,7 @@ class CancelWakeUpMusicServiceImpl(
             throw ExpectedException("본인의 신청만 취소할 수 있습니다.", HttpStatus.FORBIDDEN)
         }
 
+        wakeUpMusicLikeRepository.deleteAllByMusicId(musicId)
         wakeUpMusicRepository.delete(music)
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- `@PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])` 명시 및 springdoc에서 `jackson-dataformat-xml` 의존성 제거로 기상음악 신청 POST 응답 빈값 문제 수정
- 중복 신청 체크 기준을 전체 이력 슬라이딩에서 오늘 날짜 기준으로 변경하고, DB 제약 위반 시 409 응답 처리
- 기상음악 취소 시 좋아요 데이터를 먼저 삭제하여 FK 제약 위반으로 삭제가 안 되던 문제 수정
- 403 Forbidden 로깅을 위한 `CustomAccessDeniedHandler` 추가 및 기상음악 보안 설정을 HTTP 메서드별로 세분화

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음