### PR TITLE
동아리 개설 신청 상태 응답 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/club/dto/response/ClubApplicationResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/dto/response/ClubApplicationResponse.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.club.dto.response
 
+import team.incube.flooding.domain.club.entity.ClubApprovalStatus
 import team.incube.flooding.domain.club.entity.ClubType
 
 data class ClubApplicationListResponse(
@@ -14,4 +15,5 @@ data class ClubApplicationResponse(
     val description: String,
     val imageUrl: String?,
     val maxMember: Int?,
+    val approvalStatus: ClubApprovalStatus,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/club/service/impl/QueryClubApplicationServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/club/service/impl/QueryClubApplicationServiceImpl.kt
@@ -38,6 +38,7 @@ class QueryClubApplicationServiceImpl(
                         description = club.description ?: "",
                         imageUrl = club.imageUrl,
                         maxMember = club.maxMember,
+                        approvalStatus = club.approvalStatus,
                     )
                 },
         )

--- a/src/test/kotlin/team/incube/flooding/domain/club/service/QueryClubApplicationServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/club/service/QueryClubApplicationServiceTest.kt
@@ -1,0 +1,86 @@
+package team.incube.flooding.domain.club.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.http.HttpStatus
+import team.incube.flooding.domain.club.entity.ClubApprovalStatus
+import team.incube.flooding.domain.club.entity.ClubJpaEntity
+import team.incube.flooding.domain.club.entity.ClubStatus
+import team.incube.flooding.domain.club.entity.ClubType
+import team.incube.flooding.domain.club.repository.ClubJpaRepository
+import team.incube.flooding.domain.club.service.impl.QueryClubApplicationServiceImpl
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.global.security.util.CurrentUserProvider
+import team.themoment.sdk.exception.ExpectedException
+
+class QueryClubApplicationServiceTest :
+    BehaviorSpec({
+        isolationMode = IsolationMode.InstancePerTest
+
+        val clubJpaRepository = mockk<ClubJpaRepository>()
+        val currentUserProvider = mockk<CurrentUserProvider>()
+        val service = QueryClubApplicationServiceImpl(clubJpaRepository, currentUserProvider)
+
+        fun user(role: Role) =
+            UserJpaEntity(
+                id = 1L,
+                name = "관리자",
+                sex = Sex.MAN,
+                email = "admin@test.com",
+                studentNumber = 10101,
+                role = role,
+                dormitoryRoom = 101,
+            )
+
+        fun club(
+            id: Long,
+            approvalStatus: ClubApprovalStatus,
+        ) = ClubJpaEntity(
+            id = id,
+            name = "테스트 동아리 $id",
+            type = ClubType.MAJOR_CLUB,
+            leader = null,
+            imageUrl = null,
+            status = ClubStatus.NEW,
+            description = "설명",
+            maxMember = 10,
+            approvalStatus = approvalStatus,
+        )
+
+        given("ADMIN 사용자가 동아리 개설 신청 목록을 조회할 때") {
+            `when`("반려된 신청이 포함되어 있으면") {
+                then("응답에 approvalStatus가 포함된다") {
+                    val rejectedClub = club(1L, ClubApprovalStatus.REJECTED)
+                    every { currentUserProvider.getCurrentUser() } returns user(Role.ADMIN)
+                    every { clubJpaRepository.findAllByStatus(ClubStatus.NEW) } returns listOf(rejectedClub)
+
+                    val response = service.execute()
+
+                    response.clubs.size shouldBe 1
+                    response.clubs[0].id shouldBe 1L
+                    response.clubs[0].approvalStatus shouldBe ClubApprovalStatus.REJECTED
+                }
+            }
+        }
+
+        given("ADMIN이 아닌 사용자가 동아리 개설 신청 목록을 조회할 때") {
+            `when`("목록 조회를 요청하면") {
+                then("FORBIDDEN 예외가 발생한다") {
+                    every { currentUserProvider.getCurrentUser() } returns user(Role.GENERAL_STUDENT)
+
+                    val exception =
+                        shouldThrow<ExpectedException> {
+                            service.execute()
+                        }
+
+                    exception.statusCode shouldBe HttpStatus.FORBIDDEN
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

동아리 개설 신청 목록 응답에 승인 상태를 추가했습니다.
반려된 신청도 `approvalStatus`로 구분할 수 있도록 엔티티 값을 매핑했습니다.
반려 상태가 응답에 포함되는 서비스 테스트를 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 테스트 실행 시 develop의 WakeUpMusicControllerTest 컴파일 오류로 실패합니다. 변경 범위와 무관한 기존 오류로 보입니다.