### PR TITLE
develop → master 누적 변경 사항 반영

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,6 @@ jobs:
             --arg message "${{ steps.msg.outputs.first_line }}" \
             --argjson color "$COLOR" \
             '{
-              content: "<@&1445206322730504253>",
               allowed_mentions: {roles: ["1445206322730504253"]},
               embeds: [{
                 title: "[CI/CD] Flooding-Server-V2",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,10 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation(kotlin("test"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(platform("org.testcontainers:testcontainers-bom:1.20.4"))
+    testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
 
     // Resilience4j
     implementation("io.github.resilience4j:resilience4j-circuitbreaker:2.3.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,10 @@ dependencies {
     testImplementation(kotlin("test"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
+    // Resilience4j
+    implementation("io.github.resilience4j:resilience4j-circuitbreaker:2.3.0")
+    implementation("io.github.resilience4j:resilience4j-retry:2.3.0")
+
     // Excel
     implementation("org.apache.poi:poi-ooxml:5.2.3")
 }

--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiChatbotAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiChatbotAdapter.kt
@@ -34,17 +34,13 @@ class AiChatbotAdapter(
                 },
             ).build()
 
-    fun chat(request: SendAiChatRequest): SendAiChatResponse {
-        val decorated =
-            CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
-                Retry
-                    .decorateCheckedSupplier(retry) {
-                        doChat(request)
-                    }.get()
+    fun chat(request: SendAiChatRequest): SendAiChatResponse =
+        try {
+            circuitBreaker.executeCheckedSupplier {
+                retry.executeCheckedSupplier {
+                    doChat(request)
+                }
             }
-
-        return try {
-            decorated.get()
         } catch (e: CallNotPermittedException) {
             throw ExpectedException("AI 챗봇 서버가 일시적으로 사용 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE)
         } catch (e: ExpectedException) {
@@ -53,7 +49,6 @@ class AiChatbotAdapter(
             log.error("AI 챗봇 서버 통신 실패 - {}", e.message)
             throw ExpectedException("AI 챗봇 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
         }
-    }
 
     private fun doChat(request: SendAiChatRequest): SendAiChatResponse =
         restClient

--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiChatbotAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiChatbotAdapter.kt
@@ -1,5 +1,10 @@
 package team.incube.flooding.domain.ai.adapter
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.retry.Retry
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -13,7 +18,11 @@ import team.themoment.sdk.exception.ExpectedException
 @Component
 class AiChatbotAdapter(
     @Value("\${ai.chatbot.base-url}") baseUrl: String,
+    @Qualifier("chatbotCircuitBreaker") private val circuitBreaker: CircuitBreaker,
+    @Qualifier("chatbotRetry") private val retry: Retry,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     private val restClient =
         RestClient
             .builder()
@@ -25,14 +34,37 @@ class AiChatbotAdapter(
                 },
             ).build()
 
-    fun chat(request: SendAiChatRequest): SendAiChatResponse =
+    fun chat(request: SendAiChatRequest): SendAiChatResponse {
+        val decorated =
+            CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
+                Retry
+                    .decorateCheckedSupplier(retry) {
+                        doChat(request)
+                    }.get()
+            }
+
+        return try {
+            decorated.get()
+        } catch (e: CallNotPermittedException) {
+            throw ExpectedException("AI 챗봇 서버가 일시적으로 사용 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE)
+        } catch (e: ExpectedException) {
+            throw e
+        } catch (e: Throwable) {
+            log.error("AI 챗봇 서버 통신 실패 - {}", e.message)
+            throw ExpectedException("AI 챗봇 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
+        }
+    }
+
+    private fun doChat(request: SendAiChatRequest): SendAiChatResponse =
         restClient
             .post()
             .uri("/ai/chat")
             .contentType(MediaType.APPLICATION_JSON)
             .body(request)
             .retrieve()
-            .onStatus({ it.isError }) { _, _ ->
+            .onStatus({ it.isError }) { _, response ->
+                val body = response.body.bufferedReader().use { it.readText() }
+                log.error("AI 챗봇 서버 오류 - status: {}, body: {}", response.statusCode, body)
                 throw ExpectedException("AI 챗봇 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
             }.body(SendAiChatResponse::class.java)
             ?: throw ExpectedException("AI 챗봇 서버로부터 응답을 받지 못했습니다.", HttpStatus.BAD_GATEWAY)

--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
@@ -1,6 +1,10 @@
 package team.incube.flooding.domain.ai.adapter
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.retry.Retry
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -14,6 +18,8 @@ import team.themoment.sdk.exception.ExpectedException
 @Component
 class AiSongAdapter(
     @Value("\${ai.song.base-url}") baseUrl: String,
+    @Qualifier("songCircuitBreaker") private val circuitBreaker: CircuitBreaker,
+    @Qualifier("songRetry") private val retry: Retry,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -28,7 +34,28 @@ class AiSongAdapter(
                 },
             ).build()
 
-    fun recommend(request: RecommendAiSongRequest): RecommendAiSongResponse =
+    fun recommend(request: RecommendAiSongRequest): RecommendAiSongResponse {
+        val decorated =
+            CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
+                Retry
+                    .decorateCheckedSupplier(retry) {
+                        doRecommend(request)
+                    }.get()
+            }
+
+        return try {
+            decorated.get()
+        } catch (e: CallNotPermittedException) {
+            throw ExpectedException("AI 음악 추천 서버가 일시적으로 사용 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE)
+        } catch (e: ExpectedException) {
+            throw e
+        } catch (e: Throwable) {
+            log.error("AI 음악 추천 서버 통신 실패 - {}", e.message)
+            throw ExpectedException("AI 음악 추천 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
+        }
+    }
+
+    private fun doRecommend(request: RecommendAiSongRequest): RecommendAiSongResponse =
         restClient
             .post()
             .uri("/ai/song")

--- a/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/adapter/AiSongAdapter.kt
@@ -34,17 +34,13 @@ class AiSongAdapter(
                 },
             ).build()
 
-    fun recommend(request: RecommendAiSongRequest): RecommendAiSongResponse {
-        val decorated =
-            CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
-                Retry
-                    .decorateCheckedSupplier(retry) {
-                        doRecommend(request)
-                    }.get()
+    fun recommend(request: RecommendAiSongRequest): RecommendAiSongResponse =
+        try {
+            circuitBreaker.executeCheckedSupplier {
+                retry.executeCheckedSupplier {
+                    doRecommend(request)
+                }
             }
-
-        return try {
-            decorated.get()
         } catch (e: CallNotPermittedException) {
             throw ExpectedException("AI 음악 추천 서버가 일시적으로 사용 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE)
         } catch (e: ExpectedException) {
@@ -53,7 +49,6 @@ class AiSongAdapter(
             log.error("AI 음악 추천 서버 통신 실패 - {}", e.message)
             throw ExpectedException("AI 음악 추천 서버와 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY)
         }
-    }
 
     private fun doRecommend(request: RecommendAiSongRequest): RecommendAiSongResponse =
         restClient

--- a/src/main/kotlin/team/incube/flooding/domain/ai/health/AbstractCircuitBreakerHealthIndicator.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/health/AbstractCircuitBreakerHealthIndicator.kt
@@ -1,0 +1,38 @@
+package team.incube.flooding.domain.ai.health
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
+
+abstract class AbstractCircuitBreakerHealthIndicator(
+    private val circuitBreaker: CircuitBreaker,
+) : HealthIndicator {
+    override fun health(): Health {
+        val state = circuitBreaker.state
+        val metrics = circuitBreaker.metrics
+
+        val details =
+            mapOf(
+                "state" to state.name,
+                "failureRate" to "${metrics.failureRate}%",
+                "slowCallRate" to "${metrics.slowCallRate}%",
+                "bufferedCalls" to metrics.numberOfBufferedCalls,
+                "failedCalls" to metrics.numberOfFailedCalls,
+                "notPermittedCalls" to metrics.numberOfNotPermittedCalls,
+            )
+
+        return when (state) {
+            CircuitBreaker.State.OPEN -> {
+                Health.down().withDetails(details).build()
+            }
+
+            CircuitBreaker.State.HALF_OPEN -> {
+                Health.unknown().withDetails(details).build()
+            }
+
+            else -> {
+                Health.up().withDetails(details).build()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/ai/health/AiChatbotHealthIndicator.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/health/AiChatbotHealthIndicator.kt
@@ -1,0 +1,41 @@
+package team.incube.flooding.domain.ai.health
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
+import org.springframework.stereotype.Component
+
+@Component("aiChatbot")
+class AiChatbotHealthIndicator(
+    @Qualifier("chatbotCircuitBreaker") private val circuitBreaker: CircuitBreaker,
+) : HealthIndicator {
+    override fun health(): Health {
+        val state = circuitBreaker.state
+        val metrics = circuitBreaker.metrics
+
+        val details =
+            mapOf(
+                "state" to state.name,
+                "failureRate" to "${metrics.failureRate}%",
+                "slowCallRate" to "${metrics.slowCallRate}%",
+                "bufferedCalls" to metrics.numberOfBufferedCalls,
+                "failedCalls" to metrics.numberOfFailedCalls,
+                "notPermittedCalls" to metrics.numberOfNotPermittedCalls,
+            )
+
+        return when (state) {
+            CircuitBreaker.State.OPEN -> {
+                Health.down().withDetails(details).build()
+            }
+
+            CircuitBreaker.State.HALF_OPEN -> {
+                Health.unknown().withDetails(details).build()
+            }
+
+            else -> {
+                Health.up().withDetails(details).build()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/ai/health/AiChatbotHealthIndicator.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/health/AiChatbotHealthIndicator.kt
@@ -2,40 +2,9 @@ package team.incube.flooding.domain.ai.health
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.boot.health.contributor.Health
-import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.stereotype.Component
 
 @Component("aiChatbot")
 class AiChatbotHealthIndicator(
-    @Qualifier("chatbotCircuitBreaker") private val circuitBreaker: CircuitBreaker,
-) : HealthIndicator {
-    override fun health(): Health {
-        val state = circuitBreaker.state
-        val metrics = circuitBreaker.metrics
-
-        val details =
-            mapOf(
-                "state" to state.name,
-                "failureRate" to "${metrics.failureRate}%",
-                "slowCallRate" to "${metrics.slowCallRate}%",
-                "bufferedCalls" to metrics.numberOfBufferedCalls,
-                "failedCalls" to metrics.numberOfFailedCalls,
-                "notPermittedCalls" to metrics.numberOfNotPermittedCalls,
-            )
-
-        return when (state) {
-            CircuitBreaker.State.OPEN -> {
-                Health.down().withDetails(details).build()
-            }
-
-            CircuitBreaker.State.HALF_OPEN -> {
-                Health.unknown().withDetails(details).build()
-            }
-
-            else -> {
-                Health.up().withDetails(details).build()
-            }
-        }
-    }
-}
+    @Qualifier("chatbotCircuitBreaker") circuitBreaker: CircuitBreaker,
+) : AbstractCircuitBreakerHealthIndicator(circuitBreaker)

--- a/src/main/kotlin/team/incube/flooding/domain/ai/health/AiSongHealthIndicator.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/health/AiSongHealthIndicator.kt
@@ -2,40 +2,9 @@ package team.incube.flooding.domain.ai.health
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.boot.health.contributor.Health
-import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.stereotype.Component
 
 @Component("aiSong")
 class AiSongHealthIndicator(
-    @Qualifier("songCircuitBreaker") private val circuitBreaker: CircuitBreaker,
-) : HealthIndicator {
-    override fun health(): Health {
-        val state = circuitBreaker.state
-        val metrics = circuitBreaker.metrics
-
-        val details =
-            mapOf(
-                "state" to state.name,
-                "failureRate" to "${metrics.failureRate}%",
-                "slowCallRate" to "${metrics.slowCallRate}%",
-                "bufferedCalls" to metrics.numberOfBufferedCalls,
-                "failedCalls" to metrics.numberOfFailedCalls,
-                "notPermittedCalls" to metrics.numberOfNotPermittedCalls,
-            )
-
-        return when (state) {
-            CircuitBreaker.State.OPEN -> {
-                Health.down().withDetails(details).build()
-            }
-
-            CircuitBreaker.State.HALF_OPEN -> {
-                Health.unknown().withDetails(details).build()
-            }
-
-            else -> {
-                Health.up().withDetails(details).build()
-            }
-        }
-    }
-}
+    @Qualifier("songCircuitBreaker") circuitBreaker: CircuitBreaker,
+) : AbstractCircuitBreakerHealthIndicator(circuitBreaker)

--- a/src/main/kotlin/team/incube/flooding/domain/ai/health/AiSongHealthIndicator.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/ai/health/AiSongHealthIndicator.kt
@@ -1,0 +1,41 @@
+package team.incube.flooding.domain.ai.health
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
+import org.springframework.stereotype.Component
+
+@Component("aiSong")
+class AiSongHealthIndicator(
+    @Qualifier("songCircuitBreaker") private val circuitBreaker: CircuitBreaker,
+) : HealthIndicator {
+    override fun health(): Health {
+        val state = circuitBreaker.state
+        val metrics = circuitBreaker.metrics
+
+        val details =
+            mapOf(
+                "state" to state.name,
+                "failureRate" to "${metrics.failureRate}%",
+                "slowCallRate" to "${metrics.slowCallRate}%",
+                "bufferedCalls" to metrics.numberOfBufferedCalls,
+                "failedCalls" to metrics.numberOfFailedCalls,
+                "notPermittedCalls" to metrics.numberOfNotPermittedCalls,
+            )
+
+        return when (state) {
+            CircuitBreaker.State.OPEN -> {
+                Health.down().withDetails(details).build()
+            }
+
+            CircuitBreaker.State.HALF_OPEN -> {
+                Health.unknown().withDetails(details).build()
+            }
+
+            else -> {
+                Health.up().withDetails(details).build()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/controller/HomebaseController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/controller/HomebaseController.kt
@@ -3,7 +3,6 @@ package team.incube.flooding.domain.homebase.controller
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.incube.flooding.domain.homebase.dto.request.CreateHomebaseRequest
 import team.incube.flooding.domain.homebase.dto.response.GetHomebaseResponse
@@ -19,11 +17,10 @@ import team.incube.flooding.domain.homebase.service.CreateHomebaseReservationSer
 import team.incube.flooding.domain.homebase.service.DeleteHomebaseReservationService
 import team.incube.flooding.domain.homebase.service.GetHomebaseReservationService
 import team.themoment.sdk.response.CommonApiResponse
-import java.time.LocalDate
 
 @Tag(name = "홈베이스", description = "홈베이스 예약 관련 API")
 @RestController
-@RequestMapping("/api/reservations")
+@RequestMapping("/homebase")
 class HomebaseController(
     private val createService: CreateHomebaseReservationService,
     private val deleteService: DeleteHomebaseReservationService,
@@ -41,12 +38,8 @@ class HomebaseController(
 
     @Operation(summary = "홈베이스 예약 조회")
     @GetMapping
-    fun getReservation(
-        @RequestParam("date")
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-        date: LocalDate,
-    ): CommonApiResponse<List<GetHomebaseResponse>> {
-        val reservations = getService.getReservationList(date)
+    fun getReservation(): CommonApiResponse<List<GetHomebaseResponse>> {
+        val reservations = getService.getReservationList()
         return CommonApiResponse.success("OK", reservations)
     }
 

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/controller/HomebaseController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/controller/HomebaseController.kt
@@ -3,6 +3,7 @@ package team.incube.flooding.domain.homebase.controller
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.incube.flooding.domain.homebase.dto.request.CreateHomebaseRequest
 import team.incube.flooding.domain.homebase.dto.response.GetHomebaseResponse
@@ -17,10 +19,11 @@ import team.incube.flooding.domain.homebase.service.CreateHomebaseReservationSer
 import team.incube.flooding.domain.homebase.service.DeleteHomebaseReservationService
 import team.incube.flooding.domain.homebase.service.GetHomebaseReservationService
 import team.themoment.sdk.response.CommonApiResponse
+import java.time.LocalDate
 
 @Tag(name = "홈베이스", description = "홈베이스 예약 관련 API")
 @RestController
-@RequestMapping("/homebase")
+@RequestMapping("/api/reservations")
 class HomebaseController(
     private val createService: CreateHomebaseReservationService,
     private val deleteService: DeleteHomebaseReservationService,
@@ -38,8 +41,12 @@ class HomebaseController(
 
     @Operation(summary = "홈베이스 예약 조회")
     @GetMapping
-    fun getReservation(): CommonApiResponse<List<GetHomebaseResponse>> {
-        val reservations = getService.getReservationList()
+    fun getReservation(
+        @RequestParam("date")
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        date: LocalDate,
+    ): CommonApiResponse<List<GetHomebaseResponse>> {
+        val reservations = getService.getReservationList(date)
         return CommonApiResponse.success("OK", reservations)
     }
 

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/controller/HomebaseController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/controller/HomebaseController.kt
@@ -42,7 +42,7 @@ class HomebaseController(
     @Operation(summary = "홈베이스 예약 조회")
     @GetMapping
     fun getReservation(
-        @RequestParam("date")
+        @RequestParam("date", required = true)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         date: LocalDate,
     ): CommonApiResponse<List<GetHomebaseResponse>> {

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/controller/HomebaseController.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/controller/HomebaseController.kt
@@ -3,6 +3,7 @@ package team.incube.flooding.domain.homebase.controller
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.incube.flooding.domain.homebase.dto.request.CreateHomebaseRequest
 import team.incube.flooding.domain.homebase.dto.response.GetHomebaseResponse
@@ -17,6 +19,7 @@ import team.incube.flooding.domain.homebase.service.CreateHomebaseReservationSer
 import team.incube.flooding.domain.homebase.service.DeleteHomebaseReservationService
 import team.incube.flooding.domain.homebase.service.GetHomebaseReservationService
 import team.themoment.sdk.response.CommonApiResponse
+import java.time.LocalDate
 
 @Tag(name = "홈베이스", description = "홈베이스 예약 관련 API")
 @RestController
@@ -38,8 +41,12 @@ class HomebaseController(
 
     @Operation(summary = "홈베이스 예약 조회")
     @GetMapping
-    fun getReservation(): CommonApiResponse<List<GetHomebaseResponse>> {
-        val reservations = getService.getReservationList()
+    fun getReservation(
+        @RequestParam("date")
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        date: LocalDate,
+    ): CommonApiResponse<List<GetHomebaseResponse>> {
+        val reservations = getService.getReservationList(date)
         return CommonApiResponse.success("OK", reservations)
     }
 

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
@@ -38,7 +38,7 @@ class HomebaseReservationJpaEntity(
     @field:OneToMany(mappedBy = "reservation")
     val members: List<HomebaseMemberJpaEntity> = mutableListOf(),
 ) {
-    fun toResponse() =
+    fun toResponse(members: List<HomebaseMemberJpaEntity> = emptyList()) =
         GetHomebaseResponse(
             id = id,
             reservationDate = reservationDate,

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/entity/HomebaseReservationJpaEntity.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
@@ -15,12 +16,15 @@ import team.incube.flooding.domain.homebase.dto.response.GetHomebaseResponse
 import java.time.LocalDate
 
 @Entity
-@Table(name = "tb_homebase_reservation")
+@Table(
+    name = "tb_homebase_reservation",
+    indexes = [Index(name = "idx_tb_homebase_reservation_reservation_date", columnList = "reservation_date")],
+)
 class HomebaseReservationJpaEntity(
     @field:Id
     @field:GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
-    @field:Column(nullable = false)
+    @field:Column(name = "reservation_date", nullable = false)
     val reservationDate: LocalDate,
     @field:Column(nullable = false)
     val startPeriod: Int,

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseMemberRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseMemberRepository.kt
@@ -9,6 +9,8 @@ import java.time.LocalDate
 interface HomebaseMemberRepository : JpaRepository<HomebaseMemberJpaEntity, Long> {
     fun findByReservationId(reservationId: Long): List<HomebaseMemberJpaEntity>
 
+    fun findAllByReservationIdIn(reservationIds: List<Long>): List<HomebaseMemberJpaEntity>
+
     fun deleteByReservationId(reservationId: Long)
 
     @Query(

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseReservationRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseReservationRepository.kt
@@ -25,24 +25,22 @@ interface HomebaseReservationRepository : JpaRepository<HomebaseReservationJpaEn
 
     @Query(
         """
-        SELECT DISTINCT r 
-        FROM HomebaseReservationJpaEntity r 
-        JOIN FETCH r.homebase 
-        LEFT JOIN FETCH r.members
+        SELECT r
+        FROM HomebaseReservationJpaEntity r
+        JOIN FETCH r.homebase
     """,
     )
-    fun findAllWithMembers(): List<HomebaseReservationJpaEntity>
+    fun findAllWithHomebase(): List<HomebaseReservationJpaEntity>
 
     @Query(
         """
-        SELECT DISTINCT r 
-        FROM HomebaseReservationJpaEntity r 
-        JOIN FETCH r.homebase 
-        LEFT JOIN FETCH r.members
+        SELECT r
+        FROM HomebaseReservationJpaEntity r
+        JOIN FETCH r.homebase
         WHERE r.reservationDate = :reservationDate
     """,
     )
-    fun findAllWithMembersByDate(
+    fun findAllWithHomebaseByDate(
         @Param("reservationDate")
         reservationDate: LocalDate,
     ): List<HomebaseReservationJpaEntity>

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseReservationRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseReservationRepository.kt
@@ -32,4 +32,18 @@ interface HomebaseReservationRepository : JpaRepository<HomebaseReservationJpaEn
     """,
     )
     fun findAllWithMembers(): List<HomebaseReservationJpaEntity>
+
+    @Query(
+        """
+        SELECT DISTINCT r 
+        FROM HomebaseReservationJpaEntity r 
+        JOIN FETCH r.homebase 
+        LEFT JOIN FETCH r.members
+        WHERE r.reservationDate = :reservationDate
+    """,
+    )
+    fun findAllWithMembersByDate(
+        @Param("reservationDate")
+        reservationDate: LocalDate,
+    ): List<HomebaseReservationJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseReservationRepository.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/repository/HomebaseReservationRepository.kt
@@ -32,18 +32,4 @@ interface HomebaseReservationRepository : JpaRepository<HomebaseReservationJpaEn
     """,
     )
     fun findAllWithMembers(): List<HomebaseReservationJpaEntity>
-
-    @Query(
-        """
-        SELECT DISTINCT r 
-        FROM HomebaseReservationJpaEntity r 
-        JOIN FETCH r.homebase 
-        LEFT JOIN FETCH r.members
-        WHERE r.reservationDate = :reservationDate
-    """,
-    )
-    fun findAllWithMembersByDate(
-        @Param("reservationDate")
-        reservationDate: LocalDate,
-    ): List<HomebaseReservationJpaEntity>
 }

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.homebase.dto.response.GetHomebaseResponse
 import team.incube.flooding.domain.homebase.repository.HomebaseReservationRepository
+import java.time.LocalDate
 
 @Service
 class GetHomebaseReservationService(
@@ -12,4 +13,8 @@ class GetHomebaseReservationService(
     @Transactional(readOnly = true)
     fun getReservationList(): List<GetHomebaseResponse> =
         reservationRepository.findAllWithMembers().map { it.toResponse() }
+
+    @Transactional(readOnly = true)
+    fun getReservationList(reservationDate: LocalDate): List<GetHomebaseResponse> =
+        reservationRepository.findAllWithMembersByDate(reservationDate).map { it.toResponse() }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.homebase.dto.response.GetHomebaseResponse
 import team.incube.flooding.domain.homebase.repository.HomebaseReservationRepository
-import java.time.LocalDate
 
 @Service
 class GetHomebaseReservationService(
@@ -13,8 +12,4 @@ class GetHomebaseReservationService(
     @Transactional(readOnly = true)
     fun getReservationList(): List<GetHomebaseResponse> =
         reservationRepository.findAllWithMembers().map { it.toResponse() }
-
-    @Transactional(readOnly = true)
-    fun getReservationList(reservationDate: LocalDate): List<GetHomebaseResponse> =
-        reservationRepository.findAllWithMembersByDate(reservationDate).map { it.toResponse() }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
@@ -3,18 +3,32 @@ package team.incube.flooding.domain.homebase.service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.incube.flooding.domain.homebase.dto.response.GetHomebaseResponse
+import team.incube.flooding.domain.homebase.repository.HomebaseMemberRepository
 import team.incube.flooding.domain.homebase.repository.HomebaseReservationRepository
 import java.time.LocalDate
 
 @Service
 class GetHomebaseReservationService(
     private val reservationRepository: HomebaseReservationRepository,
+    private val memberRepository: HomebaseMemberRepository,
 ) {
     @Transactional(readOnly = true)
-    fun getReservationList(): List<GetHomebaseResponse> =
-        reservationRepository.findAllWithMembers().map { it.toResponse() }
+    fun getReservationList(): List<GetHomebaseResponse> {
+        val reservations = reservationRepository.findAllWithHomebase()
+        val membersByReservationId =
+            memberRepository
+                .findAllByReservationIdIn(reservations.map { it.id })
+                .groupBy { it.reservation.id }
+        return reservations.map { it.toResponse(membersByReservationId[it.id].orEmpty()) }
+    }
 
     @Transactional(readOnly = true)
-    fun getReservationList(reservationDate: LocalDate): List<GetHomebaseResponse> =
-        reservationRepository.findAllWithMembersByDate(reservationDate).map { it.toResponse() }
+    fun getReservationList(reservationDate: LocalDate): List<GetHomebaseResponse> {
+        val reservations = reservationRepository.findAllWithHomebaseByDate(reservationDate)
+        val membersByReservationId =
+            memberRepository
+                .findAllByReservationIdIn(reservations.map { it.id })
+                .groupBy { it.reservation.id }
+        return reservations.map { it.toResponse(membersByReservationId[it.id].orEmpty()) }
+    }
 }

--- a/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
+++ b/src/main/kotlin/team/incube/flooding/domain/homebase/service/GetHomebaseReservationService.kt
@@ -15,6 +15,7 @@ class GetHomebaseReservationService(
     @Transactional(readOnly = true)
     fun getReservationList(): List<GetHomebaseResponse> {
         val reservations = reservationRepository.findAllWithHomebase()
+        if (reservations.isEmpty()) return emptyList()
         val membersByReservationId =
             memberRepository
                 .findAllByReservationIdIn(reservations.map { it.id })
@@ -25,6 +26,7 @@ class GetHomebaseReservationService(
     @Transactional(readOnly = true)
     fun getReservationList(reservationDate: LocalDate): List<GetHomebaseResponse> {
         val reservations = reservationRepository.findAllWithHomebaseByDate(reservationDate)
+        if (reservations.isEmpty()) return emptyList()
         val membersByReservationId =
             memberRepository
                 .findAllByReservationIdIn(reservations.map { it.id })

--- a/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
@@ -1,0 +1,149 @@
+package team.incube.flooding.global.config
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.github.resilience4j.retry.Retry
+import io.github.resilience4j.retry.RetryConfig
+import io.github.resilience4j.retry.RetryRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.ResourceAccessException
+import team.themoment.sdk.exception.ExpectedException
+import java.time.Duration
+
+@Configuration
+class AiResilienceConfig {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Bean("chatbotCircuitBreaker")
+    fun chatbotCircuitBreaker(): CircuitBreaker {
+        val config =
+            CircuitBreakerConfig
+                .custom()
+                .failureRateThreshold(50f)
+                .slowCallRateThreshold(80f)
+                .slowCallDurationThreshold(Duration.ofSeconds(8))
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .slidingWindowSize(10)
+                .minimumNumberOfCalls(5)
+                .waitDurationInOpenState(Duration.ofSeconds(30))
+                .permittedNumberOfCallsInHalfOpenState(3)
+                .automaticTransitionFromOpenToHalfOpenEnabled(true)
+                .recordExceptions(ResourceAccessException::class.java)
+                .ignoreExceptions(ExpectedException::class.java)
+                .build()
+
+        val circuitBreaker = CircuitBreakerRegistry.of(config).circuitBreaker("ai-chatbot")
+
+        circuitBreaker.eventPublisher.onStateTransition { event ->
+            log.warn(
+                "AI 챗봇 Circuit Breaker 상태 변경: {} → {}",
+                event.stateTransition.fromState,
+                event.stateTransition.toState,
+            )
+        }
+        circuitBreaker.eventPublisher.onCallNotPermitted {
+            log.warn("AI 챗봇 Circuit Breaker OPEN - 요청 차단됨")
+        }
+
+        return circuitBreaker
+    }
+
+    @Bean("songCircuitBreaker")
+    fun songCircuitBreaker(): CircuitBreaker {
+        val config =
+            CircuitBreakerConfig
+                .custom()
+                .failureRateThreshold(50f)
+                .slowCallRateThreshold(80f)
+                .slowCallDurationThreshold(Duration.ofSeconds(25))
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .slidingWindowSize(10)
+                .minimumNumberOfCalls(5)
+                .waitDurationInOpenState(Duration.ofSeconds(30))
+                .permittedNumberOfCallsInHalfOpenState(3)
+                .automaticTransitionFromOpenToHalfOpenEnabled(true)
+                .recordExceptions(ResourceAccessException::class.java)
+                .ignoreExceptions(ExpectedException::class.java)
+                .build()
+
+        val circuitBreaker = CircuitBreakerRegistry.of(config).circuitBreaker("ai-song")
+
+        circuitBreaker.eventPublisher.onStateTransition { event ->
+            log.warn(
+                "AI 음악 추천 Circuit Breaker 상태 변경: {} → {}",
+                event.stateTransition.fromState,
+                event.stateTransition.toState,
+            )
+        }
+        circuitBreaker.eventPublisher.onCallNotPermitted {
+            log.warn("AI 음악 추천 Circuit Breaker OPEN - 요청 차단됨")
+        }
+
+        return circuitBreaker
+    }
+
+    @Bean("chatbotRetry")
+    fun chatbotRetry(): Retry {
+        val config =
+            RetryConfig
+                .custom<Any>()
+                .maxAttempts(3)
+                .waitDuration(Duration.ofSeconds(1))
+                .retryExceptions(ResourceAccessException::class.java)
+                .ignoreExceptions(ExpectedException::class.java)
+                .build()
+
+        val retry = RetryRegistry.of(config).retry("ai-chatbot")
+
+        retry.eventPublisher.onRetry { event ->
+            log.warn(
+                "AI 챗봇 재시도 중 - 시도 횟수: {}, 원인: {}",
+                event.numberOfRetryAttempts,
+                event.lastThrowable?.message,
+            )
+        }
+        retry.eventPublisher.onError { event ->
+            log.error(
+                "AI 챗봇 최대 재시도 초과 - 총 시도: {}, 원인: {}",
+                event.numberOfRetryAttempts,
+                event.lastThrowable?.message,
+            )
+        }
+
+        return retry
+    }
+
+    @Bean("songRetry")
+    fun songRetry(): Retry {
+        val config =
+            RetryConfig
+                .custom<Any>()
+                .maxAttempts(2)
+                .waitDuration(Duration.ofSeconds(2))
+                .retryExceptions(ResourceAccessException::class.java)
+                .ignoreExceptions(ExpectedException::class.java)
+                .build()
+
+        val retry = RetryRegistry.of(config).retry("ai-song")
+
+        retry.eventPublisher.onRetry { event ->
+            log.warn(
+                "AI 음악 추천 재시도 중 - 시도 횟수: {}, 원인: {}",
+                event.numberOfRetryAttempts,
+                event.lastThrowable?.message,
+            )
+        }
+        retry.eventPublisher.onError { event ->
+            log.error(
+                "AI 음악 추천 최대 재시도 초과 - 총 시도: {}, 원인: {}",
+                event.numberOfRetryAttempts,
+                event.lastThrowable?.message,
+            )
+        }
+
+        return retry
+    }
+}

--- a/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
@@ -9,7 +9,6 @@ import io.github.resilience4j.retry.RetryRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.client.ResourceAccessException
 import team.themoment.sdk.exception.ExpectedException
 import java.time.Duration
 
@@ -31,7 +30,6 @@ class AiResilienceConfig {
                 .waitDurationInOpenState(Duration.ofSeconds(30))
                 .permittedNumberOfCallsInHalfOpenState(3)
                 .automaticTransitionFromOpenToHalfOpenEnabled(true)
-                .recordExceptions(ResourceAccessException::class.java)
                 .ignoreExceptions(ExpectedException::class.java)
                 .build()
 
@@ -65,7 +63,6 @@ class AiResilienceConfig {
                 .waitDurationInOpenState(Duration.ofSeconds(30))
                 .permittedNumberOfCallsInHalfOpenState(3)
                 .automaticTransitionFromOpenToHalfOpenEnabled(true)
-                .recordExceptions(ResourceAccessException::class.java)
                 .ignoreExceptions(ExpectedException::class.java)
                 .build()
 

--- a/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
+++ b/src/main/kotlin/team/incube/flooding/global/config/AiResilienceConfig.kt
@@ -9,6 +9,7 @@ import io.github.resilience4j.retry.RetryRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.ResourceAccessException
 import team.themoment.sdk.exception.ExpectedException
 import java.time.Duration
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,7 @@ management:
         include: health
   endpoint:
     health:
-      show-details: always
+      show-details: when-authorized
 
 sdk:
   logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,7 @@ management:
         include: health
   endpoint:
     health:
-      show-details: never
+      show-details: always
 
 sdk:
   logging:

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapterIntegrationTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/adapter/StudyRedisAdapterIntegrationTest.kt
@@ -1,0 +1,83 @@
+package team.incube.flooding.domain.dormitory.study.adapter
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import team.incube.flooding.domain.dormitory.study.entity.StudyApplicationStatus
+import team.incube.flooding.support.IntegrationTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class StudyRedisAdapterIntegrationTest : IntegrationTestBase() {
+    @Autowired
+    lateinit var studyRedisAdapter: StudyRedisAdapter
+
+    @BeforeEach
+    fun setUp() {
+        studyRedisAdapter.resetAll()
+    }
+
+    @Test
+    fun `saveApplication 후 getApplicationStatus로 조회할 수 있다`() {
+        studyRedisAdapter.saveApplication(1L, StudyApplicationStatus.APPROVED)
+
+        val result = studyRedisAdapter.getApplicationStatus(1L)
+
+        assertEquals(StudyApplicationStatus.APPROVED, result)
+    }
+
+    @Test
+    fun `저장되지 않은 userId는 getApplicationStatus가 null을 반환한다`() {
+        val result = studyRedisAdapter.getApplicationStatus(999L)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `incrementCount는 카운트를 원자적으로 증가시킨다`() {
+        val first = studyRedisAdapter.incrementCount()
+        val second = studyRedisAdapter.incrementCount()
+
+        assertEquals(1L, first)
+        assertEquals(2L, second)
+        assertEquals(2L, studyRedisAdapter.getCount())
+    }
+
+    @Test
+    fun `decrementCount는 카운트를 감소시킨다`() {
+        studyRedisAdapter.incrementCount()
+        studyRedisAdapter.incrementCount()
+        studyRedisAdapter.decrementCount()
+
+        assertEquals(1L, studyRedisAdapter.getCount())
+    }
+
+    @Test
+    fun `카운트가 없을 때 getCount는 0을 반환한다`() {
+        assertEquals(0L, studyRedisAdapter.getCount())
+    }
+
+    @Test
+    fun `addApplicant 후 getApplicantIds에 포함된다`() {
+        studyRedisAdapter.addApplicant(1L)
+        studyRedisAdapter.addApplicant(2L)
+
+        val ids = studyRedisAdapter.getApplicantIds()
+
+        assertEquals(listOf(1L, 2L), ids)
+    }
+
+    @Test
+    fun `resetAll 후 모든 데이터가 초기화된다`() {
+        studyRedisAdapter.saveApplication(1L, StudyApplicationStatus.APPROVED)
+        studyRedisAdapter.incrementCount()
+        studyRedisAdapter.addApplicant(1L)
+
+        studyRedisAdapter.resetAll()
+
+        assertNull(studyRedisAdapter.getApplicationStatus(1L))
+        assertEquals(0L, studyRedisAdapter.getCount())
+        assertTrue(studyRedisAdapter.getApplicantIds().isEmpty())
+    }
+}

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/repository/StudyBanRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/repository/StudyBanRepositoryIntegrationTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertTrue
 @Transactional
 class StudyBanRepositoryIntegrationTest : IntegrationTestBase() {
     @Autowired
-    lateinit var studyBanJpaRepository: StudyBanJpaRepository
+    lateinit var studyBanRepository: StudyBanJpaRepository
 
     @Autowired
     lateinit var userRepository: UserRepository
@@ -43,14 +43,15 @@ class StudyBanRepositoryIntegrationTest : IntegrationTestBase() {
     @Test
     fun `활성 밴이 존재하면 existsByUserIdAndBannedUntilAfter는 true를 반환한다`() {
         val user = createUser(1L, "user1@test.com")
-        studyBanJpaRepository.save(
+        val now = LocalDateTime.now()
+        studyBanRepository.save(
             StudyBanJpaEntity(
                 user = user,
-                bannedUntil = LocalDateTime.now().plusWeeks(1),
+                bannedUntil = now.plusWeeks(1),
             ),
         )
 
-        val result = studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now())
+        val result = studyBanRepository.existsByUserIdAndBannedUntilAfter(user.id, now)
 
         assertTrue(result)
     }
@@ -58,14 +59,15 @@ class StudyBanRepositoryIntegrationTest : IntegrationTestBase() {
     @Test
     fun `만료된 밴만 존재하면 existsByUserIdAndBannedUntilAfter는 false를 반환한다`() {
         val user = createUser(2L, "user2@test.com")
-        studyBanJpaRepository.save(
+        val now = LocalDateTime.now()
+        studyBanRepository.save(
             StudyBanJpaEntity(
                 user = user,
-                bannedUntil = LocalDateTime.now().minusDays(1),
+                bannedUntil = now.minusDays(1),
             ),
         )
 
-        val result = studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now())
+        val result = studyBanRepository.existsByUserIdAndBannedUntilAfter(user.id, now)
 
         assertFalse(result)
     }
@@ -73,15 +75,16 @@ class StudyBanRepositoryIntegrationTest : IntegrationTestBase() {
     @Test
     fun `활성 밴이 존재하면 findByUserIdAndBannedUntilAfter가 해당 엔티티를 반환한다`() {
         val user = createUser(3L, "user3@test.com")
+        val now = LocalDateTime.now()
         val ban =
-            studyBanJpaRepository.save(
+            studyBanRepository.save(
                 StudyBanJpaEntity(
                     user = user,
-                    bannedUntil = LocalDateTime.now().plusWeeks(1),
+                    bannedUntil = now.plusWeeks(1),
                 ),
             )
 
-        val result = studyBanJpaRepository.findByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now())
+        val result = studyBanRepository.findByUserIdAndBannedUntilAfter(user.id, now)
 
         assertNotNull(result)
         assertEquals(ban.id, result.id)
@@ -90,14 +93,15 @@ class StudyBanRepositoryIntegrationTest : IntegrationTestBase() {
     @Test
     fun `활성 밴이 없으면 findByUserIdAndBannedUntilAfter는 null을 반환한다`() {
         val user = createUser(4L, "user4@test.com")
-        studyBanJpaRepository.save(
+        val now = LocalDateTime.now()
+        studyBanRepository.save(
             StudyBanJpaEntity(
                 user = user,
-                bannedUntil = LocalDateTime.now().minusDays(1),
+                bannedUntil = now.minusDays(1),
             ),
         )
 
-        val result = studyBanJpaRepository.findByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now())
+        val result = studyBanRepository.findByUserIdAndBannedUntilAfter(user.id, now)
 
         assertNull(result)
     }
@@ -107,18 +111,19 @@ class StudyBanRepositoryIntegrationTest : IntegrationTestBase() {
         val user1 = createUser(5L, "user5@test.com")
         val user2 = createUser(6L, "user6@test.com")
         val user3 = createUser(7L, "user7@test.com")
+        val now = LocalDateTime.now()
 
-        studyBanJpaRepository.save(
-            StudyBanJpaEntity(user = user1, bannedUntil = LocalDateTime.now().plusWeeks(1)),
+        studyBanRepository.save(
+            StudyBanJpaEntity(user = user1, bannedUntil = now.plusWeeks(1)),
         )
-        studyBanJpaRepository.save(
-            StudyBanJpaEntity(user = user2, bannedUntil = LocalDateTime.now().minusDays(1)),
+        studyBanRepository.save(
+            StudyBanJpaEntity(user = user2, bannedUntil = now.minusDays(1)),
         )
 
         val result =
-            studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(
+            studyBanRepository.findAllByUserIdInAndBannedUntilAfter(
                 listOf(user1.id, user2.id, user3.id),
-                LocalDateTime.now(),
+                now,
             )
 
         assertEquals(1, result.size)

--- a/src/test/kotlin/team/incube/flooding/domain/dormitory/study/repository/StudyBanRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/team/incube/flooding/domain/dormitory/study/repository/StudyBanRepositoryIntegrationTest.kt
@@ -1,0 +1,127 @@
+package team.incube.flooding.domain.dormitory.study.repository
+
+import jakarta.transaction.Transactional
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import team.incube.flooding.domain.dormitory.study.entity.StudyBanJpaEntity
+import team.incube.flooding.domain.user.entity.Role
+import team.incube.flooding.domain.user.entity.Sex
+import team.incube.flooding.domain.user.entity.UserJpaEntity
+import team.incube.flooding.domain.user.repository.UserRepository
+import team.incube.flooding.support.IntegrationTestBase
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@Transactional
+class StudyBanRepositoryIntegrationTest : IntegrationTestBase() {
+    @Autowired
+    lateinit var studyBanJpaRepository: StudyBanJpaRepository
+
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    private fun createUser(
+        id: Long,
+        email: String,
+    ): UserJpaEntity =
+        userRepository.save(
+            UserJpaEntity(
+                id = id,
+                name = "테스트유저",
+                sex = Sex.MAN,
+                email = email,
+                studentNumber = 10101,
+                role = Role.GENERAL_STUDENT,
+                dormitoryRoom = 101,
+            ),
+        )
+
+    @Test
+    fun `활성 밴이 존재하면 existsByUserIdAndBannedUntilAfter는 true를 반환한다`() {
+        val user = createUser(1L, "user1@test.com")
+        studyBanJpaRepository.save(
+            StudyBanJpaEntity(
+                user = user,
+                bannedUntil = LocalDateTime.now().plusWeeks(1),
+            ),
+        )
+
+        val result = studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now())
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `만료된 밴만 존재하면 existsByUserIdAndBannedUntilAfter는 false를 반환한다`() {
+        val user = createUser(2L, "user2@test.com")
+        studyBanJpaRepository.save(
+            StudyBanJpaEntity(
+                user = user,
+                bannedUntil = LocalDateTime.now().minusDays(1),
+            ),
+        )
+
+        val result = studyBanJpaRepository.existsByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now())
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `활성 밴이 존재하면 findByUserIdAndBannedUntilAfter가 해당 엔티티를 반환한다`() {
+        val user = createUser(3L, "user3@test.com")
+        val ban =
+            studyBanJpaRepository.save(
+                StudyBanJpaEntity(
+                    user = user,
+                    bannedUntil = LocalDateTime.now().plusWeeks(1),
+                ),
+            )
+
+        val result = studyBanJpaRepository.findByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now())
+
+        assertNotNull(result)
+        assertEquals(ban.id, result.id)
+    }
+
+    @Test
+    fun `활성 밴이 없으면 findByUserIdAndBannedUntilAfter는 null을 반환한다`() {
+        val user = createUser(4L, "user4@test.com")
+        studyBanJpaRepository.save(
+            StudyBanJpaEntity(
+                user = user,
+                bannedUntil = LocalDateTime.now().minusDays(1),
+            ),
+        )
+
+        val result = studyBanJpaRepository.findByUserIdAndBannedUntilAfter(user.id, LocalDateTime.now())
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `findAllByUserIdInAndBannedUntilAfter는 활성 밴을 가진 유저만 반환한다`() {
+        val user1 = createUser(5L, "user5@test.com")
+        val user2 = createUser(6L, "user6@test.com")
+        val user3 = createUser(7L, "user7@test.com")
+
+        studyBanJpaRepository.save(
+            StudyBanJpaEntity(user = user1, bannedUntil = LocalDateTime.now().plusWeeks(1)),
+        )
+        studyBanJpaRepository.save(
+            StudyBanJpaEntity(user = user2, bannedUntil = LocalDateTime.now().minusDays(1)),
+        )
+
+        val result =
+            studyBanJpaRepository.findAllByUserIdInAndBannedUntilAfter(
+                listOf(user1.id, user2.id, user3.id),
+                LocalDateTime.now(),
+            )
+
+        assertEquals(1, result.size)
+        assertEquals(user1.id, result.first().user.id)
+    }
+}

--- a/src/test/kotlin/team/incube/flooding/support/IntegrationTestBase.kt
+++ b/src/test/kotlin/team/incube/flooding/support/IntegrationTestBase.kt
@@ -1,37 +1,34 @@
 package team.incube.flooding.support
 
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
 @SpringBootTest
 @ActiveProfiles("integration-test")
-@Testcontainers
 abstract class IntegrationTestBase {
     companion object {
-        @Container
-        @ServiceConnection
-        val postgres = PostgreSQLContainer<Nothing>("postgres:16")
+        val postgres =
+            PostgreSQLContainer<Nothing>("postgres:16").apply {
+                start()
+            }
 
-        @Container
-        @Suppress("UNCHECKED_CAST")
-        val redis: GenericContainer<*> =
-            (
-                GenericContainer<Nothing>(
-                    "redis:7",
-                ) as GenericContainer<*>
-            ).withExposedPorts(6379)
+        val redis =
+            GenericContainer<Nothing>("redis:7").apply {
+                withExposedPorts(6379)
+                start()
+            }
 
         @DynamicPropertySource
         @JvmStatic
-        fun redisProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.data.redis.host") { redis.host }
+        fun registerProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+            registry.add("spring.data.redis.host", redis::getHost)
             registry.add("spring.data.redis.port") { redis.getMappedPort(6379) }
         }
     }

--- a/src/test/kotlin/team/incube/flooding/support/IntegrationTestBase.kt
+++ b/src/test/kotlin/team/incube/flooding/support/IntegrationTestBase.kt
@@ -1,0 +1,38 @@
+package team.incube.flooding.support
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@SpringBootTest
+@ActiveProfiles("integration-test")
+@Testcontainers
+abstract class IntegrationTestBase {
+    companion object {
+        @Container
+        @ServiceConnection
+        val postgres = PostgreSQLContainer<Nothing>("postgres:16")
+
+        @Container
+        @Suppress("UNCHECKED_CAST")
+        val redis: GenericContainer<*> =
+            (
+                GenericContainer<Nothing>(
+                    "redis:7",
+                ) as GenericContainer<*>
+            ).withExposedPorts(6379)
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun redisProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.data.redis.host") { redis.host }
+            registry.add("spring.data.redis.port") { redis.getMappedPort(6379) }
+        }
+    }
+}

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -1,0 +1,58 @@
+oauth:
+  client-id: test-client-id
+  client-secret: test-client-secret
+
+neis:
+  openapi:
+    timetable:
+      apiKey: test-key
+
+datagsm:
+  open-api-key: test-key
+
+ai:
+  chatbot:
+    base-url: http://localhost:19999
+  song:
+    base-url: http://localhost:19999
+
+youtube:
+  api-key: test-key
+
+jwt:
+  secret: test-secret-key-for-integration-testing-only-must-be-long-enough
+  access-token-expiration: 3600000
+  refresh-token-expiration: 604800000
+
+file:
+  bucket: test-bucket
+  endpoint: http://localhost:19999
+  access-key: test-access-key
+  secret-key: test-secret-key
+  public-base-url: http://localhost:19999
+  region: auto
+
+study:
+  open-time: "00:00"
+  close-time: "23:59"
+  max-count: 50
+  lock-key: study:lock
+
+massage:
+  open-time: "00:00"
+  close-time: "23:59"
+  max-count: 5
+  lock-key: lock
+
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+management:
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
## #️⃣연관된 이슈

> develop 브랜치 누적 변경 사항 master 반영

## 📝작업 내용

`develop`에 머지된 기능들을 `master`로 반영합니다.

- **AI 서버 안정화 (#203)**: AI 챗봇/음악 추천 서버 호출에 Resilience4j Circuit Breaker + Retry 적용. AI 서버 다운/지연 시 스레드 풀 고갈로 인한 Cascade Failure 방지 (서킷 실패율 50% 초과 시 OPEN, 30초 후 HALF_OPEN 자동 전환 / 재시도 챗봇 3회·음악 2회)
- **AI 서버 Health Indicator (#206)**: Circuit Breaker 상태 기반 Custom Health Indicator 구현. `/actuator/health`로 AI 챗봇·음악 추천 서버 가용 상태 모니터링 (actuator show-details는 when-authorized)
- **홈베이스 예약 (#201)**: 홈베이스 예약 기능 및 날짜별 예약 조회, HomebaseReservation 인덱스 추가
- **Testcontainers 통합 테스트 (#208)**: PostgreSQL/Redis Testcontainers 기반 통합 테스트 환경 구성, StudyRedisAdapter·StudyBanRepository 통합 테스트 작성 (싱글톤 컨테이너 패턴)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 23개 커밋(머지 PR #201, #203, #206, #208)이 포함된 릴리즈 PR입니다.
