### PR TITLE
feat : 학생 검색 API 응답에 권한(role) 필드 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/SearchUsersResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/SearchUsersResponse.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.user.presentation.data.response
 
+import team.incube.flooding.domain.user.entity.Role
 import team.incube.flooding.domain.user.entity.Sex
 import team.incube.flooding.domain.user.entity.UserJpaEntity
 
@@ -11,6 +12,7 @@ data class SearchUsersResponse(
     val grade: Int,
     val classNumber: Int,
     val number: Int,
+    val role: Role,
     val isBanned: Boolean,
 ) {
     companion object {
@@ -25,6 +27,7 @@ data class SearchUsersResponse(
             grade = user.grade,
             classNumber = user.classNumber,
             number = user.number,
+            role = user.role,
             isBanned = isBanned,
         )
     }


### PR DESCRIPTION
## Summary
- `GET /users` 학생 검색 API 응답에 `role` 필드 추가
- `SearchUsersResponse`에 `Role` 타입의 `role` 필드 추가 및 `from()` 팩토리 메서드에서 매핑
