### PR TITLE
AI 챗봇/음악 추천 서버 Circuit Breaker, Retry 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,10 @@ dependencies {
     testImplementation(kotlin("test"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
+    // Resilience4j
+    implementation("io.github.resilience4j:resilience4j-circuitbreaker:2.3.0")
+    implementation("io.github.resilience4j:resilience4j-retry:2.3.0")
+
     // Excel
     implementation("org.apache.poi:poi-ooxml:5.2.3")
 }

--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiChatbotAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiChatbotAdapter.kt
@@ -34,17 +34,13 @@ class AiChatbotAdapter(
                 },
             ).build()
 
-    fun chat(request: SendAiChatRequest): SendAiChatResponse {
-        val decorated =
-            CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
-                Retry
-                    .decorateCheckedSupplier(retry) {
-                        doChat(request)
-                    }.get()
+    fun chat(request: SendAiChatRequest): SendAiChatResponse =
+        try {
+            circuitBreaker.executeCheckedSupplier {
+                retry.executeCheckedSupplier {
+                    doChat(request)
+                }
             }
-
-        return try {
-            decorated.get()
         } catch (e: CallNotPermittedException) {
             throw ExpectedException("AI 챗봇 서버가 일시적으로 사용 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE)
         } catch (e: ExpectedException) {
@@ -53,7 +49,6 @@ class AiChatbotAdapter(
             log.error("AI 챗봇 서버 통신 실패 - {}", e.message)
             throw ExpectedException("AI 챗봇 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
         }
-    }
 
     private fun doChat(request: SendAiChatRequest): SendAiChatResponse =
         restClient

--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiChatbotAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiChatbotAdapter.kt
@@ -1,5 +1,10 @@
 package team.incube.flooding.domain.ai.adapter
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.retry.Retry
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -13,7 +18,11 @@ import team.themoment.sdk.exception.ExpectedException
 @Component
 class AiChatbotAdapter(
     @Value("\${ai.chatbot.base-url}") baseUrl: String,
+    @Qualifier("chatbotCircuitBreaker") private val circuitBreaker: CircuitBreaker,
+    @Qualifier("chatbotRetry") private val retry: Retry,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     private val restClient =
         RestClient
             .builder()
@@ -25,14 +34,37 @@ class AiChatbotAdapter(
                 },
             ).build()
 
-    fun chat(request: SendAiChatRequest): SendAiChatResponse =
+    fun chat(request: SendAiChatRequest): SendAiChatResponse {
+        val decorated =
+            CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
+                Retry
+                    .decorateCheckedSupplier(retry) {
+                        doChat(request)
+                    }.get()
+            }
+
+        return try {
+            decorated.get()
+        } catch (e: CallNotPermittedException) {
+            throw ExpectedException("AI 챗봇 서버가 일시적으로 사용 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE)
+        } catch (e: ExpectedException) {
+            throw e
+        } catch (e: Throwable) {
+            log.error("AI 챗봇 서버 통신 실패 - {}", e.message)
+            throw ExpectedException("AI 챗봇 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
+        }
+    }
+
+    private fun doChat(request: SendAiChatRequest): SendAiChatResponse =
         restClient
             .post()
             .uri("/ai/chat")
             .contentType(MediaType.APPLICATION_JSON)
             .body(request)
             .retrieve()
-            .onStatus({ it.isError }) { _, _ ->
+            .onStatus({ it.isError }) { _, response ->
+                val body = response.body.bufferedReader().use { it.readText() }
+                log.error("AI 챗봇 서버 오류 - status: {}, body: {}", response.statusCode, body)
                 throw ExpectedException("AI 챗봇 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
             }.body(SendAiChatResponse::class.java)
             ?: throw ExpectedException("AI 챗봇 서버로부터 응답을 받지 못했습니다.", HttpStatus.BAD_GATEWAY)

--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
@@ -1,6 +1,10 @@
 package team.incube.flooding.domain.ai.adapter
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.retry.Retry
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -14,6 +18,8 @@ import team.themoment.sdk.exception.ExpectedException
 @Component
 class AiSongAdapter(
     @Value("\${ai.song.base-url}") baseUrl: String,
+    @Qualifier("songCircuitBreaker") private val circuitBreaker: CircuitBreaker,
+    @Qualifier("songRetry") private val retry: Retry,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -28,7 +34,28 @@ class AiSongAdapter(
                 },
             ).build()
 
-    fun recommend(request: RecommendAiSongRequest): RecommendAiSongResponse =
+    fun recommend(request: RecommendAiSongRequest): RecommendAiSongResponse {
+        val decorated =
+            CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
+                Retry
+                    .decorateCheckedSupplier(retry) {
+                        doRecommend(request)
+                    }.get()
+            }
+
+        return try {
+            decorated.get()
+        } catch (e: CallNotPermittedException) {
+            throw ExpectedException("AI 음악 추천 서버가 일시적으로 사용 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE)
+        } catch (e: ExpectedException) {
+            throw e
+        } catch (e: Throwable) {
+            log.error("AI 음악 추천 서버 통신 실패 - {}", e.message)
+            throw ExpectedException("AI 음악 추천 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
+        }
+    }
+
+    private fun doRecommend(request: RecommendAiSongRequest): RecommendAiSongResponse =
         restClient
             .post()
             .uri("/ai/song")

--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
@@ -34,17 +34,13 @@ class AiSongAdapter(
                 },
             ).build()
 
-    fun recommend(request: RecommendAiSongRequest): RecommendAiSongResponse {
-        val decorated =
-            CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
-                Retry
-                    .decorateCheckedSupplier(retry) {
-                        doRecommend(request)
-                    }.get()
+    fun recommend(request: RecommendAiSongRequest): RecommendAiSongResponse =
+        try {
+            circuitBreaker.executeCheckedSupplier {
+                retry.executeCheckedSupplier {
+                    doRecommend(request)
+                }
             }
-
-        return try {
-            decorated.get()
         } catch (e: CallNotPermittedException) {
             throw ExpectedException("AI 음악 추천 서버가 일시적으로 사용 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE)
         } catch (e: ExpectedException) {
@@ -53,7 +49,6 @@ class AiSongAdapter(
             log.error("AI 음악 추천 서버 통신 실패 - {}", e.message)
             throw ExpectedException("AI 음악 추천 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
         }
-    }
 
     private fun doRecommend(request: RecommendAiSongRequest): RecommendAiSongResponse =
         restClient

--- a/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
@@ -1,0 +1,149 @@
+package team.incube.flooding.global.config
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.github.resilience4j.retry.Retry
+import io.github.resilience4j.retry.RetryConfig
+import io.github.resilience4j.retry.RetryRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.ResourceAccessException
+import team.themoment.sdk.exception.ExpectedException
+import java.time.Duration
+
+@Configuration
+class AiResilienceConfig {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Bean("chatbotCircuitBreaker")
+    fun chatbotCircuitBreaker(): CircuitBreaker {
+        val config =
+            CircuitBreakerConfig
+                .custom()
+                .failureRateThreshold(50f)
+                .slowCallRateThreshold(80f)
+                .slowCallDurationThreshold(Duration.ofSeconds(8))
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .slidingWindowSize(10)
+                .minimumNumberOfCalls(5)
+                .waitDurationInOpenState(Duration.ofSeconds(30))
+                .permittedNumberOfCallsInHalfOpenState(3)
+                .automaticTransitionFromOpenToHalfOpenEnabled(true)
+                .recordExceptions(ResourceAccessException::class.java)
+                .ignoreExceptions(ExpectedException::class.java)
+                .build()
+
+        val circuitBreaker = CircuitBreakerRegistry.of(config).circuitBreaker("ai-chatbot")
+
+        circuitBreaker.eventPublisher.onStateTransition { event ->
+            log.warn(
+                "AI 챗봇 Circuit Breaker 상태 변경: {} → {}",
+                event.stateTransition.fromState,
+                event.stateTransition.toState,
+            )
+        }
+        circuitBreaker.eventPublisher.onCallNotPermitted {
+            log.warn("AI 챗봇 Circuit Breaker OPEN - 요청 차단됨")
+        }
+
+        return circuitBreaker
+    }
+
+    @Bean("songCircuitBreaker")
+    fun songCircuitBreaker(): CircuitBreaker {
+        val config =
+            CircuitBreakerConfig
+                .custom()
+                .failureRateThreshold(50f)
+                .slowCallRateThreshold(80f)
+                .slowCallDurationThreshold(Duration.ofSeconds(25))
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .slidingWindowSize(10)
+                .minimumNumberOfCalls(5)
+                .waitDurationInOpenState(Duration.ofSeconds(30))
+                .permittedNumberOfCallsInHalfOpenState(3)
+                .automaticTransitionFromOpenToHalfOpenEnabled(true)
+                .recordExceptions(ResourceAccessException::class.java)
+                .ignoreExceptions(ExpectedException::class.java)
+                .build()
+
+        val circuitBreaker = CircuitBreakerRegistry.of(config).circuitBreaker("ai-song")
+
+        circuitBreaker.eventPublisher.onStateTransition { event ->
+            log.warn(
+                "AI 음악 추천 Circuit Breaker 상태 변경: {} → {}",
+                event.stateTransition.fromState,
+                event.stateTransition.toState,
+            )
+        }
+        circuitBreaker.eventPublisher.onCallNotPermitted {
+            log.warn("AI 음악 추천 Circuit Breaker OPEN - 요청 차단됨")
+        }
+
+        return circuitBreaker
+    }
+
+    @Bean("chatbotRetry")
+    fun chatbotRetry(): Retry {
+        val config =
+            RetryConfig
+                .custom<Any>()
+                .maxAttempts(3)
+                .waitDuration(Duration.ofSeconds(1))
+                .retryExceptions(ResourceAccessException::class.java)
+                .ignoreExceptions(ExpectedException::class.java)
+                .build()
+
+        val retry = RetryRegistry.of(config).retry("ai-chatbot")
+
+        retry.eventPublisher.onRetry { event ->
+            log.warn(
+                "AI 챗봇 재시도 중 - 시도 횟수: {}, 원인: {}",
+                event.numberOfRetryAttempts,
+                event.lastThrowable?.message,
+            )
+        }
+        retry.eventPublisher.onError { event ->
+            log.error(
+                "AI 챗봇 최대 재시도 초과 - 총 시도: {}, 원인: {}",
+                event.numberOfRetryAttempts,
+                event.lastThrowable?.message,
+            )
+        }
+
+        return retry
+    }
+
+    @Bean("songRetry")
+    fun songRetry(): Retry {
+        val config =
+            RetryConfig
+                .custom<Any>()
+                .maxAttempts(2)
+                .waitDuration(Duration.ofSeconds(2))
+                .retryExceptions(ResourceAccessException::class.java)
+                .ignoreExceptions(ExpectedException::class.java)
+                .build()
+
+        val retry = RetryRegistry.of(config).retry("ai-song")
+
+        retry.eventPublisher.onRetry { event ->
+            log.warn(
+                "AI 음악 추천 재시도 중 - 시도 횟수: {}, 원인: {}",
+                event.numberOfRetryAttempts,
+                event.lastThrowable?.message,
+            )
+        }
+        retry.eventPublisher.onError { event ->
+            log.error(
+                "AI 음악 추천 최대 재시도 초과 - 총 시도: {}, 원인: {}",
+                event.numberOfRetryAttempts,
+                event.lastThrowable?.message,
+            )
+        }
+
+        return retry
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
@@ -9,7 +9,6 @@ import io.github.resilience4j.retry.RetryRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.client.ResourceAccessException
 import team.themoment.sdk.exception.ExpectedException
 import java.time.Duration
 
@@ -31,7 +30,6 @@ class AiResilienceConfig {
                 .waitDurationInOpenState(Duration.ofSeconds(30))
                 .permittedNumberOfCallsInHalfOpenState(3)
                 .automaticTransitionFromOpenToHalfOpenEnabled(true)
-                .recordExceptions(ResourceAccessException::class.java)
                 .ignoreExceptions(ExpectedException::class.java)
                 .build()
 
@@ -65,7 +63,6 @@ class AiResilienceConfig {
                 .waitDurationInOpenState(Duration.ofSeconds(30))
                 .permittedNumberOfCallsInHalfOpenState(3)
                 .automaticTransitionFromOpenToHalfOpenEnabled(true)
-                .recordExceptions(ResourceAccessException::class.java)
                 .ignoreExceptions(ExpectedException::class.java)
                 .build()
 

--- a/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
@@ -9,6 +9,7 @@ import io.github.resilience4j.retry.RetryRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.ResourceAccessException
 import team.themoment.sdk.exception.ExpectedException
 import java.time.Duration
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #202

## 📝작업 내용

AI 챗봇 및 음악 추천 서버 호출 시 발생할 수 있는 Cascade Failure를 방지하기 위해
Resilience4j 기반의 Circuit Breaker와 Retry 패턴을 적용했습니다.

**문제 상황**
AI 서버(챗봇 최대 10초, 음악 추천 최대 30초)가 다운되거나 응답이 지연될 경우,
타임아웃까지 스레드가 계속 점유됩니다. 동시 요청이 몰리면 스레드 풀이 고갈되어
AI 도메인과 무관한 API까지 응답 불가 상태가 됩니다.

**해결 방법**
- Circuit Breaker: 슬라이딩 윈도우(10회) 기준 실패율 50% 초과 시 OPEN, 30초 후 HALF_OPEN으로 자동 전환
- Retry: 네트워크 수준의 일시적 오류(`ResourceAccessException`)에 한해 재시도 (챗봇 3회, 음악 추천 2회)
- OPEN 상태에서 즉시 503 반환, 상태 전환 및 재시도 로그 기록

**변경 파일**
- `build.gradle.kts`: resilience4j-circuitbreaker, resilience4j-retry 의존성 추가
- `AiResilienceConfig`: Circuit Breaker / Retry 빈 설정 및 상태 전환 이벤트 로깅
- `AiChatbotAdapter`: Circuit Breaker + Retry 적용, 에러 응답 본문 로깅 추가
- `AiSongAdapter`: Circuit Breaker + Retry 적용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> Circuit Breaker 설정값(실패율 임계치 50%, OPEN 대기 30초 등)이 현재 AI 서버 특성에 맞는지 확인 부탁드립니다.