### PR TITLE
Circuit Breaker 연동 AI 서버 Custom Health Indicator 구현

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/ai/health/AbstractCircuitBreakerHealthIndicator.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/health/AbstractCircuitBreakerHealthIndicator.kt
@@ -1,0 +1,38 @@
+package team.incube.flooding.domain.ai.health
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
+
+abstract class AbstractCircuitBreakerHealthIndicator(
+    private val circuitBreaker: CircuitBreaker,
+) : HealthIndicator {
+    override fun health(): Health {
+        val state = circuitBreaker.state
+        val metrics = circuitBreaker.metrics
+
+        val details =
+            mapOf(
+                "state" to state.name,
+                "failureRate" to "${metrics.failureRate}%",
+                "slowCallRate" to "${metrics.slowCallRate}%",
+                "bufferedCalls" to metrics.numberOfBufferedCalls,
+                "failedCalls" to metrics.numberOfFailedCalls,
+                "notPermittedCalls" to metrics.numberOfNotPermittedCalls,
+            )
+
+        return when (state) {
+            CircuitBreaker.State.OPEN -> {
+                Health.down().withDetails(details).build()
+            }
+
+            CircuitBreaker.State.HALF_OPEN -> {
+                Health.unknown().withDetails(details).build()
+            }
+
+            else -> {
+                Health.up().withDetails(details).build()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/ai/health/AiChatbotHealthIndicator.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/health/AiChatbotHealthIndicator.kt
@@ -1,0 +1,41 @@
+package team.incube.flooding.domain.ai.health
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
+import org.springframework.stereotype.Component
+
+@Component("aiChatbot")
+class AiChatbotHealthIndicator(
+    @Qualifier("chatbotCircuitBreaker") private val circuitBreaker: CircuitBreaker,
+) : HealthIndicator {
+    override fun health(): Health {
+        val state = circuitBreaker.state
+        val metrics = circuitBreaker.metrics
+
+        val details =
+            mapOf(
+                "state" to state.name,
+                "failureRate" to "${metrics.failureRate}%",
+                "slowCallRate" to "${metrics.slowCallRate}%",
+                "bufferedCalls" to metrics.numberOfBufferedCalls,
+                "failedCalls" to metrics.numberOfFailedCalls,
+                "notPermittedCalls" to metrics.numberOfNotPermittedCalls,
+            )
+
+        return when (state) {
+            CircuitBreaker.State.OPEN -> {
+                Health.down().withDetails(details).build()
+            }
+
+            CircuitBreaker.State.HALF_OPEN -> {
+                Health.unknown().withDetails(details).build()
+            }
+
+            else -> {
+                Health.up().withDetails(details).build()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/ai/health/AiChatbotHealthIndicator.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/health/AiChatbotHealthIndicator.kt
@@ -2,40 +2,9 @@ package team.incube.flooding.domain.ai.health
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.boot.health.contributor.Health
-import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.stereotype.Component
 
 @Component("aiChatbot")
 class AiChatbotHealthIndicator(
-    @Qualifier("chatbotCircuitBreaker") private val circuitBreaker: CircuitBreaker,
-) : HealthIndicator {
-    override fun health(): Health {
-        val state = circuitBreaker.state
-        val metrics = circuitBreaker.metrics
-
-        val details =
-            mapOf(
-                "state" to state.name,
-                "failureRate" to "${metrics.failureRate}%",
-                "slowCallRate" to "${metrics.slowCallRate}%",
-                "bufferedCalls" to metrics.numberOfBufferedCalls,
-                "failedCalls" to metrics.numberOfFailedCalls,
-                "notPermittedCalls" to metrics.numberOfNotPermittedCalls,
-            )
-
-        return when (state) {
-            CircuitBreaker.State.OPEN -> {
-                Health.down().withDetails(details).build()
-            }
-
-            CircuitBreaker.State.HALF_OPEN -> {
-                Health.unknown().withDetails(details).build()
-            }
-
-            else -> {
-                Health.up().withDetails(details).build()
-            }
-        }
-    }
-}
+    @Qualifier("chatbotCircuitBreaker") circuitBreaker: CircuitBreaker,
+) : AbstractCircuitBreakerHealthIndicator(circuitBreaker)

--- a/src/main/kotlin/team/incube/flooding/domain/ai/health/AiSongHealthIndicator.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/health/AiSongHealthIndicator.kt
@@ -2,40 +2,9 @@ package team.incube.flooding.domain.ai.health
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.boot.health.contributor.Health
-import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.stereotype.Component
 
 @Component("aiSong")
 class AiSongHealthIndicator(
-    @Qualifier("songCircuitBreaker") private val circuitBreaker: CircuitBreaker,
-) : HealthIndicator {
-    override fun health(): Health {
-        val state = circuitBreaker.state
-        val metrics = circuitBreaker.metrics
-
-        val details =
-            mapOf(
-                "state" to state.name,
-                "failureRate" to "${metrics.failureRate}%",
-                "slowCallRate" to "${metrics.slowCallRate}%",
-                "bufferedCalls" to metrics.numberOfBufferedCalls,
-                "failedCalls" to metrics.numberOfFailedCalls,
-                "notPermittedCalls" to metrics.numberOfNotPermittedCalls,
-            )
-
-        return when (state) {
-            CircuitBreaker.State.OPEN -> {
-                Health.down().withDetails(details).build()
-            }
-
-            CircuitBreaker.State.HALF_OPEN -> {
-                Health.unknown().withDetails(details).build()
-            }
-
-            else -> {
-                Health.up().withDetails(details).build()
-            }
-        }
-    }
-}
+    @Qualifier("songCircuitBreaker") circuitBreaker: CircuitBreaker,
+) : AbstractCircuitBreakerHealthIndicator(circuitBreaker)

--- a/src/main/kotlin/team/incube/flooding/domain/ai/health/AiSongHealthIndicator.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/health/AiSongHealthIndicator.kt
@@ -1,0 +1,41 @@
+package team.incube.flooding.domain.ai.health
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
+import org.springframework.stereotype.Component
+
+@Component("aiSong")
+class AiSongHealthIndicator(
+    @Qualifier("songCircuitBreaker") private val circuitBreaker: CircuitBreaker,
+) : HealthIndicator {
+    override fun health(): Health {
+        val state = circuitBreaker.state
+        val metrics = circuitBreaker.metrics
+
+        val details =
+            mapOf(
+                "state" to state.name,
+                "failureRate" to "${metrics.failureRate}%",
+                "slowCallRate" to "${metrics.slowCallRate}%",
+                "bufferedCalls" to metrics.numberOfBufferedCalls,
+                "failedCalls" to metrics.numberOfFailedCalls,
+                "notPermittedCalls" to metrics.numberOfNotPermittedCalls,
+            )
+
+        return when (state) {
+            CircuitBreaker.State.OPEN -> {
+                Health.down().withDetails(details).build()
+            }
+
+            CircuitBreaker.State.HALF_OPEN -> {
+                Health.unknown().withDetails(details).build()
+            }
+
+            else -> {
+                Health.up().withDetails(details).build()
+            }
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,7 @@ management:
         include: health
   endpoint:
     health:
-      show-details: always
+      show-details: when-authorized
 
 sdk:
   logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,7 @@ management:
         include: health
   endpoint:
     health:
-      show-details: never
+      show-details: always
 
 sdk:
   logging:


### PR DESCRIPTION
## #️⃣연관된 이슈

> #205

## 📝작업 내용

AI 챗봇 및 음악 추천 서버의 상태를 Spring Actuator `/actuator/health`에 통합했습니다.
Circuit Breaker 상태를 기반으로 각 AI 서버의 헬스를 판단합니다.

**헬스 판단 기준**
- CLOSED → UP (정상)
- HALF_OPEN → UNKNOWN (복구 테스트 중)
- OPEN → DOWN (장애)

**노출 메트릭**
- state: Circuit Breaker 현재 상태
- failureRate: 실패율
- slowCallRate: 느린 호출 비율
- bufferedCalls / failedCalls / notPermittedCalls

**변경 파일**
- `AiChatbotHealthIndicator`: 챗봇 서버 헬스 인디케이터
- `AiSongHealthIndicator`: 음악 추천 서버 헬스 인디케이터
- `application.yml`: health show-details never → always 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음