### PR TITLE
기상음악 조회 정렬 옵션 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
@@ -50,13 +50,13 @@ class WakeUpMusicController(
         @RequestParam(required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate?,
         @Parameter(description = "정렬 기준 (TIME: 시간순, LIKE: 좋아요순)", required = false)
-        @RequestParam(required = false) sort: WakeUpMusicSort?,
+        @RequestParam(required = false, defaultValue = "TIME") sort: WakeUpMusicSort,
     ): CommonApiResponse<List<WakeUpMusicResponse>> =
         CommonApiResponse.success(
             "OK",
             getWakeUpMusicService.execute(
                 date ?: LocalDate.now(),
-                sort ?: WakeUpMusicSort.TIME,
+                sort,
             ),
         )
 

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/controller/WakeUpMusicController.kt
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.incube.flooding.domain.dormitory.music.presentation.data.request.ApplyWakeUpMusicByUrlRequest
+import team.incube.flooding.domain.dormitory.music.presentation.data.request.WakeUpMusicSort
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
 import team.incube.flooding.domain.dormitory.music.service.ApplyWakeUpMusicService
 import team.incube.flooding.domain.dormitory.music.service.CancelLikeWakeUpMusicService
@@ -48,8 +49,16 @@ class WakeUpMusicController(
         @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", required = false)
         @RequestParam(required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate?,
+        @Parameter(description = "정렬 기준 (TIME: 시간순, LIKE: 좋아요순)", required = false)
+        @RequestParam(required = false) sort: WakeUpMusicSort?,
     ): CommonApiResponse<List<WakeUpMusicResponse>> =
-        CommonApiResponse.success("OK", getWakeUpMusicService.execute(date ?: LocalDate.now()))
+        CommonApiResponse.success(
+            "OK",
+            getWakeUpMusicService.execute(
+                date ?: LocalDate.now(),
+                sort ?: WakeUpMusicSort.TIME,
+            ),
+        )
 
     @Operation(
         summary = "기상음악 신청",

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/request/WakeUpMusicSort.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/request/WakeUpMusicSort.kt
@@ -1,0 +1,6 @@
+package team.incube.flooding.domain.dormitory.music.presentation.data.request
+
+enum class WakeUpMusicSort {
+    TIME,
+    LIKE,
+}

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/repository/WakeUpMusicRepository.kt
@@ -24,7 +24,6 @@ interface WakeUpMusicRepository : JpaRepository<WakeUpMusicJpaEntity, Long> {
         FROM WakeUpMusicJpaEntity m LEFT JOIN WakeUpMusicLikeJpaEntity l ON l.music = m
         WHERE m.appliedAt >= :startOfDay AND m.appliedAt < :endOfDay
         GROUP BY m.id, m.user.id, m.user.name, m.user.studentNumber, m.musicUrl, m.title, m.artist, m.duration, m.durationText, m.thumbnailUrl, m.videoUrl, m.appliedAt
-        ORDER BY m.appliedAt DESC
     """,
     )
     fun findAllWithLikeCountByDate(

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicService.kt
@@ -7,6 +7,6 @@ import java.time.LocalDate
 interface GetWakeUpMusicService {
     fun execute(
         date: LocalDate,
-        sort: WakeUpMusicSort,
+        sort: WakeUpMusicSort = WakeUpMusicSort.TIME,
     ): List<WakeUpMusicResponse>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicService.kt
@@ -1,8 +1,12 @@
 package team.incube.flooding.domain.dormitory.music.service
 
+import team.incube.flooding.domain.dormitory.music.presentation.data.request.WakeUpMusicSort
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
 import java.time.LocalDate
 
 interface GetWakeUpMusicService {
-    fun execute(date: LocalDate): List<WakeUpMusicResponse>
+    fun execute(
+        date: LocalDate,
+        sort: WakeUpMusicSort,
+    ): List<WakeUpMusicResponse>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/GetWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/GetWakeUpMusicServiceImpl.kt
@@ -32,8 +32,16 @@ class GetWakeUpMusicServiceImpl(
                 .toSet()
         val result = musicList.map { it.copy(isLiked = it.id in likedIds) }
         return when (sort) {
-            WakeUpMusicSort.TIME -> result.sortedByDescending { it.appliedAt }
-            WakeUpMusicSort.LIKE -> result.sortedByDescending { it.likeCount }
+            WakeUpMusicSort.TIME -> {
+                result.sortedByDescending { it.appliedAt }
+            }
+
+            WakeUpMusicSort.LIKE -> {
+                result.sortedWith(
+                    compareByDescending<WakeUpMusicResponse> { it.likeCount }
+                        .thenByDescending { it.appliedAt },
+                )
+            }
         }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/GetWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/GetWakeUpMusicServiceImpl.kt
@@ -2,6 +2,7 @@ package team.incube.flooding.domain.dormitory.music.service.impl
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.dormitory.music.presentation.data.request.WakeUpMusicSort
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRepository
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
@@ -16,7 +17,10 @@ class GetWakeUpMusicServiceImpl(
     private val currentUserProvider: CurrentUserProvider,
 ) : GetWakeUpMusicService {
     @Transactional(readOnly = true)
-    override fun execute(date: LocalDate): List<WakeUpMusicResponse> {
+    override fun execute(
+        date: LocalDate,
+        sort: WakeUpMusicSort,
+    ): List<WakeUpMusicResponse> {
         val startOfDay = date.atStartOfDay()
         val endOfDay = date.plusDays(1).atStartOfDay()
         val musicList = wakeUpMusicRepository.findAllWithLikeCountByDate(startOfDay, endOfDay)
@@ -26,6 +30,10 @@ class GetWakeUpMusicServiceImpl(
             wakeUpMusicLikeRepository
                 .findLikedMusicIdsByUserIdAndMusicIdIn(currentUser.id, musicList.map { it.id })
                 .toSet()
-        return musicList.map { it.copy(isLiked = it.id in likedIds) }
+        val result = musicList.map { it.copy(isLiked = it.id in likedIds) }
+        return when (sort) {
+            WakeUpMusicSort.TIME -> result.sortedByDescending { it.appliedAt }
+            WakeUpMusicSort.LIKE -> result.sortedByDescending { it.likeCount }
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

기상음악 목록 조회 API에 정렬 필터를 추가했습니다.

- `WakeUpMusicSort` enum 추가 (`TIME`, `LIKE`)
- `GET /dormitory/music?sort=TIME` : 신청 시간 최신순 (기본값)
- `GET /dormitory/music?sort=LIKE` : 좋아요 많은 순
- Repository의 하드코딩된 `ORDER BY` 제거, 서비스 레이어에서 정렬 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음