### PR TITLE
HomebaseReservation 조회 쿼리 분리로 카디널 곱 문제 해결

### DIFF
--- a/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
@@ -38,7 +38,7 @@ class HomebaseReservationJpaEntity(
     @field:OneToMany(mappedBy = "reservation")
     val members: List<HomebaseMemberJpaEntity> = mutableListOf(),
 ) {
-    fun toResponse() =
+    fun toResponse(members: List<HomebaseMemberJpaEntity> = emptyList()) =
         GetHomebaseResponse(
             id = id,
             reservationDate = reservationDate,

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseMemberRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseMemberRepository.kt
@@ -9,6 +9,8 @@ import java.time.LocalDate
 interface HomebaseMemberRepository : JpaRepository<HomebaseMemberJpaEntity, Long> {
     fun findByReservationId(reservationId: Long): List<HomebaseMemberJpaEntity>
 
+    fun findAllByReservationIdIn(reservationIds: List<Long>): List<HomebaseMemberJpaEntity>
+
     fun deleteByReservationId(reservationId: Long)
 
     @Query(

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseReservationRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseReservationRepository.kt
@@ -25,24 +25,22 @@ interface HomebaseReservationRepository : JpaRepository<HomebaseReservationJpaEn
 
     @Query(
         """
-        SELECT DISTINCT r 
-        FROM HomebaseReservationJpaEntity r 
-        JOIN FETCH r.homebase 
-        LEFT JOIN FETCH r.members
+        SELECT r
+        FROM HomebaseReservationJpaEntity r
+        JOIN FETCH r.homebase
     """,
     )
-    fun findAllWithMembers(): List<HomebaseReservationJpaEntity>
+    fun findAllWithHomebase(): List<HomebaseReservationJpaEntity>
 
     @Query(
         """
-        SELECT DISTINCT r 
-        FROM HomebaseReservationJpaEntity r 
-        JOIN FETCH r.homebase 
-        LEFT JOIN FETCH r.members
+        SELECT r
+        FROM HomebaseReservationJpaEntity r
+        JOIN FETCH r.homebase
         WHERE r.reservationDate = :reservationDate
     """,
     )
-    fun findAllWithMembersByDate(
+    fun findAllWithHomebaseByDate(
         @Param("reservationDate")
         reservationDate: LocalDate,
     ): List<HomebaseReservationJpaEntity>

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
@@ -3,18 +3,32 @@ package team.incube.flooding.domain.homebase.service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.homebase.dto.response.GetHomebaseResponse
+import team.incube.flooding.domain.homebase.repository.HomebaseMemberRepository
 import team.incube.flooding.domain.homebase.repository.HomebaseReservationRepository
 import java.time.LocalDate
 
 @Service
 class GetHomebaseReservationService(
     private val reservationRepository: HomebaseReservationRepository,
+    private val memberRepository: HomebaseMemberRepository,
 ) {
     @Transactional(readOnly = true)
-    fun getReservationList(): List<GetHomebaseResponse> =
-        reservationRepository.findAllWithMembers().map { it.toResponse() }
+    fun getReservationList(): List<GetHomebaseResponse> {
+        val reservations = reservationRepository.findAllWithHomebase()
+        val membersByReservationId =
+            memberRepository
+                .findAllByReservationIdIn(reservations.map { it.id })
+                .groupBy { it.reservation.id }
+        return reservations.map { it.toResponse(membersByReservationId[it.id].orEmpty()) }
+    }
 
     @Transactional(readOnly = true)
-    fun getReservationList(reservationDate: LocalDate): List<GetHomebaseResponse> =
-        reservationRepository.findAllWithMembersByDate(reservationDate).map { it.toResponse() }
+    fun getReservationList(reservationDate: LocalDate): List<GetHomebaseResponse> {
+        val reservations = reservationRepository.findAllWithHomebaseByDate(reservationDate)
+        val membersByReservationId =
+            memberRepository
+                .findAllByReservationIdIn(reservations.map { it.id })
+                .groupBy { it.reservation.id }
+        return reservations.map { it.toResponse(membersByReservationId[it.id].orEmpty()) }
+    }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
@@ -15,6 +15,7 @@ class GetHomebaseReservationService(
     @Transactional(readOnly = true)
     fun getReservationList(): List<GetHomebaseResponse> {
         val reservations = reservationRepository.findAllWithHomebase()
+        if (reservations.isEmpty()) return emptyList()
         val membersByReservationId =
             memberRepository
                 .findAllByReservationIdIn(reservations.map { it.id })
@@ -25,6 +26,7 @@ class GetHomebaseReservationService(
     @Transactional(readOnly = true)
     fun getReservationList(reservationDate: LocalDate): List<GetHomebaseResponse> {
         val reservations = reservationRepository.findAllWithHomebaseByDate(reservationDate)
+        if (reservations.isEmpty()) return emptyList()
         val membersByReservationId =
             memberRepository
                 .findAllByReservationIdIn(reservations.map { it.id })


### PR DESCRIPTION
## #️⃣연관된 이슈

> #209

## 📝작업 내용

HomebaseReservation 조회 시 LEFT JOIN FETCH r.members 사용으로 발생하던 카디널 곱 문제를 쿼리 분리로 해결했습니다.

**문제**
OneToMany 관계에서 LEFT JOIN FETCH 사용 시 예약 1건에 멤버 N명이면 SQL 결과가 N행으로 증가.
데이터가 늘수록 메모리/쿼리 비용이 멤버 수에 비례해 증가하며, 페이징 적용 불가.

**변경 내용**
- findAllWithMembers() → findAllWithHomebase() : LEFT JOIN FETCH r.members, DISTINCT 제거
- findAllWithMembersByDate() → findAllWithHomebaseByDate() : 동일하게 제거
- HomebaseMemberRepository에 findAllByReservationIdIn() 추가
- GetHomebaseReservationService: 예약 조회 후 멤버를 예약 ID IN 쿼리로 일괄 조회, 메모리에서 조합

**결과**
항상 정확히 2번의 쿼리만 실행되며 멤버 수에 관계없이 일정한 성능 보장.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 없음