### PR TITLE
자습 신청자 목록에 신청 순서(order) 필드 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapter.kt
@@ -60,20 +60,21 @@ class StudyRedisAdapter(
     fun getCount(): Long = redisTemplate.opsForValue().get(COUNT_KEY)?.toLong() ?: 0
 
     fun addApplicant(userId: Long) {
-        redisTemplate.opsForSet().add(APPLICANTS_KEY, userId.toString())
-        redisTemplate.expire(APPLICANTS_KEY, ttlUntil6AM())
+        val size = redisTemplate.opsForList().rightPush(APPLICANTS_KEY, userId.toString())
+        if (size == 1L) {
+            redisTemplate.expire(APPLICANTS_KEY, ttlUntil6AM())
+        }
     }
 
     fun removeApplicant(userId: Long) {
-        redisTemplate.opsForSet().remove(APPLICANTS_KEY, userId.toString())
+        redisTemplate.opsForList().remove(APPLICANTS_KEY, 1, userId.toString())
     }
 
-    fun getApplicantIds(): Set<Long> =
+    fun getApplicantIds(): List<Long> =
         redisTemplate
-            .opsForSet()
-            .members(APPLICANTS_KEY)
-            ?.map { it.toLong() }
-            ?.toSet() ?: emptySet()
+            .opsForList()
+            .range(APPLICANTS_KEY, 0, -1)
+            ?.map { it.toLong() } ?: emptyList()
 
     fun checkAttendance(userId: Long) {
         redisTemplate.opsForSet().add(ATTENDANCE_KEY, userId.toString())

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
@@ -3,6 +3,7 @@ package team.incube.flooding.domain.dormitory.study.presentation.data.response
 import team.incube.flooding.domain.user.entity.Sex
 
 data class GetStudyResponse(
+    val order: Int,
     val userId: Long,
     val name: String,
     val studentNumber: Int,

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
@@ -47,19 +47,19 @@ class GetStudyServiceImpl(
             if (applicantIds.isEmpty()) {
                 emptyList()
             } else {
-                userRepository
-                    .findAllById(applicantIds)
-                    .sortedBy { it.studentNumber }
-                    .map {
-                        GetStudyResponse(
-                            userId = it.id,
-                            name = it.name,
-                            studentNumber = it.studentNumber,
-                            sex = it.sex,
-                            isBanned = it.id in bannedUserIds,
-                            isChecked = it.id in checkedUserIds,
-                        )
-                    }
+                val userMap = userRepository.findAllById(applicantIds).associateBy { it.id }
+                applicantIds.mapIndexedNotNull { index, userId ->
+                    val user = userMap[userId] ?: return@mapIndexedNotNull null
+                    GetStudyResponse(
+                        order = index + 1,
+                        userId = user.id,
+                        name = user.name,
+                        studentNumber = user.studentNumber,
+                        sex = user.sex,
+                        isBanned = user.id in bannedUserIds,
+                        isChecked = user.id in checkedUserIds,
+                    )
+                }
             }
         return GetStudyListResponse(
             isApplicationOpen = isStudyAvailable(now),

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/massage/service/GetMassageServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/massage/service/GetMassageServiceTest.kt
@@ -1,0 +1,76 @@
+package team.incube.flooding.domain.dormitory.massage.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import team.incube.flooding.domain.dormitory.massage.adapter.MassageRedisAdapter
+import team.incube.flooding.domain.dormitory.massage.config.MassageProperties
+import team.incube.flooding.domain.dormitory.massage.service.impl.GetMassageServiceImpl
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.incube.flooding.global.security.util.CurrentUserProvider
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneId
+
+class GetMassageServiceTest :
+    BehaviorSpec({
+        val massageRedisAdapter = mockk<MassageRedisAdapter>()
+        val userRepository = mockk<UserRepository>()
+        val massageProperties =
+            MassageProperties(
+                openTime = LocalTime.of(20, 0),
+                closeTime = LocalTime.of(22, 0),
+                maxCount = 5,
+                lockKey = "massage:lock",
+            )
+        val currentUserProvider = mockk<CurrentUserProvider>()
+        val clock = Clock.fixed(Instant.parse("2026-06-04T12:00:00Z"), ZoneId.of("Asia/Seoul"))
+
+        fun user(id: Long) =
+            UserJpaEntity(
+                id = id,
+                name = "학생$id",
+                sex = Sex.MAN,
+                email = "s$id@test.com",
+                studentNumber = (1000 + id).toInt(),
+                role = Role.GENERAL_STUDENT,
+                dormitoryRoom = 101,
+            )
+
+        val currentUser = user(999L)
+        every { currentUserProvider.getCurrentUser() } returns currentUser
+        every { massageRedisAdapter.isReapplyBlocked(any()) } returns false
+        every { massageRedisAdapter.isApply(any()) } returns false
+
+        val service =
+            GetMassageServiceImpl(
+                massageRedisAdapter = massageRedisAdapter,
+                userRepository = userRepository,
+                massageProperties = massageProperties,
+                currentUserProvider = currentUserProvider,
+                clock = clock,
+            )
+
+        given("5명이 순서대로 신청했을 때 (신청 순서: userId 1→2→3→4→5)") {
+            `when`("목록을 조회하면") {
+                then("제일 먼저 신청한 userId=1의 order가 1이다") {
+                    every { massageRedisAdapter.getQueue() } returns listOf(1L, 2L, 3L, 4L, 5L)
+                    every { userRepository.findAllById(any<List<Long>>()) } returns
+                        listOf(user(1), user(2), user(3), user(4), user(5))
+
+                    val result = service.execute()
+
+                    result.applicants[0].order shouldBe 1L
+                    result.applicants[1].order shouldBe 2L
+                    result.applicants[2].order shouldBe 3L
+                    result.applicants[3].order shouldBe 4L
+                    result.applicants[4].order shouldBe 5L
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/service/GetStudyServiceTest.kt
@@ -70,7 +70,7 @@ class GetStudyServiceTest :
         given("신청자가 없을 때") {
             `when`("자습 신청자 목록을 조회하면") {
                 then("빈 리스트를 반환한다") {
-                    every { studyRedisAdapter.getApplicantIds() } returns emptySet()
+                    every { studyRedisAdapter.getApplicantIds() } returns emptyList()
                     every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
 
                     val result = service.execute()
@@ -87,7 +87,7 @@ class GetStudyServiceTest :
 
             `when`("아무도 자습체크를 하지 않았으면") {
                 then("모든 isChecked가 false다") {
-                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L)
+                    every { studyRedisAdapter.getApplicantIds() } returns listOf(1L, 2L)
                     every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
                         emptyList()
                     every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
@@ -102,7 +102,7 @@ class GetStudyServiceTest :
 
             `when`("한 명만 자습체크를 했으면") {
                 then("체크한 학생의 isChecked는 true, 나머지는 false다") {
-                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L)
+                    every { studyRedisAdapter.getApplicantIds() } returns listOf(1L, 2L)
                     every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
                         emptyList()
                     every { studyRedisAdapter.getAttendanceIds() } returns setOf(1L)
@@ -117,7 +117,7 @@ class GetStudyServiceTest :
 
             `when`("모두 자습체크를 했으면") {
                 then("모든 isChecked가 true다") {
-                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L)
+                    every { studyRedisAdapter.getApplicantIds() } returns listOf(1L, 2L)
                     every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
                         emptyList()
                     every { studyRedisAdapter.getAttendanceIds() } returns setOf(1L, 2L)
@@ -144,7 +144,7 @@ class GetStudyServiceTest :
 
             `when`("자습 신청자 목록을 조회하면") {
                 then("금지된 학생의 isBanned는 true다") {
-                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L)
+                    every { studyRedisAdapter.getApplicantIds() } returns listOf(1L, 2L)
                     every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
                         listOf(banEntity)
                     every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
@@ -170,7 +170,7 @@ class GetStudyServiceTest :
 
             `when`("자습 신청자 목록을 조회하면") {
                 then("isBanned와 isChecked가 모두 true다") {
-                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L)
+                    every { studyRedisAdapter.getApplicantIds() } returns listOf(1L)
                     every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
                         listOf(banEntity)
                     every { studyRedisAdapter.getAttendanceIds() } returns setOf(1L)
@@ -190,7 +190,7 @@ class GetStudyServiceTest :
 
             `when`("자습 신청자 목록을 조회하면") {
                 then("sex 필드가 올바르게 매핑된다") {
-                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L)
+                    every { studyRedisAdapter.getApplicantIds() } returns listOf(1L, 2L)
                     every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
                         emptyList()
                     every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
@@ -204,14 +204,14 @@ class GetStudyServiceTest :
             }
         }
 
-        given("신청자 3명이 studentNumber 순서가 섞여 있을 때") {
+        given("신청자 3명이 순서대로 신청했을 때") {
             val user1 = user(id = 1L, studentNumber = 1103)
             val user2 = user(id = 2L, studentNumber = 1101)
             val user3 = user(id = 3L, studentNumber = 1102)
 
             `when`("자습 신청자 목록을 조회하면") {
-                then("studentNumber 오름차순으로 정렬된다") {
-                    every { studyRedisAdapter.getApplicantIds() } returns setOf(1L, 2L, 3L)
+                then("신청 순서대로 정렬된다") {
+                    every { studyRedisAdapter.getApplicantIds() } returns listOf(1L, 2L, 3L)
                     every { studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(any(), any()) } returns
                         emptyList()
                     every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
@@ -219,9 +219,12 @@ class GetStudyServiceTest :
 
                     val result = service.execute().applicants
 
-                    result[0].studentNumber shouldBe 1101
-                    result[1].studentNumber shouldBe 1102
-                    result[2].studentNumber shouldBe 1103
+                    result[0].userId shouldBe 1L
+                    result[1].userId shouldBe 2L
+                    result[2].userId shouldBe 3L
+                    result[0].order shouldBe 1
+                    result[1].order shouldBe 2
+                    result[2].order shouldBe 3
                 }
             }
         }
@@ -229,7 +232,7 @@ class GetStudyServiceTest :
         given("현재 사용자가 오늘 자습을 취소했을 때") {
             `when`("자습 신청자 목록을 조회하면") {
                 then("내 신청 상태가 CANCELLED로 반환된다") {
-                    every { studyRedisAdapter.getApplicantIds() } returns emptySet()
+                    every { studyRedisAdapter.getApplicantIds() } returns emptyList()
                     every { studyRedisAdapter.getAttendanceIds() } returns emptySet()
                     every { studyRedisAdapter.getApplicationStatus(currentUser.id) } returns
                         StudyApplicationStatus.CANCELLED


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

- 자습 신청자 목록(`APPLICANTS_KEY`)의 Redis 자료구조를 Set → List로 변경하여 신청 순서를 보존
- `GetStudyResponse`에 `order` 필드 추가 (1-based 신청 순서)
- `GetStudyServiceImpl`에서 `sortedBy { studentNumber }` 대신 Redis List의 삽입 순서를 유지하도록 변경
- `GetStudyServiceTest` 전체 mock 반환 타입을 `Set` → `List`로 수정, 순서 검증 테스트 보완
- `GetMassageServiceTest` 신규 추가 — 마사지 신청자 목록의 order 필드 검증

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음