### PR TITLE
기상음악 응답에 신청자 이름 및 학번 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/ApplyMassageServiceImpl.kt
@@ -23,9 +23,9 @@ class ApplyMassageServiceImpl(
 
         val now = LocalTime.now()
 
-    if (now.isBefore(massageProperties.openTime)) {
-        throw ExpectedException("안마의자 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
-    }
+        if (now.isBefore(massageProperties.openTime)) {
+            throw ExpectedException("안마의자 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
+        }
 
         val lock = redissonClient.getLock(massageProperties.lockKey)
         val acquired = lock.tryLock(5, 3, TimeUnit.SECONDS)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/response/WakeUpMusicResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/response/WakeUpMusicResponse.kt
@@ -4,6 +4,9 @@ import java.time.LocalDateTime
 
 data class WakeUpMusicResponse(
     val id: Long,
+    val userId: Long,
+    val userName: String,
+    val studentNumber: Int,
     val musicUrl: String,
     val title: String?,
     val artist: String?,

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
@@ -14,10 +14,10 @@ interface WakeUpMusicRepository : JpaRepository<WakeUpMusicJpaEntity, Long> {
     @Query(
         """
         SELECT new team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse(
-            m.id, m.musicUrl, m.title, m.artist, m.duration, m.durationText, m.thumbnailUrl, m.videoUrl, m.appliedAt, COUNT(l.id), false)
+            m.id, m.user.id, m.user.name, m.user.studentNumber, m.musicUrl, m.title, m.artist, m.duration, m.durationText, m.thumbnailUrl, m.videoUrl, m.appliedAt, COUNT(l.id), false)
         FROM WakeUpMusicJpaEntity m LEFT JOIN WakeUpMusicLikeJpaEntity l ON l.music = m
         WHERE m.appliedAt >= :startOfDay AND m.appliedAt < :endOfDay
-        GROUP BY m.id, m.musicUrl, m.title, m.artist, m.duration, m.durationText, m.thumbnailUrl, m.videoUrl, m.appliedAt
+        GROUP BY m.id, m.user.id, m.user.name, m.user.studentNumber, m.musicUrl, m.title, m.artist, m.duration, m.durationText, m.thumbnailUrl, m.videoUrl, m.appliedAt
         ORDER BY m.appliedAt DESC
     """,
     )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -59,6 +59,9 @@ class ApplyWakeUpMusicServiceImpl(
 
         return WakeUpMusicResponse(
             id = saved.id,
+            userId = user.id,
+            userName = user.name,
+            studentNumber = user.studentNumber,
             musicUrl = saved.musicUrl,
             title = saved.title,
             artist = saved.artist,

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/StudyApplicationServiceImpl.kt
@@ -43,8 +43,15 @@ class StudyApplicationServiceImpl(
             }
 
         if (outOfRange) {
-            log.warn("자습 신청 가능 시간 아님: userId={}, now={}, openTime={}, closeTime={}", user.id, now, studyProperties.openTime, studyProperties.closeTime)
-            throw ExpectedException("자습 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST) }
+            log.warn(
+                "자습 신청 가능 시간 아님: userId={}, now={}, openTime={}, closeTime={}",
+                user.id,
+                now,
+                studyProperties.openTime,
+                studyProperties.closeTime,
+            )
+            throw ExpectedException("자습 신청 시간이 아닙니다.", HttpStatus.BAD_REQUEST)
+        }
 
         if (studyRedisAdapter.getApplicationStatus(user.id) == StudyApplicationStatus.BANNED ||
             studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now(clock))

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicControllerTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicControllerTest.kt
@@ -38,6 +38,9 @@ class WakeUpMusicControllerTest :
             val serviceResponse =
                 WakeUpMusicResponse(
                     id = 1L,
+                    userId = 1L,
+                    userName = "테스트",
+                    studentNumber = 1101,
                     musicUrl = request.musicUrl,
                     title = "테스트 음악",
                     artist = "테스트 채널",

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicServiceImplTest.kt
@@ -40,6 +40,9 @@ class GetWakeUpMusicServiceImplTest :
                         listOf(
                             WakeUpMusicResponse(
                                 id = 1L,
+                                userId = 1L,
+                                userName = "테스트",
+                                studentNumber = 1101,
                                 musicUrl = "https://youtube.com/watch?v=abc",
                                 title = "테스트 음악",
                                 artist = "테스트 채널",
@@ -95,6 +98,9 @@ class GetWakeUpMusicServiceImplTest :
                         listOf(
                             WakeUpMusicResponse(
                                 id = 1L,
+                                userId = 1L,
+                                userName = "테스트 A",
+                                studentNumber = 1101,
                                 musicUrl = "https://youtube.com/watch?v=abc",
                                 title = "테스트 음악 A",
                                 artist = "테스트 채널",
@@ -108,6 +114,9 @@ class GetWakeUpMusicServiceImplTest :
                             ),
                             WakeUpMusicResponse(
                                 id = 2L,
+                                userId = 2L,
+                                userName = "테스트 B",
+                                studentNumber = 1102,
                                 musicUrl = "https://youtube.com/watch?v=def",
                                 title = "테스트 음악 B",
                                 artist = "테스트 채널",


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- `WakeUpMusicResponse`에 `userId`, `userName`, `studentNumber` 필드 추가
- 클라이언트가 매번 별도 조회 없이 신청자 정보를 바로 사용할 수 있도록 개선
- JPQL 생성자 쿼리 및 `GROUP BY`에 `m.user.id`, `m.user.name`, `m.user.studentNumber` 반영
- `ApplyWakeUpMusicServiceImpl` 응답 생성 시 신청자 정보 전달

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음