### PR TITLE
SSE broadcast 직렬 블로킹 제거로 다중 접속 시 이벤트 멈춤 해결

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistry.kt
@@ -8,12 +8,14 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicCancelledEvent
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicLikeEvent
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
+import team.incube.flooding.global.sse.SseEmitterDispatcher
 import tools.jackson.databind.ObjectMapper
 import java.util.concurrent.CopyOnWriteArrayList
 
 @Component
 class WakeUpMusicSseEmitterRegistry(
     private val objectMapper: ObjectMapper,
+    private val sseEmitterDispatcher: SseEmitterDispatcher,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
     private val emitters = CopyOnWriteArrayList<SseEmitter>()
@@ -97,14 +99,8 @@ class WakeUpMusicSseEmitterRegistry(
 
     @Scheduled(fixedDelay = 30_000L)
     fun sendHeartbeat() {
-        emitters.forEach { emitter ->
-            synchronized(emitter) {
-                try {
-                    emitter.send(SseEmitter.event().comment("heartbeat"))
-                } catch (e: Exception) {
-                    emitter.completeWithError(e)
-                }
-            }
+        sseEmitterDispatcher.dispatch(emitters) {
+            SseEmitter.event().comment("heartbeat")
         }
     }
 
@@ -113,21 +109,11 @@ class WakeUpMusicSseEmitterRegistry(
         json: String,
     ) {
         log.info("broadcastEvent: name={}, emitters.size={}", name, emitters.size)
-        emitters.forEach { emitter ->
-            synchronized(emitter) {
-                try {
-                    emitter.send(
-                        SseEmitter
-                            .event()
-                            .name(name)
-                            .data(json),
-                    )
-                    log.info("send 성공: name={}", name)
-                } catch (e: Exception) {
-                    log.error("send 실패: name={}, json={}", name, json, e)
-                    emitter.completeWithError(e)
-                }
-            }
+        sseEmitterDispatcher.dispatch(emitters) {
+            SseEmitter
+                .event()
+                .name(name)
+                .data(json)
         }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyAttendanceSseEmitterRegistry.kt
@@ -6,12 +6,14 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import team.incube.flooding.domain.dormitory.study.presentation.data.response.StudyAttendanceEventResponse
+import team.incube.flooding.global.sse.SseEmitterDispatcher
 import tools.jackson.databind.ObjectMapper
 import java.util.concurrent.CopyOnWriteArrayList
 
 @Component
 class StudyAttendanceSseEmitterRegistry(
     private val objectMapper: ObjectMapper,
+    private val sseEmitterDispatcher: SseEmitterDispatcher,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
     private val emitters = CopyOnWriteArrayList<SseEmitter>()
@@ -80,14 +82,8 @@ class StudyAttendanceSseEmitterRegistry(
 
     @Scheduled(fixedDelay = 30_000L)
     fun sendHeartbeat() {
-        emitters.forEach { emitter ->
-            synchronized(emitter) {
-                try {
-                    emitter.send(SseEmitter.event().comment("heartbeat"))
-                } catch (e: Exception) {
-                    emitter.completeWithError(e)
-                }
-            }
+        sseEmitterDispatcher.dispatch(emitters) {
+            SseEmitter.event().comment("heartbeat")
         }
     }
 
@@ -120,21 +116,11 @@ class StudyAttendanceSseEmitterRegistry(
         json: String,
     ) {
         log.info("broadcastEvent: name={}, emitters.size={}", name, emitters.size)
-        emitters.forEach { emitter ->
-            synchronized(emitter) {
-                try {
-                    emitter.send(
-                        SseEmitter
-                            .event()
-                            .name(name)
-                            .data(json),
-                    )
-                    log.info("send 성공: name={}", name)
-                } catch (e: Exception) {
-                    log.error("send 실패: name={}, json={}", name, json, e)
-                    emitter.completeWithError(e)
-                }
-            }
+        sseEmitterDispatcher.dispatch(emitters) {
+            SseEmitter
+                .event()
+                .name(name)
+                .data(json)
         }
     }
 }

--- a/src/main/kotlin/team/incube/flooding/global/config/AsyncConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/AsyncConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.scheduling.annotation.AsyncConfigurer
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 import java.util.concurrent.ThreadPoolExecutor
 
 @Configuration
@@ -28,16 +29,7 @@ class AsyncConfig : AsyncConfigurer {
     }
 
     @Bean(name = ["sseSendExecutor"])
-    fun sseSendExecutor(): ThreadPoolTaskExecutor {
-        val executor = ThreadPoolTaskExecutor()
-        executor.corePoolSize = 8
-        executor.maxPoolSize = 32
-        executor.queueCapacity = 1000
-        executor.setThreadNamePrefix("sse-send-")
-        executor.setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
-        executor.initialize()
-        return executor
-    }
+    fun sseSendExecutor(): Executor = Executors.newVirtualThreadPerTaskExecutor()
 
     override fun getAsyncUncaughtExceptionHandler(): AsyncUncaughtExceptionHandler =
         AsyncUncaughtExceptionHandler { ex, method, params ->

--- a/src/main/kotlin/team/incube/flooding/global/config/AsyncConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/AsyncConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.scheduling.annotation.AsyncConfigurer
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
+import java.util.concurrent.ThreadPoolExecutor
 
 @Configuration
 @EnableAsync
@@ -17,10 +18,23 @@ class AsyncConfig : AsyncConfigurer {
     @Bean(name = ["taskExecutor"])
     override fun getAsyncExecutor(): Executor {
         val executor = ThreadPoolTaskExecutor()
-        executor.corePoolSize = 2
-        executor.maxPoolSize = 10
-        executor.queueCapacity = 50
+        executor.corePoolSize = 4
+        executor.maxPoolSize = 20
+        executor.queueCapacity = 100
         executor.setThreadNamePrefix("async-event-")
+        executor.setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
+        executor.initialize()
+        return executor
+    }
+
+    @Bean(name = ["sseSendExecutor"])
+    fun sseSendExecutor(): ThreadPoolTaskExecutor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 8
+        executor.maxPoolSize = 32
+        executor.queueCapacity = 1000
+        executor.setThreadNamePrefix("sse-send-")
+        executor.setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
         executor.initialize()
         return executor
     }

--- a/src/main/kotlin/team/incube/flooding/global/sse/SseEmitterDispatcher.kt
+++ b/src/main/kotlin/team/incube/flooding/global/sse/SseEmitterDispatcher.kt
@@ -2,16 +2,16 @@ package team.incube.flooding.global.sse
 
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
-import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 
 @Component
 class SseEmitterDispatcher(
-    @Qualifier("sseSendExecutor") private val sendExecutor: ThreadPoolTaskExecutor,
+    @Qualifier("sseSendExecutor") private val sendExecutor: Executor,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -19,29 +19,19 @@ class SseEmitterDispatcher(
         emitters: CopyOnWriteArrayList<SseEmitter>,
         event: () -> SseEmitter.SseEventBuilder,
     ) {
-        val targets = emitters.toList()
-        if (targets.isEmpty()) return
-
-        val tasks =
-            targets.map { emitter ->
-                Callable {
+        emitters.toList().forEach { emitter ->
+            CompletableFuture
+                .runAsync({
                     synchronized(emitter) { emitter.send(event()) }
+                }, sendExecutor)
+                .orTimeout(SEND_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .exceptionally { e ->
+                    if (emitters.remove(emitter)) {
+                        log.warn("SSE 전송 실패/지연으로 emitter 제거: {}", e.message)
+                        runCatching { emitter.completeWithError(e) }
+                    }
+                    null
                 }
-            }
-
-        val futures =
-            sendExecutor.threadPoolExecutor.invokeAll(tasks, SEND_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-
-        futures.forEachIndexed { index, future ->
-            try {
-                future.get()
-            } catch (e: Exception) {
-                val emitter = targets[index]
-                if (emitters.remove(emitter)) {
-                    log.warn("SSE 전송 실패/지연으로 emitter 제거: {}", e.message)
-                    runCatching { emitter.completeWithError(e) }
-                }
-            }
         }
     }
 

--- a/src/main/kotlin/team/incube/flooding/global/sse/SseEmitterDispatcher.kt
+++ b/src/main/kotlin/team/incube/flooding/global/sse/SseEmitterDispatcher.kt
@@ -1,0 +1,51 @@
+package team.incube.flooding.global.sse
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.concurrent.Callable
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+
+@Component
+class SseEmitterDispatcher(
+    @Qualifier("sseSendExecutor") private val sendExecutor: ThreadPoolTaskExecutor,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun dispatch(
+        emitters: CopyOnWriteArrayList<SseEmitter>,
+        event: () -> SseEmitter.SseEventBuilder,
+    ) {
+        val targets = emitters.toList()
+        if (targets.isEmpty()) return
+
+        val tasks =
+            targets.map { emitter ->
+                Callable {
+                    synchronized(emitter) { emitter.send(event()) }
+                }
+            }
+
+        val futures =
+            sendExecutor.threadPoolExecutor.invokeAll(tasks, SEND_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+
+        futures.forEachIndexed { index, future ->
+            try {
+                future.get()
+            } catch (e: Exception) {
+                val emitter = targets[index]
+                if (emitters.remove(emitter)) {
+                    log.warn("SSE 전송 실패/지연으로 emitter 제거: {}", e.message)
+                    runCatching { emitter.completeWithError(e) }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val SEND_TIMEOUT_MS = 3_000L
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ spring:
   application:
     name: flooding-server-v2
 
+  task:
+    scheduling:
+      pool:
+        size: 2
+
   servlet:
     multipart:
       max-file-size: 5MB

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistryTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistryTest.kt
@@ -8,7 +8,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicCancelledEvent
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicLikeEvent
@@ -18,20 +17,12 @@ import tools.jackson.databind.ObjectMapper
 import java.io.IOException
 import java.time.LocalDateTime
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.Executor
 
 class WakeUpMusicSseEmitterRegistryTest :
     BehaviorSpec({
         val objectMapper = mockk<ObjectMapper>()
-        val sseSendExecutor =
-            ThreadPoolTaskExecutor().apply {
-                corePoolSize = 4
-                maxPoolSize = 8
-                queueCapacity = 100
-                setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
-                initialize()
-            }
-        val sseEmitterDispatcher = SseEmitterDispatcher(sseSendExecutor)
+        val sseEmitterDispatcher = SseEmitterDispatcher(Executor { it.run() })
         lateinit var registry: WakeUpMusicSseEmitterRegistry
 
         fun emitters(): CopyOnWriteArrayList<SseEmitter> {

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistryTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/music/adapter/WakeUpMusicSseEmitterRegistryTest.kt
@@ -8,18 +8,30 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicCancelledEvent
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicLikeEvent
 import team.incube.flooding.domain.dormitory.music.presentation.data.response.WakeUpMusicResponse
+import team.incube.flooding.global.sse.SseEmitterDispatcher
 import tools.jackson.databind.ObjectMapper
 import java.io.IOException
 import java.time.LocalDateTime
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ThreadPoolExecutor
 
 class WakeUpMusicSseEmitterRegistryTest :
     BehaviorSpec({
         val objectMapper = mockk<ObjectMapper>()
+        val sseSendExecutor =
+            ThreadPoolTaskExecutor().apply {
+                corePoolSize = 4
+                maxPoolSize = 8
+                queueCapacity = 100
+                setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
+                initialize()
+            }
+        val sseEmitterDispatcher = SseEmitterDispatcher(sseSendExecutor)
         lateinit var registry: WakeUpMusicSseEmitterRegistry
 
         fun emitters(): CopyOnWriteArrayList<SseEmitter> {
@@ -48,7 +60,7 @@ class WakeUpMusicSseEmitterRegistryTest :
 
         beforeEach {
             clearAllMocks()
-            registry = WakeUpMusicSseEmitterRegistry(objectMapper)
+            registry = WakeUpMusicSseEmitterRegistry(objectMapper, sseEmitterDispatcher)
         }
 
         given("emitter를 등록할 때") {

--- a/src/test/kotlin/team/incube/flooding/global/sse/SseEmitterDispatcherTest.kt
+++ b/src/test/kotlin/team/incube/flooding/global/sse/SseEmitterDispatcherTest.kt
@@ -7,27 +7,18 @@ import io.kotest.matchers.longs.shouldBeLessThan
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.Executors
 import kotlin.system.measureTimeMillis
 
 class SseEmitterDispatcherTest :
     BehaviorSpec({
-        val sseSendExecutor =
-            ThreadPoolTaskExecutor().apply {
-                corePoolSize = 4
-                maxPoolSize = 8
-                queueCapacity = 100
-                setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
-                initialize()
-            }
-        val dispatcher = SseEmitterDispatcher(sseSendExecutor)
+        val dispatcher = SseEmitterDispatcher(Executors.newVirtualThreadPerTaskExecutor())
 
         given("느린 emitter와 정상 emitter가 함께 있을 때") {
             `when`("dispatch를 호출하면") {
-                then("느린 연결이 정상 연결의 수신을 막지 않고, 느린 연결만 제거된다") {
+                then("호출 스레드를 막지 않고, 느린 연결만 제거되며 정상 연결은 유지된다") {
                     val healthy = mockk<SseEmitter>(relaxed = true)
                     val slow = mockk<SseEmitter>(relaxed = true)
                     every { slow.send(any<SseEmitter.SseEventBuilder>()) } answers {
@@ -43,7 +34,10 @@ class SseEmitterDispatcherTest :
                             }
                         }
 
-                    elapsed shouldBeLessThan 5_000L
+                    elapsed shouldBeLessThan 1_000L
+
+                    Thread.sleep(3_500)
+
                     verify(exactly = 1) { healthy.send(any<SseEmitter.SseEventBuilder>()) }
                     verify(exactly = 0) { healthy.completeWithError(any()) }
                     verify(exactly = 1) { slow.completeWithError(any()) }

--- a/src/test/kotlin/team/incube/flooding/global/sse/SseEmitterDispatcherTest.kt
+++ b/src/test/kotlin/team/incube/flooding/global/sse/SseEmitterDispatcherTest.kt
@@ -1,0 +1,55 @@
+package team.incube.flooding.global.sse
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.longs.shouldBeLessThan
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ThreadPoolExecutor
+import kotlin.system.measureTimeMillis
+
+class SseEmitterDispatcherTest :
+    BehaviorSpec({
+        val sseSendExecutor =
+            ThreadPoolTaskExecutor().apply {
+                corePoolSize = 4
+                maxPoolSize = 8
+                queueCapacity = 100
+                setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
+                initialize()
+            }
+        val dispatcher = SseEmitterDispatcher(sseSendExecutor)
+
+        given("느린 emitter와 정상 emitter가 함께 있을 때") {
+            `when`("dispatch를 호출하면") {
+                then("느린 연결이 정상 연결의 수신을 막지 않고, 느린 연결만 제거된다") {
+                    val healthy = mockk<SseEmitter>(relaxed = true)
+                    val slow = mockk<SseEmitter>(relaxed = true)
+                    every { slow.send(any<SseEmitter.SseEventBuilder>()) } answers {
+                        Thread.sleep(5_000)
+                    }
+
+                    val emitters = CopyOnWriteArrayList(listOf(healthy, slow))
+
+                    val elapsed =
+                        measureTimeMillis {
+                            dispatcher.dispatch(emitters) {
+                                SseEmitter.event().comment("heartbeat")
+                            }
+                        }
+
+                    elapsed shouldBeLessThan 5_000L
+                    verify(exactly = 1) { healthy.send(any<SseEmitter.SseEventBuilder>()) }
+                    verify(exactly = 0) { healthy.completeWithError(any()) }
+                    verify(exactly = 1) { slow.completeWithError(any()) }
+                    emitters shouldContain healthy
+                    emitters shouldNotContain slow
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

동시 접속이 많을 때 SSE 이벤트가 멈추거나 느려지는 문제를 수정합니다. broadcast와 heartbeat가 모든 emitter를 단일 스레드에서 직렬·블로킹으로 순회해, 느리거나 끊긴 연결 하나가 전체 수신을 막았습니다. 공통 SseEmitterDispatcher로 emitter별 전송을 전용 풀에서 병렬 실행하고 전송 타임아웃으로 막힌 연결을 즉시 제거하도록 바꿨으며, @Async 거부 정책을 CallerRunsPolicy로 바꿔 이벤트 드롭을 막고 스케줄러 풀을 2로 늘렸습니다. 단위 테스트를 갱신하고 느린 emitter 격리 동시성 테스트를 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 전송 타임아웃 3초와 sseSendExecutor 풀 크기가 실제 동시 접속 규모에 적절한지 확인 부탁드립니다.

- 로컬환경에서 클라이언트와 테스트를 완료하였습니다.