### PR TITLE
유저 Role 변경 API 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
@@ -4,17 +4,24 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import team.incube.flooding.domain.user.presentation.data.request.PatchUserRoleRequest
 import team.incube.flooding.domain.user.presentation.data.response.GetMeResponse
 import team.incube.flooding.domain.user.presentation.data.response.SearchUsersResponse
 import team.incube.flooding.domain.user.service.GetMeService
+import team.incube.flooding.domain.user.service.PatchUserRoleService
 import team.incube.flooding.domain.user.service.SearchUsersService
 import team.themoment.sdk.response.CommonApiResponse
 
@@ -24,6 +31,7 @@ import team.themoment.sdk.response.CommonApiResponse
 class UserController(
     private val getMeService: GetMeService,
     private val searchUsersService: SearchUsersService,
+    private val patchUserRoleService: PatchUserRoleService,
 ) {
     @Operation(
         summary = "내 정보 조회",
@@ -54,4 +62,21 @@ class UserController(
         pageable: Pageable,
     ): CommonApiResponse<Page<SearchUsersResponse>> =
         CommonApiResponse.success("OK", searchUsersService.execute(name, studentNumber, pageable))
+
+    @Operation(
+        summary = "유저 권한 변경",
+        description = "특정 유저의 권한(Role)을 변경합니다. ADMIN 또는 DORMITORY_MANAGER 역할만 접근 가능합니다.",
+    )
+    @ApiResponse(responseCode = "204", description = "권한 변경 성공")
+    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    @ApiResponse(responseCode = "403", description = "권한 없음 (ADMIN 또는 DORMITORY_MANAGER만 접근 가능)")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자")
+    @PatchMapping("/{userId}/role")
+    fun patchUserRole(
+        @Parameter(description = "권한을 변경할 유저 ID") @PathVariable userId: Long,
+        @Valid @RequestBody request: PatchUserRoleRequest,
+    ): ResponseEntity<Void> {
+        patchUserRoleService.execute(userId, request.role)
+        return ResponseEntity.noContent().build()
+    }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/request/PatchUserRoleRequest.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/request/PatchUserRoleRequest.kt
@@ -1,0 +1,9 @@
+package team.incube.flooding.domain.user.presentation.data.request
+
+import jakarta.validation.constraints.NotNull
+import team.incube.flooding.domain.user.entity.Role
+
+data class PatchUserRoleRequest(
+    @field:NotNull
+    val role: Role,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/PatchUserRoleService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/PatchUserRoleService.kt
@@ -1,0 +1,10 @@
+package team.incube.flooding.domain.user.service
+
+import team.incube.flooding.domain.user.entity.Role
+
+interface PatchUserRoleService {
+    fun execute(
+        userId: Long,
+        role: Role,
+    )
+}

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/impl/PatchUserRoleServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/impl/PatchUserRoleServiceImpl.kt
@@ -1,0 +1,27 @@
+package team.incube.flooding.domain.user.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.incube.flooding.domain.user.service.PatchUserRoleService
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class PatchUserRoleServiceImpl(
+    private val userRepository: UserRepository,
+) : PatchUserRoleService {
+    @Transactional
+    override fun execute(
+        userId: Long,
+        role: Role,
+    ) {
+        val user =
+            userRepository
+                .findById(userId)
+                .orElseThrow { ExpectedException("존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND) }
+        user.role = role
+        userRepository.save(user)
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -125,6 +125,11 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.PATCH, "/dormitory/cleaning-zones/*/members")
                     .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
 
+                // user
+                it
+                    .requestMatchers(HttpMethod.PATCH, "/users/*/role")
+                    .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
+
                 it.anyRequest().authenticated()
             }.exceptionHandling {
                 it.authenticationEntryPoint { _, response, _ ->


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

ADMIN 또는 DORMITORY_MANAGER 역할을 가진 사용자가 다른 유저의 권한(Role)을 변경할 수 있는 API를 구현했습니다.

- `PATCH /users/{userId}/role` 엔드포인트 추가
- `PatchUserRoleRequest` 요청 DTO 생성 (role 필드, NotNull 검증)
- `PatchUserRoleService` 인터페이스 및 `PatchUserRoleServiceImpl` 구현체 생성
- 존재하지 않는 userId 요청 시 404 반환
- SecurityConfig에 해당 엔드포인트 접근 권한 설정 (ADMIN, DORMITORY_MANAGER)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음