### PR TITLE
기상음악 SSE 구독 엔드포인트 SecurityConfig 누락 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -98,6 +98,7 @@ class SecurityConfig(
 
                 // music
                 it.requestMatchers(HttpMethod.GET, "/dormitory/music").authenticated()
+                it.requestMatchers(HttpMethod.GET, "/dormitory/music/subscribe").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/dormitory/music").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/dormitory/music/*").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/dormitory/music/*/like").authenticated()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

`SecurityConfig`에서 기상음악 SSE 구독 엔드포인트가 누락되어 있던 문제를 수정했습니다.

- `GET /dormitory/music/subscribe` 엔드포인트를 SecurityConfig에 명시적으로 추가
- 기존에는 `anyRequest().authenticated()` 에만 의존하고 있어, SSE 연결 시 인증 처리가 불명확했음

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음