### PR TITLE
동아리 전체 목록 조회 시 승인된 동아리만 반환하도록 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/repository/ClubRepository.kt
@@ -2,6 +2,7 @@ package team.incube.flooding.domain.club.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import team.incube.flooding.domain.club.entity.ClubApprovalStatus
 import team.incube.flooding.domain.club.entity.ClubJpaEntity
 import team.incube.flooding.domain.club.entity.ClubType
 
@@ -26,4 +27,25 @@ interface ClubRepository : JpaRepository<ClubJpaEntity, Long> {
     ): List<ClubJpaEntity>
 
     fun findAllByDataGsmClubIdIsNotNull(): List<ClubJpaEntity>
+
+    fun findAllByTypeAndApprovalStatus(
+        type: ClubType,
+        approvalStatus: ClubApprovalStatus,
+    ): List<ClubJpaEntity>
+
+    @Query(
+        """
+        SELECT c FROM ClubJpaEntity c
+        LEFT JOIN c.leader l
+        WHERE c.type = :type
+        AND c.approvalStatus = :approvalStatus
+        AND (LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+             OR LOWER(l.name) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        """,
+    )
+    fun findAllByTypeAndKeywordAndApprovalStatus(
+        type: ClubType,
+        keyword: String,
+        approvalStatus: ClubApprovalStatus,
+    ): List<ClubJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
@@ -19,14 +19,12 @@ class GetClubListServiceImpl(
         type: ClubType,
         name: String?,
     ): GetClubListResponse {
-        val allClubs =
+        val approvedClubs =
             if (name.isNullOrBlank()) {
-                clubRepository.findAllByType(type)
+                clubRepository.findAllByTypeAndApprovalStatus(type, ClubApprovalStatus.APPROVED)
             } else {
-                clubRepository.findAllByTypeAndKeyword(type, name.trim())
+                clubRepository.findAllByTypeAndKeywordAndApprovalStatus(type, name.trim(), ClubApprovalStatus.APPROVED)
             }
-
-        val approvedClubs = allClubs.filter { it.approvalStatus == ClubApprovalStatus.APPROVED }
 
         if (approvedClubs.isEmpty()) {
             return GetClubListResponse(clubs = emptyList())

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/GetClubListServiceImpl.kt
@@ -2,6 +2,7 @@ package team.incube.flooding.domain.club.service.impl
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.club.entity.ClubApprovalStatus
 import team.incube.flooding.domain.club.entity.ClubType
 import team.incube.flooding.domain.club.presentation.data.response.GetClubListResponse
 import team.incube.flooding.domain.club.repository.ClubParticipantRepository
@@ -18,22 +19,27 @@ class GetClubListServiceImpl(
         type: ClubType,
         name: String?,
     ): GetClubListResponse {
-        val clubs =
+        val allClubs =
             if (name.isNullOrBlank()) {
                 clubRepository.findAllByType(type)
             } else {
                 clubRepository.findAllByTypeAndKeyword(type, name.trim())
             }
-        if (clubs.isEmpty()) {
+
+        val approvedClubs = allClubs.filter { it.approvalStatus == ClubApprovalStatus.APPROVED }
+
+        if (approvedClubs.isEmpty()) {
             return GetClubListResponse(clubs = emptyList())
         }
+
         val countMap =
             clubParticipantRepository
-                .countGroupByClubIdIn(clubs.map { it.id })
+                .countGroupByClubIdIn(approvedClubs.map { it.id })
                 .associate { it.clubId to it.count }
+
         return GetClubListResponse(
             clubs =
-                clubs.map { club ->
+                approvedClubs.map { club ->
                     GetClubListResponse.ClubSummary(
                         id = club.id,
                         name = club.name,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호


## 📝작업 내용
동아리 전체 목록 조회 시, 아직 승인되지 않았거나 거절된 동아리가 노출되는 문제를 해결하기 위해 approvalStatus가 APPROVED인 동아리만 반환하도록 비즈니스 로직을 수정했습니다


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
