### PR TITLE
기상음악 SSE 초기 데이터 전송 비동기 처리 누락 수정

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistry.kt
@@ -26,6 +26,7 @@ class WakeUpMusicSseEmitterRegistry(
         return emitter
     }
 
+    @Async
     fun sendInitialData(
         emitter: SseEmitter,
         initList: List<WakeUpMusicResponse>,

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistryTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistryTest.kt
@@ -1,0 +1,186 @@
+package team.incube.flooding.domain.dormitory.music.adapter
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicCancelledEvent
+import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
+import tools.jackson.databind.ObjectMapper
+import java.io.IOException
+import java.time.LocalDateTime
+import java.util.concurrent.CopyOnWriteArrayList
+
+class WakeUpMusicSseEmitterRegistryTest :
+    BehaviorSpec({
+        val objectMapper = mockk<ObjectMapper>()
+        lateinit var registry: WakeUpMusicSseEmitterRegistry
+
+        fun emitters(): CopyOnWriteArrayList<SseEmitter> {
+            val field = WakeUpMusicSseEmitterRegistry::class.java.getDeclaredField("emitters")
+            field.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            return field.get(registry) as CopyOnWriteArrayList<SseEmitter>
+        }
+
+        val sampleMusic =
+            WakeUpMusicResponse(
+                id = 1L,
+                userId = 1L,
+                userName = "테스트",
+                studentNumber = 1101,
+                musicUrl = "https://youtube.com/watch?v=test",
+                title = "테스트 음악",
+                artist = "테스트 채널",
+                duration = "PT3M",
+                durationText = "3:00",
+                thumbnailUrl = null,
+                videoUrl = null,
+                appliedAt = LocalDateTime.of(2026, 6, 5, 8, 0),
+                likeCount = 0,
+            )
+
+        beforeEach {
+            clearAllMocks()
+            registry = WakeUpMusicSseEmitterRegistry(objectMapper)
+        }
+
+        given("emitter를 등록할 때") {
+            `when`("register를 호출하면") {
+                then("emitter가 목록에 추가된다") {
+                    registry.register(SseEmitter(1_800_000L))
+
+                    emitters() shouldHaveSize 1
+                }
+            }
+        }
+
+        given("초기 데이터를 전송할 때") {
+            val initList = listOf(sampleMusic)
+
+            `when`("직렬화가 성공하면") {
+                then("connect와 init 이벤트 총 2회 전송되고 연결이 유지된다") {
+                    val emitter = spyk(SseEmitter(1_800_000L))
+                    registry.register(emitter)
+                    every { objectMapper.writeValueAsString(any()) } returns "[]"
+
+                    registry.sendInitialData(emitter, initList)
+
+                    verify(exactly = 2) { emitter.send(any<SseEmitter.SseEventBuilder>()) }
+                    // 성공 시 emitter가 목록에서 제거되지 않아야 한다 (SSE 연결 유지)
+                    emitters() shouldHaveSize 1
+                }
+            }
+
+            `when`("직렬화가 실패하면") {
+                then("emitter가 목록에서 제거되고 에러 완료가 호출된다") {
+                    val emitter = spyk(SseEmitter(1_800_000L))
+                    registry.register(emitter)
+                    every { objectMapper.writeValueAsString(any()) } answers {
+                        throw RuntimeException("직렬화 실패")
+                    }
+
+                    registry.sendInitialData(emitter, initList)
+
+                    emitters().shouldBeEmpty()
+                    verify(exactly = 1) { emitter.completeWithError(any()) }
+                }
+            }
+
+            `when`("이벤트 전송 중 IOException이 발생하면") {
+                then("emitter가 목록에서 제거되고 에러 완료가 호출된다") {
+                    val emitter = spyk(SseEmitter(1_800_000L))
+                    registry.register(emitter)
+                    every { objectMapper.writeValueAsString(any()) } returns "[]"
+                    every { emitter.send(any<SseEmitter.SseEventBuilder>()) } throws IOException("broken pipe")
+
+                    registry.sendInitialData(emitter, initList)
+
+                    emitters().shouldBeEmpty()
+                    verify(exactly = 1) { emitter.completeWithError(any()) }
+                }
+            }
+        }
+
+        given("broadcast를 호출할 때") {
+            `when`("등록된 emitter가 여러 개 있으면") {
+                then("모든 emitter에 이벤트가 전송된다") {
+                    val emitter1 = spyk(SseEmitter(1_800_000L))
+                    val emitter2 = spyk(SseEmitter(1_800_000L))
+                    registry.register(emitter1)
+                    registry.register(emitter2)
+                    every { objectMapper.writeValueAsString(sampleMusic) } returns "{}"
+
+                    registry.broadcast(sampleMusic)
+
+                    verify(exactly = 1) { emitter1.send(any<SseEmitter.SseEventBuilder>()) }
+                    verify(exactly = 1) { emitter2.send(any<SseEmitter.SseEventBuilder>()) }
+                }
+            }
+
+            `when`("특정 emitter 전송이 실패하면") {
+                then("해당 emitter에만 에러 완료가 호출된다") {
+                    val failingEmitter = spyk(SseEmitter(1_800_000L))
+                    val healthyEmitter = spyk(SseEmitter(1_800_000L))
+                    registry.register(failingEmitter)
+                    registry.register(healthyEmitter)
+                    every { objectMapper.writeValueAsString(sampleMusic) } returns "{}"
+                    every { failingEmitter.send(any<SseEmitter.SseEventBuilder>()) } throws IOException("broken pipe")
+
+                    registry.broadcast(sampleMusic)
+
+                    verify(exactly = 1) { failingEmitter.completeWithError(any()) }
+                    verify(exactly = 0) { healthyEmitter.completeWithError(any()) }
+                }
+            }
+        }
+
+        given("broadcastCancelled를 호출할 때") {
+            val cancelEvent = WakeUpMusicCancelledEvent(musicId = 1L)
+
+            `when`("등록된 emitter가 있으면") {
+                then("emitter에 취소 이벤트가 전송된다") {
+                    val emitter = spyk(SseEmitter(1_800_000L))
+                    registry.register(emitter)
+                    every { objectMapper.writeValueAsString(cancelEvent) } returns "{}"
+
+                    registry.broadcastCancelled(cancelEvent)
+
+                    verify(exactly = 1) { emitter.send(any<SseEmitter.SseEventBuilder>()) }
+                }
+            }
+        }
+
+        given("heartbeat를 전송할 때") {
+            `when`("전송이 성공하면") {
+                then("모든 emitter에 heartbeat comment가 전송된다") {
+                    val emitter1 = spyk(SseEmitter(1_800_000L))
+                    val emitter2 = spyk(SseEmitter(1_800_000L))
+                    registry.register(emitter1)
+                    registry.register(emitter2)
+
+                    registry.sendHeartbeat()
+
+                    verify(exactly = 1) { emitter1.send(any<SseEmitter.SseEventBuilder>()) }
+                    verify(exactly = 1) { emitter2.send(any<SseEmitter.SseEventBuilder>()) }
+                }
+            }
+
+            `when`("전송이 실패하면") {
+                then("해당 emitter에 에러 완료가 호출된다") {
+                    val emitter = spyk(SseEmitter(1_800_000L))
+                    registry.register(emitter)
+                    every { emitter.send(any<SseEmitter.SseEventBuilder>()) } throws IOException("broken pipe")
+
+                    registry.sendHeartbeat()
+
+                    verify(exactly = 1) { emitter.completeWithError(any()) }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/SubscribeWakeUpMusicServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/SubscribeWakeUpMusicServiceImplTest.kt
@@ -1,0 +1,96 @@
+package team.incube.flooding.domain.dormitory.music.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import team.incube.flooding.domain.dormitory.music.adapter.WakeUpMusicSseEmitterRegistry
+import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
+import team.incube.flooding.domain.dormitory.music.service.impl.SubscribeWakeUpMusicServiceImpl
+import java.time.LocalDateTime
+
+class SubscribeWakeUpMusicServiceImplTest :
+    BehaviorSpec({
+        val getWakeUpMusicService = mockk<GetWakeUpMusicService>()
+        val sseEmitterRegistry = mockk<WakeUpMusicSseEmitterRegistry>(relaxed = true)
+
+        val service =
+            SubscribeWakeUpMusicServiceImpl(
+                getWakeUpMusicService = getWakeUpMusicService,
+                sseEmitterRegistry = sseEmitterRegistry,
+            )
+
+        beforeEach { clearAllMocks() }
+
+        val sampleMusicList =
+            listOf(
+                WakeUpMusicResponse(
+                    id = 1L,
+                    userId = 1L,
+                    userName = "테스트",
+                    studentNumber = 1101,
+                    musicUrl = "https://youtube.com/watch?v=test",
+                    title = "테스트 음악",
+                    artist = "테스트 채널",
+                    duration = "PT3M21S",
+                    durationText = "3:21",
+                    thumbnailUrl = null,
+                    videoUrl = null,
+                    appliedAt = LocalDateTime.of(2026, 6, 5, 8, 0),
+                    likeCount = 0,
+                ),
+            )
+
+        given("기상음악 목록이 있을 때") {
+            `when`("execute를 호출하면") {
+                then("SseEmitter가 반환되고 registry에 등록 및 초기 데이터 전송이 요청된다") {
+                    every { getWakeUpMusicService.execute(any(), any()) } returns sampleMusicList
+
+                    val result = service.execute()
+
+                    result shouldNotBe null
+                    verify(exactly = 1) { sseEmitterRegistry.register(result) }
+                    verify(exactly = 1) { sseEmitterRegistry.sendInitialData(result, sampleMusicList) }
+                }
+            }
+        }
+
+        given("기상음악 목록이 없을 때") {
+            `when`("execute를 호출하면") {
+                then("SseEmitter가 반환되고 빈 목록으로 초기 데이터 전송이 요청된다") {
+                    every { getWakeUpMusicService.execute(any(), any()) } returns emptyList()
+
+                    val result = service.execute()
+
+                    result shouldNotBe null
+                    verify(exactly = 1) { sseEmitterRegistry.register(result) }
+                    verify(exactly = 1) { sseEmitterRegistry.sendInitialData(result, emptyList()) }
+                }
+            }
+        }
+
+        given("SseEmitter 반환 후 registry 상호작용 순서가 올바를 때") {
+            `when`("execute를 호출하면") {
+                then("register 이후에 sendInitialData가 호출된다") {
+                    every { getWakeUpMusicService.execute(any(), any()) } returns sampleMusicList
+                    val callOrder = mutableListOf<String>()
+                    every { sseEmitterRegistry.register(any()) } answers {
+                        callOrder.add("register")
+                        firstArg()
+                    }
+                    every { sseEmitterRegistry.sendInitialData(any(), any()) } answers {
+                        callOrder.add("sendInitialData")
+                    }
+
+                    service.execute()
+
+                    callOrder[0] shouldBe "register"
+                    callOrder[1] shouldBe "sendInitialData"
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

`WakeUpMusicSseEmitterRegistry.sendInitialData()`에 `@Async` 어노테이션이 누락되어 SSE 연결이 계속 닫히는 문제를 수정했습니다.

**원인**
- `StudyAttendanceSseEmitterRegistry`의 `sendInitialData()`는 `@Async`로 선언되어 있어 emitter가 Spring 프레임워크에 반환된 후 비동기 스레드에서 초기 이벤트를 전송합니다.
- `WakeUpMusicSseEmitterRegistry`의 `sendInitialData()`는 `@Async`가 없어 HTTP 요청 스레드에서 동기적으로 실행되었고, async context가 설정되기 전에 이벤트를 전송하여 연결이 닫히는 문제가 발생했습니다.

**변경 사항**
- `WakeUpMusicSseEmitterRegistry.sendInitialData()`에 `@Async` 추가
- `SubscribeWakeUpMusicServiceImplTest` 단위 테스트 추가 (emitter 반환, register/sendInitialData 호출 순서 검증)
- `WakeUpMusicSseEmitterRegistryTest` 단위 테스트 추가 (연결 유지 검증, 직렬화 실패, broadcast, heartbeat 등 9개 시나리오)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> `sendInitialData` 성공 후 emitter가 목록에서 제거되지 않는다는 테스트(`emitters() shouldHaveSize 1`)가 연결 유지를 검증하는 핵심 케이스입니다.