### PR TITLE
기상음악 응답에 userId 필드 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/response/WakeUpMusicResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/response/WakeUpMusicResponse.kt
@@ -4,6 +4,7 @@ import java.time.LocalDateTime
 
 data class WakeUpMusicResponse(
     val id: Long,
+    val userId: Long,
     val musicUrl: String,
     val title: String?,
     val artist: String?,

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
@@ -20,10 +20,10 @@ interface WakeUpMusicRepository : JpaRepository<WakeUpMusicJpaEntity, Long> {
     @Query(
         """
         SELECT new team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse(
-            m.id, m.musicUrl, m.title, m.artist, m.duration, m.durationText, m.thumbnailUrl, m.videoUrl, m.appliedAt, COUNT(l.id), false)
+            m.id, m.user.id, m.musicUrl, m.title, m.artist, m.duration, m.durationText, m.thumbnailUrl, m.videoUrl, m.appliedAt, COUNT(l.id), false)
         FROM WakeUpMusicJpaEntity m LEFT JOIN WakeUpMusicLikeJpaEntity l ON l.music = m
         WHERE m.appliedAt >= :startOfDay AND m.appliedAt < :endOfDay
-        GROUP BY m.id, m.musicUrl, m.title, m.artist, m.duration, m.durationText, m.thumbnailUrl, m.videoUrl, m.appliedAt
+        GROUP BY m.id, m.user.id, m.musicUrl, m.title, m.artist, m.duration, m.durationText, m.thumbnailUrl, m.videoUrl, m.appliedAt
         ORDER BY m.appliedAt DESC
     """,
     )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -68,6 +68,7 @@ class ApplyWakeUpMusicServiceImpl(
 
         return WakeUpMusicResponse(
             id = saved.id,
+            userId = user.id,
             musicUrl = saved.musicUrl,
             title = saved.title,
             artist = saved.artist,

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicControllerTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicControllerTest.kt
@@ -38,6 +38,7 @@ class WakeUpMusicControllerTest :
             val serviceResponse =
                 WakeUpMusicResponse(
                     id = 1L,
+                    userId = 1L,
                     musicUrl = request.musicUrl,
                     title = "테스트 음악",
                     artist = "테스트 채널",

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicServiceImplTest.kt
@@ -40,6 +40,7 @@ class GetWakeUpMusicServiceImplTest :
                         listOf(
                             WakeUpMusicResponse(
                                 id = 1L,
+                                userId = 1L,
                                 musicUrl = "https://youtube.com/watch?v=abc",
                                 title = "테스트 음악",
                                 artist = "테스트 채널",
@@ -95,6 +96,7 @@ class GetWakeUpMusicServiceImplTest :
                         listOf(
                             WakeUpMusicResponse(
                                 id = 1L,
+                                userId = 1L,
                                 musicUrl = "https://youtube.com/watch?v=abc",
                                 title = "테스트 음악 A",
                                 artist = "테스트 채널",
@@ -108,6 +110,7 @@ class GetWakeUpMusicServiceImplTest :
                             ),
                             WakeUpMusicResponse(
                                 id = 2L,
+                                userId = 2L,
                                 musicUrl = "https://youtube.com/watch?v=def",
                                 title = "테스트 음악 B",
                                 artist = "테스트 채널",


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- `WakeUpMusicResponse`에 `userId` 필드 추가
- JPQL 생성자 쿼리 및 `GROUP BY`에 `m.user.id` 반영
- `ApplyWakeUpMusicServiceImpl` 응답 생성 시 `userId` 전달

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음