### PR TITLE
기상음악 실시간 좋아요 SSE 이벤트 추가 및 이벤트 미수신 문제 해결

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistry.kt
@@ -6,6 +6,7 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicCancelledEvent
+import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicLikeEvent
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
 import tools.jackson.databind.ObjectMapper
 import java.util.concurrent.CopyOnWriteArrayList
@@ -80,6 +81,18 @@ class WakeUpMusicSseEmitterRegistry(
                 return
             }
         broadcastEvent("music-cancelled", json)
+    }
+
+    @Async
+    fun broadcastLike(event: WakeUpMusicLikeEvent) {
+        log.info("broadcastLike 진입: emitters.size={}, event={}", emitters.size, event)
+        val json =
+            try {
+                objectMapper.writeValueAsString(event)
+            } catch (e: Exception) {
+                return
+            }
+        broadcastEvent("music-like-updated", json)
     }
 
     @Scheduled(fixedDelay = 30_000L)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/response/WakeUpMusicLikeEvent.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/presentation/data/response/WakeUpMusicLikeEvent.kt
@@ -1,0 +1,6 @@
+package team.incube.flooding.domain.dormitory.music.presentation.data.response
+
+data class WakeUpMusicLikeEvent(
+    val musicId: Long,
+    val likeCount: Long,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/ApplyWakeUpMusicServiceImpl.kt
@@ -88,13 +88,17 @@ class ApplyWakeUpMusicServiceImpl(
                 isLiked = false,
             )
 
-        TransactionSynchronizationManager.registerSynchronization(
-            object : TransactionSynchronization {
-                override fun afterCommit() {
-                    sseEmitterRegistry.broadcast(response)
-                }
-            },
-        )
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                object : TransactionSynchronization {
+                    override fun afterCommit() {
+                        sseEmitterRegistry.broadcast(response)
+                    }
+                },
+            )
+        } else {
+            sseEmitterRegistry.broadcast(response)
+        }
 
         return response
     }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/CancelLikeWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/CancelLikeWakeUpMusicServiceImpl.kt
@@ -3,6 +3,10 @@ package team.incube.flooding.domain.dormitory.music.service.impl
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import team.incube.flooding.domain.dormitory.music.adapter.WakeUpMusicSseEmitterRegistry
+import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicLikeEvent
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRepository
 import team.incube.flooding.domain.dormitory.music.service.CancelLikeWakeUpMusicService
 import team.incube.flooding.global.security.util.CurrentUserProvider
@@ -12,6 +16,7 @@ import team.themoment.sdk.exception.ExpectedException
 class CancelLikeWakeUpMusicServiceImpl(
     private val wakeUpMusicLikeRepository: WakeUpMusicLikeRepository,
     private val currentUserProvider: CurrentUserProvider,
+    private val sseEmitterRegistry: WakeUpMusicSseEmitterRegistry,
 ) : CancelLikeWakeUpMusicService {
     @Transactional
     override fun execute(musicId: Long) {
@@ -22,5 +27,29 @@ class CancelLikeWakeUpMusicServiceImpl(
                 ?: throw ExpectedException("좋아요 내역이 없습니다.", HttpStatus.NOT_FOUND)
 
         wakeUpMusicLikeRepository.delete(like)
+
+        val likeCount = wakeUpMusicLikeRepository.countByMusicId(musicId)
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                object : TransactionSynchronization {
+                    override fun afterCommit() {
+                        sseEmitterRegistry.broadcastLike(
+                            WakeUpMusicLikeEvent(
+                                musicId = musicId,
+                                likeCount = likeCount,
+                            ),
+                        )
+                    }
+                },
+            )
+        } else {
+            sseEmitterRegistry.broadcastLike(
+                WakeUpMusicLikeEvent(
+                    musicId = musicId,
+                    likeCount = likeCount,
+                ),
+            )
+        }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/CancelWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/CancelWakeUpMusicServiceImpl.kt
@@ -37,12 +37,16 @@ class CancelWakeUpMusicServiceImpl(
         wakeUpMusicLikeRepository.deleteAllByMusicId(musicId)
         wakeUpMusicRepository.delete(music)
 
-        TransactionSynchronizationManager.registerSynchronization(
-            object : TransactionSynchronization {
-                override fun afterCommit() {
-                    sseEmitterRegistry.broadcastCancelled(WakeUpMusicCancelledEvent(musicId = musicId))
-                }
-            },
-        )
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                object : TransactionSynchronization {
+                    override fun afterCommit() {
+                        sseEmitterRegistry.broadcastCancelled(WakeUpMusicCancelledEvent(musicId = musicId))
+                    }
+                },
+            )
+        } else {
+            sseEmitterRegistry.broadcastCancelled(WakeUpMusicCancelledEvent(musicId = musicId))
+        }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/LikeWakeUpMusicServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/service/impl/LikeWakeUpMusicServiceImpl.kt
@@ -3,7 +3,11 @@ package team.incube.flooding.domain.dormitory.music.service.impl
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import team.incube.flooding.domain.dormitory.music.adapter.WakeUpMusicSseEmitterRegistry
 import team.incube.flooding.domain.dormitory.music.entity.WakeUpMusicLikeJpaEntity
+import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicLikeEvent
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicLikeRepository
 import team.incube.flooding.domain.dormitory.music.repository.WakeUpMusicRepository
 import team.incube.flooding.domain.dormitory.music.service.LikeWakeUpMusicService
@@ -15,6 +19,7 @@ class LikeWakeUpMusicServiceImpl(
     private val wakeUpMusicRepository: WakeUpMusicRepository,
     private val wakeUpMusicLikeRepository: WakeUpMusicLikeRepository,
     private val currentUserProvider: CurrentUserProvider,
+    private val sseEmitterRegistry: WakeUpMusicSseEmitterRegistry,
 ) : LikeWakeUpMusicService {
     @Transactional
     override fun execute(musicId: Long) {
@@ -35,5 +40,29 @@ class LikeWakeUpMusicServiceImpl(
                 music = music,
             ),
         )
+
+        val likeCount = wakeUpMusicLikeRepository.countByMusicId(musicId)
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                object : TransactionSynchronization {
+                    override fun afterCommit() {
+                        sseEmitterRegistry.broadcastLike(
+                            WakeUpMusicLikeEvent(
+                                musicId = musicId,
+                                likeCount = likeCount,
+                            ),
+                        )
+                    }
+                },
+            )
+        } else {
+            sseEmitterRegistry.broadcastLike(
+                WakeUpMusicLikeEvent(
+                    musicId = musicId,
+                    likeCount = likeCount,
+                ),
+            )
+        }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.global.security.config
 
+import jakarta.servlet.DispatcherType
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -45,6 +46,16 @@ class SecurityConfig(
             .formLogin { it.disable() }
             .httpBasic { it.disable() }
             .authorizeHttpRequests {
+                // SSE 등 비동기 요청의 ASYNC/ERROR/FORWARD 재디스패치는 인가를 재평가하지 않도록 permit.
+                // STATELESS + ThreadLocal 환경에서 재디스패치 시 SecurityContext가 비어 Access Denied가
+                // 발생하고, 이미 commit된 text/event-stream 응답이 끊겨 재연결 폭주가 생기는 것을 방지한다.
+                // (Spring Security 7에서 제거된 shouldFilterAllDispatcherTypes(false) 대체)
+                it
+                    .dispatcherTypeMatchers(
+                        DispatcherType.ASYNC,
+                        DispatcherType.ERROR,
+                        DispatcherType.FORWARD,
+                    ).permitAll()
                 it.requestMatchers("/actuator/**").permitAll()
                 it.requestMatchers("/error").permitAll()
                 it.requestMatchers("/auth/signin", "/auth/reissue").permitAll()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,7 @@ sdk:
       - "/v3/api-docs/**"
       - "/swagger-ui/**"
       - "/dormitory/studies/attendance"
+      - "/dormitory/music/subscribe"
 
   response:
     enabled: true
@@ -50,6 +51,7 @@ sdk:
       - "/v3/api-docs"
       - "/swagger-ui/**"
       - "/dormitory/studies/attendance"
+      - "/dormitory/music/subscribe"
 
   swagger:
     enabled: true

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistryTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistryTest.kt
@@ -10,6 +10,7 @@ import io.mockk.spyk
 import io.mockk.verify
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicCancelledEvent
+import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicLikeEvent
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
 import tools.jackson.databind.ObjectMapper
 import java.io.IOException
@@ -150,6 +151,22 @@ class WakeUpMusicSseEmitterRegistryTest :
                     every { objectMapper.writeValueAsString(cancelEvent) } returns "{}"
 
                     registry.broadcastCancelled(cancelEvent)
+
+                    verify(exactly = 1) { emitter.send(any<SseEmitter.SseEventBuilder>()) }
+                }
+            }
+        }
+
+        given("broadcastLike를 호출할 때") {
+            val likeEvent = WakeUpMusicLikeEvent(musicId = 1L, likeCount = 5L)
+
+            `when`("등록된 emitter가 있으면") {
+                then("emitter에 좋아요 업데이트 이벤트가 전송된다") {
+                    val emitter = spyk(SseEmitter(1_800_000L))
+                    registry.register(emitter)
+                    every { objectMapper.writeValueAsString(likeEvent) } returns "{}"
+
+                    registry.broadcastLike(likeEvent)
 
                     verify(exactly = 1) { emitter.send(any<SseEmitter.SseEventBuilder>()) }
                 }

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/service/GetWakeUpMusicServiceImplTest.kt
@@ -138,8 +138,8 @@ class GetWakeUpMusicServiceImplTest :
 
                     val result = service.execute(date)
 
-                    result[0].isLiked shouldBe false
-                    result[1].isLiked shouldBe true
+                    result[0].isLiked shouldBe true
+                    result[1].isLiked shouldBe false
                 }
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

기상음악 SSE 구독이 끊기거나 이벤트가 미수신되는 문제를 수정하고 좋아요/좋아요 취소 시 실시간 반영을 위한 SSE 이벤트를 추가했습니다.

- SSE ASYNC 재디스패치 시 SecurityContext가 비어 Access Denied가 발생하는 문제 해결 (`DispatcherType.ASYNC/ERROR/FORWARD` permitAll)
- `/dormitory/music/subscribe` 엔드포인트를 SDK 응답 래핑 제외 목록에 추가
- 좋아요/좋아요 취소 시 `music-like-updated` SSE 이벤트 브로드캐스트 (`WakeUpMusicLikeEvent`)
- 트랜잭션 동기화가 비활성인 환경(단위 테스트 등)에서도 SSE가 정상 동작하도록 `isSynchronizationActive()` 분기 추가
- `broadcastLike` 단위 테스트 추가 및 `GetWakeUpMusicServiceImplTest` 기대값 수정

### 로컬 테스트

https://github.com/user-attachments/assets/6526aab9-1e21-456c-b808-64bde1cb206f



## 💬리뷰 요구사항(선택)

> SecurityConfig의 `dispatcherTypeMatchers` permitAll 설정이 다른 SSE 엔드포인트에도 동일하게 적용되는지 확인 부탁드립니다.