### PR TITLE
유저 프로필 이미지 업로드 기능 추가

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/data/response/GetMassageResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/presentation/data/response/GetMassageResponse.kt
@@ -4,4 +4,5 @@ data class GetMassageResponse(
     val order: Long,
     val name: String,
     val studentNumber: Int,
+    val profileImageUrl: String?,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/massage/service/impl/GetMassageServiceImpl.kt
@@ -41,7 +41,12 @@ class GetMassageServiceImpl(
                 queue
                     .mapIndexed { index, userId ->
                         val user = userMap[userId] ?: return@mapIndexed null
-                        GetMassageResponse(order = index + 1L, name = user.name, studentNumber = user.studentNumber)
+                        GetMassageResponse(
+                            order = index + 1L,
+                            name = user.name,
+                            studentNumber = user.studentNumber,
+                            profileImageUrl = user.profileImageUrl,
+                        )
                     }.filterNotNull()
             }
         return GetMassageListResponse(

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/presentation/data/response/GetStudyResponse.kt
@@ -10,4 +10,5 @@ data class GetStudyResponse(
     val sex: Sex,
     val isBanned: Boolean,
     val isChecked: Boolean,
+    val profileImageUrl: String?,
 )

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/service/impl/GetStudyServiceImpl.kt
@@ -58,6 +58,7 @@ class GetStudyServiceImpl(
                         sex = user.sex,
                         isBanned = user.id in bannedUserIds,
                         isChecked = user.id in checkedUserIds,
+                        profileImageUrl = user.profileImageUrl,
                     )
                 }
             }

--- a/src/main/kotlin/team/incube/flooding/domain/user/entity/UserJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/entity/UserJpaEntity.kt
@@ -34,6 +34,8 @@ class UserJpaEntity(
     var dormitoryRoom: Int,
     @field:Column(name = "specialty", length = 100)
     var specialty: String? = null,
+    @field:Column(name = "profile_image_url")
+    var profileImageUrl: String? = null,
     @field:Column(name = "penalty_score", nullable = false)
     var penaltyScore: Int = 0,
     @field:ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
@@ -3,26 +3,34 @@ package team.incube.flooding.domain.user.presentation.controller
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 import team.incube.flooding.domain.user.presentation.data.request.PatchUserRoleRequest
 import team.incube.flooding.domain.user.presentation.data.response.GetMeResponse
 import team.incube.flooding.domain.user.presentation.data.response.SearchUsersResponse
+import team.incube.flooding.domain.user.presentation.data.response.UploadUserProfileImageResponse
 import team.incube.flooding.domain.user.service.GetMeService
 import team.incube.flooding.domain.user.service.PatchUserRoleService
 import team.incube.flooding.domain.user.service.SearchUsersService
+import team.incube.flooding.domain.user.service.UploadUserProfileImageService
 import team.themoment.sdk.response.CommonApiResponse
 
 @Tag(name = "유저", description = "유저 관련 API")
@@ -32,6 +40,7 @@ class UserController(
     private val getMeService: GetMeService,
     private val searchUsersService: SearchUsersService,
     private val patchUserRoleService: PatchUserRoleService,
+    private val uploadUserProfileImageService: UploadUserProfileImageService,
 ) {
     @Operation(
         summary = "내 정보 조회",
@@ -62,6 +71,23 @@ class UserController(
         pageable: Pageable,
     ): CommonApiResponse<Page<SearchUsersResponse>> =
         CommonApiResponse.success("OK", searchUsersService.execute(name, studentNumber, pageable))
+
+    @Operation(
+        summary = "유저 프로필 이미지 업로드",
+        description = "multipart/form-data로 프로필 이미지를 업로드하고, 사용할 profileImageUrl을 반환합니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "업로드 성공"),
+        ApiResponse(responseCode = "400", description = "지원하지 않는 이미지 파일"),
+        ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+        ApiResponse(responseCode = "413", description = "업로드 가능한 파일 크기 초과"),
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/me/profile-image", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun uploadUserProfileImage(
+        @RequestParam("image") image: MultipartFile,
+    ): CommonApiResponse<UploadUserProfileImageResponse> =
+        CommonApiResponse.created("OK", uploadUserProfileImageService.execute(image))
 
     @Operation(
         summary = "유저 권한 변경",

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/controller/UserController.kt
@@ -3,7 +3,6 @@ package team.incube.flooding.domain.user.presentation.controller
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.data.domain.Page
@@ -76,12 +75,10 @@ class UserController(
         summary = "유저 프로필 이미지 업로드",
         description = "multipart/form-data로 프로필 이미지를 업로드하고, 사용할 profileImageUrl을 반환합니다.",
     )
-    @ApiResponses(
-        ApiResponse(responseCode = "201", description = "업로드 성공"),
-        ApiResponse(responseCode = "400", description = "지원하지 않는 이미지 파일"),
-        ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-        ApiResponse(responseCode = "413", description = "업로드 가능한 파일 크기 초과"),
-    )
+    @ApiResponse(responseCode = "201", description = "업로드 성공")
+    @ApiResponse(responseCode = "400", description = "지원하지 않는 이미지 파일")
+    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    @ApiResponse(responseCode = "413", description = "업로드 가능한 파일 크기 초과")
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/me/profile-image", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun uploadUserProfileImage(

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/GetMeResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/GetMeResponse.kt
@@ -20,6 +20,7 @@ data class GetMeResponse(
     val penaltyScore: Int,
     val isBanned: Boolean,
     val hasClubApplication: Boolean,
+    val profileImageUrl: String?,
 ) {
     companion object {
         fun from(
@@ -42,6 +43,7 @@ data class GetMeResponse(
             penaltyScore = user.penaltyScore,
             isBanned = isBanned,
             hasClubApplication = hasClubApplication,
+            profileImageUrl = user.profileImageUrl,
         )
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/SearchUsersResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/SearchUsersResponse.kt
@@ -14,6 +14,7 @@ data class SearchUsersResponse(
     val number: Int,
     val role: Role,
     val isBanned: Boolean,
+    val profileImageUrl: String?,
 ) {
     companion object {
         fun from(
@@ -29,6 +30,7 @@ data class SearchUsersResponse(
             number = user.number,
             role = user.role,
             isBanned = isBanned,
+            profileImageUrl = user.profileImageUrl,
         )
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/UploadUserProfileImageResponse.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/presentation/data/response/UploadUserProfileImageResponse.kt
@@ -1,0 +1,5 @@
+package team.incube.flooding.domain.user.presentation.data.response
+
+data class UploadUserProfileImageResponse(
+    val profileImageUrl: String,
+)

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/UploadUserProfileImageService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/UploadUserProfileImageService.kt
@@ -1,0 +1,8 @@
+package team.incube.flooding.domain.user.service
+
+import org.springframework.web.multipart.MultipartFile
+import team.incube.flooding.domain.user.presentation.data.response.UploadUserProfileImageResponse
+
+interface UploadUserProfileImageService {
+    fun execute(image: MultipartFile): UploadUserProfileImageResponse
+}

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/impl/UploadUserProfileImageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/impl/UploadUserProfileImageServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.incube.flooding.domain.user.service.impl
 
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -9,6 +10,7 @@ import team.incube.flooding.domain.user.service.UploadUserProfileImageService
 import team.incube.flooding.global.config.FileStorageConstants.USER_PROFILE_IMAGE_SUB_DIR
 import team.incube.flooding.global.security.util.CurrentUserProvider
 import team.incube.flooding.global.util.FileStorageService
+import team.themoment.sdk.exception.ExpectedException
 
 @Service
 class UploadUserProfileImageServiceImpl(
@@ -18,7 +20,11 @@ class UploadUserProfileImageServiceImpl(
 ) : UploadUserProfileImageService {
     @Transactional
     override fun execute(image: MultipartFile): UploadUserProfileImageResponse {
-        val user = currentUserProvider.getCurrentUser()
+        val currentUser = currentUserProvider.getCurrentUser()
+        val user =
+            userRepository
+                .findById(currentUser.id)
+                .orElseThrow { ExpectedException("존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND) }
         fileStorageService.delete(user.profileImageUrl)
         val profileImageUrl = fileStorageService.store(image, USER_PROFILE_IMAGE_SUB_DIR)
         user.profileImageUrl = profileImageUrl

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/impl/UploadUserProfileImageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/impl/UploadUserProfileImageServiceImpl.kt
@@ -1,18 +1,28 @@
 package team.incube.flooding.domain.user.service.impl
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import team.incube.flooding.domain.user.presentation.data.response.UploadUserProfileImageResponse
+import team.incube.flooding.domain.user.repository.UserRepository
 import team.incube.flooding.domain.user.service.UploadUserProfileImageService
 import team.incube.flooding.global.config.FileStorageConstants.USER_PROFILE_IMAGE_SUB_DIR
+import team.incube.flooding.global.security.util.CurrentUserProvider
 import team.incube.flooding.global.util.FileStorageService
 
 @Service
 class UploadUserProfileImageServiceImpl(
     private val fileStorageService: FileStorageService,
+    private val currentUserProvider: CurrentUserProvider,
+    private val userRepository: UserRepository,
 ) : UploadUserProfileImageService {
+    @Transactional
     override fun execute(image: MultipartFile): UploadUserProfileImageResponse {
+        val user = currentUserProvider.getCurrentUser()
+        fileStorageService.delete(user.profileImageUrl)
         val profileImageUrl = fileStorageService.store(image, USER_PROFILE_IMAGE_SUB_DIR)
+        user.profileImageUrl = profileImageUrl
+        userRepository.save(user)
         return UploadUserProfileImageResponse(profileImageUrl)
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/user/service/impl/UploadUserProfileImageServiceImpl.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/user/service/impl/UploadUserProfileImageServiceImpl.kt
@@ -1,0 +1,18 @@
+package team.incube.flooding.domain.user.service.impl
+
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+import team.incube.flooding.domain.user.presentation.data.response.UploadUserProfileImageResponse
+import team.incube.flooding.domain.user.service.UploadUserProfileImageService
+import team.incube.flooding.global.config.FileStorageConstants.USER_PROFILE_IMAGE_SUB_DIR
+import team.incube.flooding.global.util.FileStorageService
+
+@Service
+class UploadUserProfileImageServiceImpl(
+    private val fileStorageService: FileStorageService,
+) : UploadUserProfileImageService {
+    override fun execute(image: MultipartFile): UploadUserProfileImageResponse {
+        val profileImageUrl = fileStorageService.store(image, USER_PROFILE_IMAGE_SUB_DIR)
+        return UploadUserProfileImageResponse(profileImageUrl)
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/global/config/FileStorageConstants.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/FileStorageConstants.kt
@@ -2,4 +2,5 @@ package team.incube.flooding.global.config
 
 object FileStorageConstants {
     const val CLUB_IMAGE_SUB_DIR = "clubs"
+    const val USER_PROFILE_IMAGE_SUB_DIR = "users/profiles"
 }

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -140,6 +140,9 @@ class SecurityConfig(
                 it
                     .requestMatchers(HttpMethod.PATCH, "/users/*/role")
                     .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
+                it
+                    .requestMatchers(HttpMethod.POST, "/users/me/profile-image")
+                    .authenticated()
 
                 it.anyRequest().authenticated()
             }.exceptionHandling {

--- a/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/security/config/SecurityConfig.kt
@@ -140,9 +140,6 @@ class SecurityConfig(
                 it
                     .requestMatchers(HttpMethod.PATCH, "/users/*/role")
                     .hasAnyRole(Role.DORMITORY_MANAGER.name, Role.ADMIN.name)
-                it
-                    .requestMatchers(HttpMethod.POST, "/users/me/profile-image")
-                    .authenticated()
 
                 it.anyRequest().authenticated()
             }.exceptionHandling {

--- a/src/test/kotlin/team/incube/flooding/domain/user/service/UploadUserProfileImageServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/user/service/UploadUserProfileImageServiceImplTest.kt
@@ -5,39 +5,85 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.MockMultipartFile
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.domain.user.repository.UserRepository
 import team.incube.flooding.domain.user.service.impl.UploadUserProfileImageServiceImpl
 import team.incube.flooding.global.config.FileStorageConstants.USER_PROFILE_IMAGE_SUB_DIR
+import team.incube.flooding.global.security.util.CurrentUserProvider
 import team.incube.flooding.global.util.FileStorageService
 import team.themoment.sdk.exception.ExpectedException
 
 class UploadUserProfileImageServiceImplTest :
     BehaviorSpec({
         val fileStorageService = mockk<FileStorageService>()
-        val service = UploadUserProfileImageServiceImpl(fileStorageService)
+        val currentUserProvider = mockk<CurrentUserProvider>()
+        val userRepository = mockk<UserRepository>()
+        val service = UploadUserProfileImageServiceImpl(fileStorageService, currentUserProvider, userRepository)
 
         beforeEach { clearAllMocks() }
 
         fun image() = MockMultipartFile("image", "profile.png", "image/png", byteArrayOf(1, 2, 3))
 
+        fun user(profileImageUrl: String? = null) =
+            UserJpaEntity(
+                id = 1L,
+                name = "홍길동",
+                sex = Sex.MAN,
+                email = "test@test.com",
+                studentNumber = 10101,
+                role = Role.GENERAL_STUDENT,
+                dormitoryRoom = 101,
+                profileImageUrl = profileImageUrl,
+            )
+
         given("유저 프로필 이미지 업로드 요청이 들어오면") {
-            `when`("정상 이미지 파일을 전달하면") {
-                then("저장된 이미지 URL을 반환한다") {
+            `when`("기존 프로필 이미지가 없고 정상 이미지를 전달하면") {
+                then("저장된 이미지 URL을 반환하고 엔티티를 저장한다") {
+                    val user = user()
+                    every { currentUserProvider.getCurrentUser() } returns user
+                    justRun { fileStorageService.delete(null) }
                     every { fileStorageService.store(any(), USER_PROFILE_IMAGE_SUB_DIR) } returns
                         "https://image-dev.flooding.kr/users/profiles/profile.png"
+                    every { userRepository.save(any()) } returns user
 
                     val response = service.execute(image())
 
                     response.profileImageUrl shouldBe "https://image-dev.flooding.kr/users/profiles/profile.png"
                     verify(exactly = 1) { fileStorageService.store(any(), USER_PROFILE_IMAGE_SUB_DIR) }
+                    verify(exactly = 1) { userRepository.save(any()) }
+                }
+            }
+
+            `when`("기존 프로필 이미지가 있고 새 이미지를 전달하면") {
+                then("기존 이미지를 S3에서 삭제하고 새 URL을 저장한다") {
+                    val oldUrl = "https://image-dev.flooding.kr/users/profiles/old.png"
+                    val user = user(profileImageUrl = oldUrl)
+                    every { currentUserProvider.getCurrentUser() } returns user
+                    justRun { fileStorageService.delete(oldUrl) }
+                    every { fileStorageService.store(any(), USER_PROFILE_IMAGE_SUB_DIR) } returns
+                        "https://image-dev.flooding.kr/users/profiles/new.png"
+                    every { userRepository.save(any()) } returns user
+
+                    val response = service.execute(image())
+
+                    response.profileImageUrl shouldBe "https://image-dev.flooding.kr/users/profiles/new.png"
+                    verify(exactly = 1) { fileStorageService.delete(oldUrl) }
+                    verify(exactly = 1) { userRepository.save(any()) }
                 }
             }
 
             `when`("파일 저장에 실패하면") {
                 then("예외를 그대로 전파한다") {
+                    val user = user()
+                    every { currentUserProvider.getCurrentUser() } returns user
+                    justRun { fileStorageService.delete(null) }
                     every { fileStorageService.store(any(), USER_PROFILE_IMAGE_SUB_DIR) } throws
                         ExpectedException("파일 저장에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
 

--- a/src/test/kotlin/team/incube/flooding/domain/user/service/UploadUserProfileImageServiceImplTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/user/service/UploadUserProfileImageServiceImplTest.kt
@@ -1,0 +1,50 @@
+package team.incube.flooding.domain.user.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockMultipartFile
+import team.incube.flooding.domain.user.service.impl.UploadUserProfileImageServiceImpl
+import team.incube.flooding.global.config.FileStorageConstants.USER_PROFILE_IMAGE_SUB_DIR
+import team.incube.flooding.global.util.FileStorageService
+import team.themoment.sdk.exception.ExpectedException
+
+class UploadUserProfileImageServiceImplTest :
+    BehaviorSpec({
+        val fileStorageService = mockk<FileStorageService>()
+        val service = UploadUserProfileImageServiceImpl(fileStorageService)
+
+        beforeEach { clearAllMocks() }
+
+        fun image() = MockMultipartFile("image", "profile.png", "image/png", byteArrayOf(1, 2, 3))
+
+        given("유저 프로필 이미지 업로드 요청이 들어오면") {
+            `when`("정상 이미지 파일을 전달하면") {
+                then("저장된 이미지 URL을 반환한다") {
+                    every { fileStorageService.store(any(), USER_PROFILE_IMAGE_SUB_DIR) } returns
+                        "https://image-dev.flooding.kr/users/profiles/profile.png"
+
+                    val response = service.execute(image())
+
+                    response.profileImageUrl shouldBe "https://image-dev.flooding.kr/users/profiles/profile.png"
+                    verify(exactly = 1) { fileStorageService.store(any(), USER_PROFILE_IMAGE_SUB_DIR) }
+                }
+            }
+
+            `when`("파일 저장에 실패하면") {
+                then("예외를 그대로 전파한다") {
+                    every { fileStorageService.store(any(), USER_PROFILE_IMAGE_SUB_DIR) } throws
+                        ExpectedException("파일 저장에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+
+                    val exception = shouldThrow<ExpectedException> { service.execute(image()) }
+
+                    exception.statusCode shouldBe HttpStatus.INTERNAL_SERVER_ERROR
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

## 📝작업 내용

동아리 대표 이미지 업로드와 동일한 패턴으로 유저 프로필 이미지 업로드 API를 구현했습니다.

- `POST /users/me/profile-image` 엔드포인트 추가 (multipart/form-data)
- S3에 `users/profiles/` 경로로 저장 후 URL 반환
- 모든 인증된 사용자 접근 가능
- `FileStorageConstants`에 `USER_PROFILE_IMAGE_SUB_DIR` 상수 추가
- 서비스 단위 테스트 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음