### PR TITLE
안마의자 신청 종료 시간 설정 기능 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/config/MassageProperties.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/config/MassageProperties.kt
@@ -6,6 +6,7 @@ import java.time.LocalTime
 @ConfigurationProperties(prefix = "massage")
 class MassageProperties(
     val openTime: LocalTime,
+    val closeTime: LocalTime,
     val maxCount: Int,
     val lockKey: String,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
@@ -8,6 +8,7 @@ import team.incube.flooding.domain.dormitory.massage.config.MassageProperties
 import team.incube.flooding.domain.dormitory.massage.service.ApplyMassageService
 import team.incube.flooding.global.security.util.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
+import java.time.Clock
 import java.time.LocalTime
 import java.util.concurrent.TimeUnit
 
@@ -17,13 +18,14 @@ class ApplyMassageServiceImpl(
     private val massageProperties: MassageProperties,
     private val currentUserProvider: CurrentUserProvider,
     private val redissonClient: RedissonClient,
+    private val clock: Clock,
 ) : ApplyMassageService {
     override fun execute() {
         val user = currentUserProvider.getCurrentUser()
 
-        val now = LocalTime.now()
+        val now = LocalTime.now(clock)
 
-        if (now.isBefore(massageProperties.openTime) || !now.isBefore(massageProperties.closeTime)) {
+        if (now < massageProperties.openTime || now >= massageProperties.closeTime) {
             throw ExpectedException("안마의자 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
         }
 

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
@@ -23,9 +23,9 @@ class ApplyMassageServiceImpl(
 
         val now = LocalTime.now()
 
-    if (now.isBefore(massageProperties.openTime)) {
-        throw ExpectedException("안마의자 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
-    }
+        if (now.isBefore(massageProperties.openTime) || !now.isBefore(massageProperties.closeTime)) {
+            throw ExpectedException("안마의자 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
+        }
 
         val lock = redissonClient.getLock(massageProperties.lockKey)
         val acquired = lock.tryLock(5, 3, TimeUnit.SECONDS)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
@@ -25,7 +25,7 @@ class GetMassageServiceImpl(
     override fun execute(): GetMassageListResponse {
         val currentUser = currentUserProvider.getCurrentUser()
         val now = LocalTime.now(clock)
-        val isApplicationOpen = !now.isBefore(massageProperties.openTime) && now.isBefore(massageProperties.closeTime)
+        val isApplicationOpen = now >= massageProperties.openTime && now < massageProperties.closeTime
         val myApplicationStatus =
             when {
                 massageRedisAdapter.isReapplyBlocked(currentUser.id) -> MassageApplicationStatus.CANCELLED

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
@@ -24,7 +24,8 @@ class GetMassageServiceImpl(
 ) : GetMassageService {
     override fun execute(): GetMassageListResponse {
         val currentUser = currentUserProvider.getCurrentUser()
-        val isApplicationOpen = !LocalTime.now(clock).isBefore(massageProperties.openTime)
+        val now = LocalTime.now(clock)
+        val isApplicationOpen = !now.isBefore(massageProperties.openTime) && now.isBefore(massageProperties.closeTime)
         val myApplicationStatus =
             when {
                 massageRedisAdapter.isReapplyBlocked(currentUser.id) -> MassageApplicationStatus.CANCELLED

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
@@ -43,8 +43,15 @@ class StudyApplicationServiceImpl(
             }
 
         if (outOfRange) {
-            log.warn("자습 신청 가능 시간 아님: userId={}, now={}, openTime={}, closeTime={}", user.id, now, studyProperties.openTime, studyProperties.closeTime)
-            throw ExpectedException("자습 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST) }
+            log.warn(
+                "자습 신청 가능 시간 아님: userId={}, now={}, openTime={}, closeTime={}",
+                user.id,
+                now,
+                studyProperties.openTime,
+                studyProperties.closeTime,
+            )
+            throw ExpectedException("자습 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
+        }
 
         if (studyRedisAdapter.getApplicationStatus(user.id) == StudyApplicationStatus.BANNED ||
             studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now(clock))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,7 @@ study:
 
 massage:
   open-time : "${MASSAGE_OPEN_TIME:20:20}"
+  close-time : "${MASSAGE_CLOSE_TIME:21:00}"
   max-count : ${MASSAGE_MAX_COUNT:5}
   lock-key: ${MASSAGE_KEY:lock}
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- MassageProperties에 closeTime 필드 추가
- application.yml에 close-time 기본값 21:00 추가 (환경변수 MASSAGE_CLOSE_TIME으로 오버라이드 가능)
- ApplyMassageServiceImpl: openTime 이전 또는 closeTime 이후 신청 시 400 예외 반환
- GetMassageServiceImpl: isApplicationOpen을 openTime 이상 & closeTime 미만인 경우에만 true로 반환

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음